### PR TITLE
bugfix: strange numerical error in ground state calculation.

### DIFF
--- a/src/atom/pp/prep_pp.f90
+++ b/src/atom/pp/prep_pp.f90
@@ -264,7 +264,7 @@ subroutine calc_mps(pp,ppg,alx,aly,alz,lx,ly,lz,nl,mx,my,mz,ml,hx,hy,hz,al0,matr
 
 
 !$omp parallel
-!$omp do private(a,ik,j,i,ix,iy,iz,x,y,z,r,rr,tmpx,tmpy,tmpz)
+!$omp do private(a,ik,j,i,ix,iy,iz,tmpx,tmpy,tmpz,x,y,z,r,rr,u,v,w)
   do a=1,natom
     ik=kion(a)
     j=0
@@ -373,7 +373,7 @@ subroutine calc_jxyz(pp,ppg,alx,aly,alz,lx,ly,lz,nl,mx,my,mz,ml,hx,hy,hz,al0,mat
   end if
 
 !$omp parallel
-!$omp do private(a,ik,j,ix,iy,iz,tmpx,tmpy,tmpz,i,x,y,z,r,rr)
+!$omp do private(a,ik,j,i,ix,iy,iz,tmpx,tmpy,tmpz,x,y,z,r,rr,u,v,w)
   do a=1,natom
     ik=kion(a)
     j=0


### PR DESCRIPTION
@ayamada224 san founds strange error in ground state calculation, I fixed it.

This PR fixes an OpenMP error (missing the thread private variables) in `src/atom/pp/prep_pp.f90`
The ground state calculation log matched between default build version and `-check all` version (testsuites/101_C2H2_gs when iter = 20).