### PR TITLE
calc_total_energy_periodic: skip the update ion-ion energy.

### DIFF
--- a/src/GCEED/modules/scf_data.f90
+++ b/src/GCEED/modules/scf_data.f90
@@ -592,5 +592,19 @@ iwk3num(1:3)=iwk3end(1:3)-iwk3sta(1:3)+1
 
 end subroutine make_iwksta_iwkend
 
+function check_rion_update() result(rion_update)
+  implicit none
+  logical :: rion_update
+  ! iflag_opt <= calculation%use_geometry_opt (in scf)
+  ! iflag_md  <= calculation%use_ehrenfest_md (in rt)
+  if (iscfrt == 1) then
+    rion_update = (iflag_opt == 1)
+  else if (iscfrt == 2) then
+    rion_update = (iflag_md == 1)
+  else
+    rion_update = .true.
+  end if
+end function
+
 END MODULE scf_data
 

--- a/src/GCEED/rt/time_evolution_step.f90
+++ b/src/GCEED/rt/time_evolution_step.f90
@@ -72,11 +72,16 @@ SUBROUTINE time_evolution_step(lg,mg,ng,system,nspin,info,stencil,srg,srg_ng,ppn
 
   character(100) :: comment_line
 
+  logical :: rion_update
+
   call timer_begin(LOG_CALC_VBOX)
   
   idensity=0
   idiffDensity=1
-  ielf=2 
+  ielf=2
+
+  ! for calc_total_energy_periodic
+  rion_update = check_rion_update() .or. (itt == Miter_rt+1)
   
   if(iperiodic==3) call init_k_rd(k_rd,ksquare,1,system%brl)
   
@@ -476,7 +481,7 @@ SUBROUTINE time_evolution_step(lg,mg,ng,system,nspin,info,stencil,srg,srg_ng,ppn
     end if
     if(iflag_md==1) call calc_current_ion(system,curr_ion(:,itt))
 
-    call calc_Total_Energy_periodic(energy,system,pp,fg)
+    call calc_Total_Energy_periodic(energy,system,pp,fg,rion_update)
     rbox1=0.d0
   !$OMP parallel do private(iz,iy,ix) reduction( + : rbox1 )
     do iz=ng_sta(3),ng_end(3)

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -95,8 +95,8 @@ type(s_fourier_grid) :: fg
 type(s_pp_nlcc) :: ppn
 type(s_energy) :: energy
 type(s_force)  :: force
- 
 
+logical :: rion_update
 
 call init_xc(xc_func, ispin, cval, xcname=xc, xname=xname, cname=cname)
 
@@ -596,7 +596,8 @@ if(iopt==1)then
         enddo
         enddo
       end if
-      call calc_Total_Energy_periodic(energy,system,pp,fg)
+      rion_update = .true. ! it's first calculation
+      call calc_Total_Energy_periodic(energy,system,pp,fg,rion_update)
     end select
     esp = energy%esp(:,:,1) !++++++++
     if(iperiodic==3) deallocate(stencil%kAc,ppg%ekr_uV)
@@ -944,6 +945,9 @@ DFT_Iteration : do iter=1,iDiter(img)
 
   Miter=Miter+1
 
+  ! for calc_total_energy_periodic
+  rion_update = check_rion_update() .or. (iter == 1)
+
   if(temperature_k>=0.d0.and.Miter>iditer_notemperature) then
     if(iperiodic.eq.3) then
       call ne2mu_p
@@ -1072,7 +1076,7 @@ DFT_Iteration : do iter=1,iDiter(img)
         enddo
         enddo
       end if
-      call calc_Total_Energy_periodic(energy,system,pp,fg)
+      call calc_Total_Energy_periodic(energy,system,pp,fg,rion_update)
     end select
     esp = energy%esp(:,:,1) !++++++++
     if(iperiodic==3) deallocate(stencil%kAc,ppg%ekr_uV)
@@ -1262,7 +1266,7 @@ DFT_Iteration : do iter=1,iDiter(img)
         enddo
         enddo
       end if
-      call calc_Total_Energy_periodic(energy,system,pp,fg)
+      call calc_Total_Energy_periodic(energy,system,pp,fg,rion_update)
     end select
     esp = energy%esp(:,:,1) !++++++++
     if(iperiodic==3) deallocate(stencil%kAc,ppg%ekr_uV)


### PR DESCRIPTION
In `calc_total_energy_periodic` subroutine at `src/common/total_energy.f90`, they will skip the update ion-ion energy in GCEED SCF and RT iterations if atom is not moved.

Skip condition:
1. In SCF, an input file sets `calculation%use_geometry_opt=n`
2. In RT, an input file sets `calculation%use_ehrenfest_md=n`