### PR TITLE
FIXED: Attempt to fetch from allocatable variable when it is not allocated.

### DIFF
--- a/src/GCEED/modules/allocate_mat.f90
+++ b/src/GCEED/modules/allocate_mat.f90
@@ -168,21 +168,23 @@ if(iSCFRT==2)then
 
 end if
 
-if(iSCFRT==1.and.iperiodic==0)then
+! FIX: Attempt to fetch from allocatable variable [RXK,RHXK,RGK,RPK]_OB when it is not allocated
+!if(iSCFRT==1.and.iperiodic==0)then
   allocate (rxk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
   allocate (rhxk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
   allocate (rgk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
   allocate (rpk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
-end if
+!end if
 
-if(iSCFRT==1.and.iperiodic==3)then
+! FIX: Attempt to fetch from allocatable variable [ZXK,ZHXK,ZGK,ZPK,ZPKO,ZHTPSI]_OB when it is not allocated
+!if(iSCFRT==1.and.iperiodic==3)then
   allocate (zxk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
   allocate (zhxk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
   allocate (zgk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
   allocate (zpk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
   allocate (zpko_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
   allocate (zhtpsi_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
-end if
+!end if
 
 allocate (rho_tmp(ng_num(1), ng_num(2), ng_num(3)))
 allocate (rho_s_tmp(ng_num(1), ng_num(2), ng_num(3), 2))

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -967,6 +967,9 @@ DFT_Iteration : do iter=1,iDiter(img)
 
   if(iscf_order==1)then
 
+    ! FIX: Attempt to fetch from allocatable variable K_RD when it is not allocated
+    if (.not. allocated(k_rd)) allocate(k_rd(3,num_kpoints_rd))
+
     call scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob, &
                        num_kpoints_rd,k_rd,   &
                        rxk_ob,rhxk_ob,rgk_ob,rpk_ob,   &


### PR DESCRIPTION
I compiled the SALMON as following options with intel compiler 2019.3,

    CFLAGS="-traceback" FFLAGS="-check all,noarg_temp_created -traceback" ../../salmon2/configure.py --debug --arch=intel-avx512

SALMON crashed with they fetch the not allocated array at `scf_iteration` routine.
I temporary fixed it. @mn2007 san, could you please fix it?