### PR TITLE
remove a function of iparaway_ob

### DIFF
--- a/src/GCEED/common/OUT_IN_data.f90
+++ b/src/GCEED/common/OUT_IN_data.f90
@@ -155,8 +155,8 @@ case(0)
   
     do ik=1,num_kpoints_rd
     do iob=1,itotMST
-      call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-      call check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+      call check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
   
       matbox_l=0.d0
       if(icorr_p==1)then
@@ -194,8 +194,8 @@ case(3)
     do ik=1,num_kpoints_rd
     do iob=1,itotMST
 
-      call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-      call check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+      call check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
       cmatbox_l=0.d0
       if(icorr_p==1)then
         cmatbox_l(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))   &
@@ -754,7 +754,7 @@ if(iSCFRT==2) call make_new_world
 
 call setk(k_sta, k_end, k_num, num_kpoints_rd, nproc_k, nproc_id_orbitalgrid)
 
-call calc_iobnum(itotMST,nproc_ob,nproc_id_kgrid,iobnum,nproc_ob,iparaway_ob)
+call calc_iobnum(itotMST,nproc_ob,nproc_id_kgrid,iobnum,nproc_ob)
 
 if(iSCFRT==2)then
   call allocate_mat(cg)
@@ -809,7 +809,7 @@ else if(iSCFRT==2)then
     zpsi_out(:,:,:,:,:) = 0.d0
   end if
   if(iwrite_projection==1)then
-    call calc_iobnum(itotMST0,nproc_ob,nproc_id_kgrid,iobnum0,nproc_ob,iparaway_ob)
+    call calc_iobnum(itotMST0,nproc_ob,nproc_id_kgrid,iobnum0,nproc_ob)
     if(iobnum0.ge.1)then
       allocate(zpsi_t0(mg%is_overlap(1):mg%ie_overlap(1), &
                      & mg%is_overlap(2):mg%ie_overlap(2), &
@@ -988,8 +988,8 @@ do p0=pstart(is),pend(is)
 
 ! read file
   call conv_p0(p0,iob)
-  call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-  call check_corrkob(iob,ik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+  call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+  call check_corrkob(iob,ik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
 
   if(IC<=2)then
     if(nproc_id_global<num_datafiles_IN)then

--- a/src/GCEED/common/calcELF.f90
+++ b/src/GCEED/common/calcELF.f90
@@ -86,7 +86,7 @@ if(iSCFRT==1)then
   if(iperiodic==0)then
 
     do iob=1,iobnum
-      call calc_allob(iob,p_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,p_allob,itotmst,mst,iobnum)
       if((ilsda==0.and.p_allob<=ifMST(1)).or.  &
          (ilsda==1.and.(p_allob<=ifMST(1).or.(p_allob>=MST(1)+1.and.p_allob<=MST(1)+ifMST(2)))))then
   
@@ -108,7 +108,7 @@ if(iSCFRT==1)then
   else if(iperiodic==3)then
 
     do iob=1,iobnum
-      call calc_allob(iob,p_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,p_allob,itotmst,mst,iobnum)
       if((ilsda==0.and.p_allob<=ifMST(1)).or.  &
          (ilsda==1.and.(p_allob<=ifMST(1).or.(p_allob>=MST(1)+1.and.p_allob<=MST(1)+ifMST(2)))))then
   
@@ -148,7 +148,7 @@ else
 
   do iob=1,iobnum
 
-    call calc_allob(iob,p_allob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_allob(iob,p_allob,itotmst,mst,iobnum)
     if((ilsda==0.and.p_allob<=ifMST(1)).or.   &
        (ilsda==1.and.(p_allob<=ifMST(1).or.(p_allob>=MST(1)+1.and.p_allob<=MST(1)+ifMST(2)))))then
 

--- a/src/GCEED/common/calc_pmax.f90
+++ b/src/GCEED/common/calc_pmax.f90
@@ -25,7 +25,7 @@ if(iSCFRT==1)then
   iobmax=iobnum
 else if(iSCFRT==2)then
   if(ilsda==0)then
-    call calc_iobnum(ifMST(1),nproc_ob,nproc_id_kgrid,iobmax,nproc_ob,iparaway_ob)
+    call calc_iobnum(ifMST(1),nproc_ob,nproc_id_kgrid,iobmax,nproc_ob)
   else if(ilsda==1)then
     iobmax=iobnum
   end if

--- a/src/GCEED/common/init_wf.f90
+++ b/src/GCEED/common/init_wf.f90
@@ -58,8 +58,8 @@ case(0)
   iseed=123
   do is=1,iss
   do iob=pstart(is),pend(is)
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-    call check_corrkob(iob,1,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+    call check_corrkob(iob,1,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
     call quickrnd_ns ; x1=Xmax*(2.d0*rnd-1.d0)
     call quickrnd_ns ; y1=Ymax*(2.d0*rnd-1.d0)
     call quickrnd_ns ; z1=Zmax*(2.d0*rnd-1.d0)
@@ -86,8 +86,8 @@ case(3)
   do is=1,iss
   do ik=1,num_kpoints_rd
   do iob=pstart(is),pend(is)
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-    call check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+    call check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
     call quickrnd_ns ; x1=Xmax*rnd
     call quickrnd_ns ; y1=Ymax*rnd
     call quickrnd_ns ; z1=Zmax*rnd

--- a/src/GCEED/common/writepsi.f90
+++ b/src/GCEED/common/writepsi.f90
@@ -37,8 +37,8 @@ subroutine writepsi(lg)
   if(iSCFRT==1)then
     do p0=1,itotMST
       call conv_p0(p0,iob)
-      call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-      call check_corrkob(iob,1,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+      call check_corrkob(iob,1,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
   !OMP parallel do private(iz,iy,ix)
       do iz=lg_sta(3),lg_end(3)
       do iy=lg_sta(2),lg_end(2)

--- a/src/GCEED/modules/calc_density.f90
+++ b/src/GCEED/modules/calc_density.f90
@@ -44,7 +44,7 @@ if(ilsda==0)then
   matbox_m=0d0
   do iik=k_sta,k_end
   do i1=1,iobnum
-    call calc_allob(i1,i1_allob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_allob(i1,i1_allob,itotmst,mst,iobnum)
 !$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
@@ -68,8 +68,8 @@ else if(ilsda==1)then
     matbox_m=0d0
     do iik=k_sta,k_end
     do iob=iob_start(iss),iob_end(iss)
-      call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-      call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+      call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icorr_p==1)then
 !$OMP parallel do private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
@@ -118,7 +118,7 @@ if(ilsda==0)then
   matbox_m=0d0
   do iik=k_sta,k_end
   do i1=1,iobnum
-    call calc_allob(i1,i1_allob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_allob(i1,i1_allob,itotmst,mst,iobnum)
 !$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
@@ -142,8 +142,8 @@ else if(ilsda==1)then
     matbox_m=0d0
     do iik=k_sta,k_end
     do iob=iob_start(iss),iob_end(iss)
-      call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-      call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+      call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icorr_p==1)then
 !$OMP parallel do private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)

--- a/src/GCEED/modules/change_order.f90
+++ b/src/GCEED/modules/change_order.f90
@@ -63,27 +63,27 @@ end if
 do iik=k_sta,k_end
 do is=1,iss
   do iob=iobsta(is),iobend(is)-1
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
     imin=iob
     do job=iob+1,iobend(is)
       if(esp(job,iik)<esp(imin,iik)) imin=job
     end do
-    call calc_myob(imin,imin_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_myob(imin,imin_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
     if(iob/=imin)then
       rbox=esp(iob,iik)
       esp(iob,iik)=esp(imin,iik)
       esp(imin,iik)=rbox
       matbox1=0.d0
-      call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icheck_corrkob==1) matbox1(:,:,:)=tpsi(:,:,:,iob_myob,iik)
       call comm_summation(matbox1,matbox2,mg_num(1)*mg_num(2)*mg_num(3),nproc_group_kgrid)
       matbox3=0.d0
-      call check_corrkob(imin,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call check_corrkob(imin,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icheck_corrkob==1) matbox3(:,:,:)=tpsi(:,:,:,imin_myob,iik)
       call comm_summation(matbox3,matbox4,mg_num(1)*mg_num(2)*mg_num(3),nproc_group_kgrid)
-      call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icheck_corrkob==1) tpsi(:,:,:,iob_myob,iik)=matbox4(:,:,:)
-      call check_corrkob(imin,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call check_corrkob(imin,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icheck_corrkob==1) tpsi(:,:,:,imin_myob,iik)=matbox2(:,:,:)
     end if
   end do
@@ -132,27 +132,27 @@ end if
 do iik=k_sta,k_end
 do is=1,iss
   do iob=iobsta(is),iobend(is)-1
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
     imin=iob
     do job=iob+1,iobend(is)
       if(esp(job,iik)<esp(imin,iik)) imin=job
     end do
-    call calc_myob(imin,imin_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_myob(imin,imin_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
     if(iob/=imin)then
       rbox=esp(iob,iik)
       esp(iob,iik)=esp(imin,iik)
       esp(imin,iik)=rbox
       matbox1=0.d0
-      call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icheck_corrkob==1) matbox1(:,:,:)=tpsi(:,:,:,iob_myob,iik)
       call comm_summation(matbox1,matbox2,mg_num(1)*mg_num(2)*mg_num(3),nproc_group_kgrid)
       matbox3=0.d0
-      call check_corrkob(imin,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call check_corrkob(imin,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icheck_corrkob==1) matbox3(:,:,:)=tpsi(:,:,:,imin_myob,iik)
       call comm_summation(matbox3,matbox4,mg_num(1)*mg_num(2)*mg_num(3),nproc_group_kgrid)
-      call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icheck_corrkob==1) tpsi(:,:,:,iob_myob,iik)=matbox4(:,:,:)
-      call check_corrkob(imin,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+      call check_corrkob(imin,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
       if(icheck_corrkob==1) tpsi(:,:,:,imin_myob,iik)=matbox2(:,:,:)
     end if
   end do

--- a/src/GCEED/modules/copy_psi_mesh.f90
+++ b/src/GCEED/modules/copy_psi_mesh.f90
@@ -47,8 +47,8 @@ allocate(matbox2(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3)))
 if(icopy_psi_mesh==1)then
   do iik=1,num_kpoints_rd
   do iob=1,itotMST
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-    call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+    call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
     matbox=0.d0
     if(icheck_corrkob==1)then
 !$OMP parallel do private(iz,iy,ix) 
@@ -76,8 +76,8 @@ if(icopy_psi_mesh==1)then
 else if(icopy_psi_mesh==2)then
   do iik=1,num_kpoints_rd
   do iob=1,itotMST
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-    call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+    call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
     matbox=0.d0
 !$OMP parallel do private(iz,iy,ix) 
     do iz=ng_sta(3),ng_end(3)
@@ -131,8 +131,8 @@ allocate(matbox2(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3)))
 if(icopy_psi_mesh==1)then
   do iik=1,num_kpoints_rd
   do iob=1,itotMST
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-    call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+    call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
     matbox=0.d0
     if(icheck_corrkob==1)then
 !$OMP parallel do private(iz,iy,ix) 
@@ -160,8 +160,8 @@ if(icopy_psi_mesh==1)then
 else if(icopy_psi_mesh==2)then
   do iik=1,num_kpoints_rd
   do iob=1,itotMST
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-    call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+    call check_corrkob(iob,iik,icheck_corrkob,ilsda,nproc_ob,k_sta,k_end,mst)
     matbox=0.d0
 !$OMP parallel do private(iz,iy,ix) 
     do iz=ng_sta(3),ng_end(3)

--- a/src/GCEED/rt/add_polynomial.f90
+++ b/src/GCEED/rt/add_polynomial.f90
@@ -103,7 +103,7 @@ else if(ifunc==4)then
   if(ilsda==0)then
     do iik=k_sta,k_end
     do iob=1,iobmax
-      call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
 !$OMP parallel do private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
@@ -120,7 +120,7 @@ else if(ifunc==4)then
   else
     do iik=k_sta,k_end
     do iob=1,iobmax
-      call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
       if(iob_allob<=MST(1))then
 !$OMP parallel do private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
@@ -153,7 +153,7 @@ else if(ifunc==5)then
   if(ilsda==0)then
     do iik=k_sta,k_end
     do iob=1,iobmax
-      call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
       cbox=0.d0
 !$OMP parallel do reduction(+:cbox) private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
@@ -173,7 +173,7 @@ else if(ifunc==5)then
   else if(ilsda==1)then
     do iik=k_sta,k_end
     do iob=1,iobmax
-      call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
       cbox=0.d0
       if(iob_allob<=MST(1))then
 !$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 
@@ -210,7 +210,7 @@ else if(ifunc==6)then
   if(ilsda==0)then
     do iik=k_sta,k_end
     do iob=1,iobmax
-      call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
 !$OMP parallel do private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
@@ -227,7 +227,7 @@ else if(ifunc==6)then
   else if(ilsda==1)then
     do iik=k_sta,k_end
     do iob=1,iobmax
-      call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
       if(iob_allob<=MST(1))then
 !$OMP parallel do private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
@@ -279,7 +279,7 @@ else if(ifunc==7)then
   else if(ilsda==1)then
     do iik=k_sta,k_end
     do iob=1,iobmax
-      call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
       cbox=0.d0
       if(iob_allob<=MST(1))then
 !$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 

--- a/src/GCEED/rt/calc_current.f90
+++ b/src/GCEED/rt/calc_current.f90
@@ -54,7 +54,7 @@ call timer_end(LOG_CUR_SENDRECV)
 call timer_begin(LOG_CUR_LOCAL)
 do iik=k_sta,k_end
 do iob=1,iobnum
-  call calc_allob(iob,p_allob,iparaway_ob,itotmst,mst,iobnum)
+  call calc_allob(iob,p_allob,itotmst,mst,iobnum)
   jxt=0.d0
 !$OMP parallel do private(iz,iy,ix) reduction(+ : jxt)
   do iz=mg%is(3),mg%ie(3)
@@ -155,7 +155,7 @@ call timer_end(LOG_ALLREDUCE_CURRENT)
 call timer_begin(LOG_CUR_NONLOCAL2)
 do iik=k_sta,k_end
   do iob=1,iobnum
-    call calc_allob(iob,p_allob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_allob(iob,p_allob,itotmst,mst,iobnum)
     do iatom=1,MI
       ik=Kion(iatom)
       do lm=1,(Mlps(ik)+1)**2

--- a/src/GCEED/rt/projection.f90
+++ b/src/GCEED/rt/projection.f90
@@ -55,8 +55,8 @@ coef_mat=0.d0
 
 do iik=k_sta,k_end
 do iob=1,itotMST0
-  call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-  call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+  call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+  call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
   if(icorr_p==1)then
 !$OMP parallel do private(iz,iy,ix)
     do iz=mg%is(3),mg%ie(3)
@@ -67,7 +67,7 @@ do iob=1,itotMST0
     end do
     end do
   end if
-  call calc_iroot(iob,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+  call calc_iroot(iob,iroot,ilsda,nproc_ob,itotmst,mst)
   call comm_bcast(cmatbox_m,nproc_group_kgrid,iroot)
   do job=1,iobmax
     cbox=0.d0
@@ -79,7 +79,7 @@ do iob=1,itotMST0
     end do
     end do
     end do
-    call calc_allob(job,job_allob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_allob(job,job_allob,itotmst,mst,iobnum)
     coef_mat(job_allob,iob,iik,1)=coef_mat(job_allob,iob,iik,1)+cbox
   end do
 end do

--- a/src/GCEED/rt/read_rt.f90
+++ b/src/GCEED/rt/read_rt.f90
@@ -81,8 +81,8 @@ end if
 
 do iik=1,num_kpoints_rd
 do iob=1,itotMST
-  call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-  call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+  call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+  call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
 
   cmatbox_l2=0.d0
     if(mod(itotNtime,2)==1)then
@@ -345,8 +345,8 @@ end if
 
 do iik=k_sta,k_end
 do iob=1,itotMST
-  call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-  call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+  call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+  call check_corrkob(iob,iik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
   
   if(num_datafiles_IN==1.or.num_datafiles_IN>nproc_size_global)then
     if(comm_is_root(nproc_id_global))then

--- a/src/GCEED/rt/real_time_dft.f90
+++ b/src/GCEED/rt/real_time_dft.f90
@@ -797,12 +797,12 @@ call timer_begin(LOG_INIT_TIME_PROPAGATION)
           ,info%irank_jo(1:system%no))
   info%jo_tbl(:) = 0 ! info%io_s-1 (initial value)
   do iob=info%io_s,info%io_e
-    call calc_allob(iob,jj,iparaway_ob,itotmst,mst,iobnum)
+    call calc_allob(iob,jj,itotmst,mst,iobnum)
     info%io_tbl(iob) = jj
     info%jo_tbl(jj) = iob
   end do
   do jj=1, system%no
-    call calc_iroot(jj,info%irank_jo(jj),ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+    call calc_iroot(jj,info%irank_jo(jj),ilsda,nproc_ob,itotmst,mst)
   end do
 
   do ik=info%ik_s,info%ik_e

--- a/src/GCEED/scf/calc_dos.f90
+++ b/src/GCEED/scf/calc_dos.f90
@@ -50,7 +50,7 @@ dos_l_tmp=0.d0
  
 do iik=k_sta,k_end
 do iob=1,iobmax
-  call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+  call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
   select case (out_dos_method)
   case('lorentzian') 
     fk=2.d0*out_dos_smearing/pi

--- a/src/GCEED/scf/calc_pdos.f90
+++ b/src/GCEED/scf/calc_pdos.f90
@@ -62,7 +62,7 @@ pdos_l_tmp=0.d0
 
 do iik=k_sta,k_end
 do iob=1,iobmax
-  call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+  call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
   rbox_pdos=0.d0
   do iatom=1,MI
     ikoa=Kion(iatom)

--- a/src/GCEED/scf/convert_input_scf.f90
+++ b/src/GCEED/scf/convert_input_scf.f90
@@ -306,10 +306,6 @@ call comm_bcast(iflag_pdos,     nproc_group_global)
 
 !===== namelist for group_others =====
 if(comm_is_root(nproc_id_global))then
-  if(iparaway_ob<=0.or.iparaway_ob>=3)then
-    write(*,*) "iparaway_ob must be equal to 1 or 2."
-    stop
-  end if
   if(iflag_dos<=-1.or.iflag_dos>=2)then
     write(*,*) "iflag_dos must be equal to 0 or 1."
     stop

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -133,7 +133,7 @@ call set_filename
 
 call setk(k_sta, k_end, k_num, num_kpoints_rd, nproc_k, nproc_id_orbitalgrid)
 
-call calc_iobnum(itotMST,nproc_ob,nproc_id_kgrid,iobnum,nproc_ob,iparaway_ob)
+call calc_iobnum(itotMST,nproc_ob,nproc_id_kgrid,iobnum,nproc_ob)
 
 if(iflag_opt==1)then
    call structure_opt_ini(MI)
@@ -253,7 +253,7 @@ if(iopt==1)then
  
     info%jo_tbl(:) = 0 !(initial value)
     do iob=info%io_s,info%io_e
-      call calc_allob(iob,jj,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,jj,itotmst,mst,iobnum)
       info%io_tbl(iob) = jj
       info%jo_tbl(jj)  = iob
     end do
@@ -268,7 +268,7 @@ if(iopt==1)then
     end do
     
     do jj=1, system%no
-      call calc_iroot(jj,info%irank_jo(jj),ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+      call calc_iroot(jj,info%irank_jo(jj),ilsda,nproc_ob,itotmst,mst)
     end do
     
     info_ob%im_s = 1
@@ -648,7 +648,7 @@ if(iopt==1)then
  
     info%jo_tbl(:) = 0 !(initial value)
     do iob=info%io_s,info%io_e
-      call calc_allob(iob,jj,iparaway_ob,itotmst,mst,iobnum)
+      call calc_allob(iob,jj,itotmst,mst,iobnum)
       info%io_tbl(iob) = jj
       info%jo_tbl(jj)  = iob
     end do
@@ -663,7 +663,7 @@ if(iopt==1)then
     end do
     
     do jj=1, system%no
-      call calc_iroot(jj,info%irank_jo(jj),ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+      call calc_iroot(jj,info%irank_jo(jj),ilsda,nproc_ob,itotmst,mst)
     end do
     
     info_ob%im_s = 1
@@ -923,7 +923,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     ! FIX: Attempt to fetch from allocatable variable K_RD when it is not allocated
     if (.not. allocated(k_rd)) allocate(k_rd(3,num_kpoints_rd))
 
-    call scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,srho,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob, &
+    call scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,srho,iflag,itotmst,mst,ilsda,nproc_ob, &
                        num_kpoints_rd,k_rd,cg,   &
                        info_ob,ppg,vlocal,  &
                        iflag_diisjump,energy, &
@@ -1039,11 +1039,11 @@ DFT_Iteration : do iter=1,iDiter(img)
     if(Miter>iDiter_nosubspace_diag)then
       select case(iperiodic)
       case(0)
-        call subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iparaway_ob,iobnum,itotmst,mst,ifmst,  &
+        call subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iobnum,itotmst,mst,ifmst,  &
                 info_ob,ppg,vlocal)
 
       case(3)
-        call subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iparaway_ob,  &
+        call subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,  &
                                     iobnum,itotmst,mst,ifmst,   &
                                     info_ob,ppg,vlocal,num_kpoints_rd,k_rd)
 
@@ -1060,19 +1060,19 @@ DFT_Iteration : do iter=1,iDiter(img)
       case(0)
         select case(gscg)
         case('y')
-          call sgscg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,cg, &
+          call sgscg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,cg, &
                      info_ob,ppg,vlocal)
         case('n')
-          call dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,  &
+          call dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,  &
                     info_ob,ppg,vlocal)
         end select
       case(3)
         select case(gscg)
         case('y')
-          call gscg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,cg,   &
+          call gscg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,cg,   &
                              info_ob,ppg,vlocal,num_kpoints_rd,k_rd)
         case('n')
-          call dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,   &
+          call dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,   &
                              info_ob,ppg,vlocal,num_kpoints_rd,k_rd)
         end select
       end select
@@ -1080,7 +1080,7 @@ DFT_Iteration : do iter=1,iDiter(img)
       select case(iperiodic)
       case(0)
         call rmmdiis(mg,system,info,stencil,srg_ob_1,spsi,energy,itotmst,mst,iflag_diisjump, &
-                     norm_diff_psi_stock,info_ob,ppg,vlocal,iparaway_ob)
+                     norm_diff_psi_stock,info_ob,ppg,vlocal)
       case(3)
         stop "rmmdiis method is not implemented for periodic systems."
       end select

--- a/src/common/calc_allob.f90
+++ b/src/common/calc_allob.f90
@@ -18,36 +18,23 @@ module calc_allob_sub
 
 contains
 
-subroutine calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+subroutine calc_allob(iob,iob_allob,itotmst,mst,iobnum)
   use inputoutput, only: ispin,nproc_ob
   use salmon_parallel, only: nproc_id_kgrid
   implicit none
   integer,intent(in) :: iob
   integer,intent(out) ::  iob_allob
-  integer,intent(in) :: iparaway_ob,itotmst,mst(2),iobnum
+  integer,intent(in) :: itotmst,mst(2),iobnum
   integer :: iob_tmp
   
   if(ispin==0)then
-    if(iparaway_ob==1)then
-      iob_allob=nproc_id_kgrid*itotmst/nproc_ob+iob
-    else if(iparaway_ob==2)then
-      iob_allob=(iob-1)*nproc_ob+nproc_id_kgrid+1
-    end if
+    iob_allob=nproc_id_kgrid*itotmst/nproc_ob+iob
   else
-    if(iparaway_ob==1)then
-      if(iob<=iobnum/2)then
-        iob_allob=nproc_id_kgrid*mst(1)/nproc_ob+iob
-      else
-        iob_tmp=iob-iobnum/2
-        iob_allob=nproc_id_kgrid*mst(2)/nproc_ob+iob_tmp+mst(1)
-      end if
-    else if(iparaway_ob==2)then
-      if(iob<=iobnum/2)then
-        iob_allob=(iob-1)*nproc_ob+nproc_id_kgrid+1
-      else
-        iob_tmp=iob-iobnum/2
-        iob_allob=(iob_tmp-1)*nproc_ob+nproc_id_kgrid+1+mst(1)
-      end if
+    if(iob<=iobnum/2)then
+      iob_allob=nproc_id_kgrid*mst(1)/nproc_ob+iob
+    else
+      iob_tmp=iob-iobnum/2
+      iob_allob=nproc_id_kgrid*mst(2)/nproc_ob+iob_tmp+mst(1)
     end if
   end if
   

--- a/src/common/calc_iroot.f90
+++ b/src/common/calc_iroot.f90
@@ -18,33 +18,21 @@ module calc_iroot_sub
 
 contains
 
-subroutine calc_iroot(iob,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+subroutine calc_iroot(iob,iroot,ilsda,nproc_ob,itotmst,mst)
   use calc_iquotient_sub
   implicit none
   integer,intent(in)  :: iob
   integer,intent(out) :: iroot
-  integer,intent(in)  :: ilsda,nproc_ob,iparaway_ob,itotmst,mst(2)
+  integer,intent(in)  :: ilsda,nproc_ob,itotmst,mst(2)
   
   if(ilsda==0)then
-    if(iparaway_ob==1)then
-      call calc_iquotient(iob,nproc_ob,itotmst,iroot)
-    else if(iparaway_ob==2)then
-      iroot=mod(iob-1,nproc_ob)
-    end if
+    call calc_iquotient(iob,nproc_ob,itotmst,iroot)
   else
-    if(iparaway_ob==1)then
-      if(iob<=mst(1))then
-        call calc_iquotient(iob,nproc_ob,mst(1),iroot)
-      else
-        call calc_iquotient(iob-mst(1),nproc_ob,mst(2),iroot)
-      end if
-    else if(iparaway_ob==2)then
-      if(iob<=mst(1))then
-        iroot=mod(iob-1,nproc_ob)
-      else
-        iroot=mod(iob-1-mst(1),nproc_ob)
-      end if
-    end if 
+    if(iob<=mst(1))then
+      call calc_iquotient(iob,nproc_ob,mst(1),iroot)
+    else
+      call calc_iquotient(iob-mst(1),nproc_ob,mst(2),iroot)
+    end if
   end if
 
 end subroutine calc_iroot

--- a/src/common/calc_myob.f90
+++ b/src/common/calc_myob.f90
@@ -18,42 +18,24 @@ module calc_myob_sub
 
 contains
 
-subroutine calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
+subroutine calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
   use calc_iquotient_sub
   implicit none
   integer,intent(in)  :: iob
   integer,intent(out) :: iob_myob
-  integer,intent(in)  :: ilsda,nproc_ob,iparaway_ob,itotmst,mst(2),iobnum
+  integer,intent(in)  :: ilsda,nproc_ob,itotmst,mst(2),iobnum
   integer :: iquotient,iob_min
   integer :: iob_tmp
   
   if(ilsda==0)then
-    if(iparaway_ob==1)then
-      call calc_iquotient(iob,nproc_ob,itotmst,iquotient)
-      iob_min=itotmst*iquotient/nproc_ob
-      iob_myob=iob-iob_min
-    else if(iparaway_ob==2)then
-      iob_myob=(iob-1)/nproc_ob+1
-    end if
+    call calc_iquotient(iob,nproc_ob,itotmst,iquotient)
+    iob_min=itotmst*iquotient/nproc_ob
+    iob_myob=iob-iob_min
   else
-    if(iparaway_ob==1)then
-      if(iob<=mst(1))then
-        call calc_iquotient(iob,nproc_ob,mst(1),iquotient)
-        iob_min=mst(1)*iquotient/nproc_ob
-        iob_myob=iob-iob_min
-      else
-        iob_tmp=iob-mst(1)
-        call calc_iquotient(iob_tmp,nproc_ob,mst(1),iquotient)
-        iob_min=mst(1)*iquotient/nproc_ob
-        iob_myob=iob_tmp-iob_min+iobnum/2
-      end if
-    else if(iparaway_ob==2)then
-      if(iob<=mst(1))then
-        iob_myob=(iob-1)/nproc_ob+1
-      else
-        iob_tmp=iob-mst(1)
-        iob_myob=(iob_tmp-1)/nproc_ob+1+iobnum/2
-      end if
+    if(iob<=mst(1))then
+      call calc_iquotient(iob,nproc_ob,mst(1),iquotient)
+      iob_min=mst(1)*iquotient/nproc_ob
+      iob_myob=iob-iob_min
     end if
   end if
 

--- a/src/common/calc_ob_num.f90
+++ b/src/common/calc_ob_num.f90
@@ -18,12 +18,12 @@ module calc_iobnum_sub
 
 contains
 
-subroutine calc_iobnum(tmst,tproc,trank,tiobnum,nproc_ob,iparaway_ob)
+subroutine calc_iobnum(tmst,tproc,trank,tiobnum,nproc_ob)
   use inputoutput, only : ispin
   implicit none
   integer :: tmst,tproc,trank,tiobnum
   integer :: ttmst
-  integer :: nproc_ob,iparaway_ob
+  integer :: nproc_ob
   
   if(ispin==0)then
     ttmst=tmst
@@ -31,19 +31,7 @@ subroutine calc_iobnum(tmst,tproc,trank,tiobnum,nproc_ob,iparaway_ob)
     ttmst=tmst/2
   end if
   
-  if(iparaway_ob==1)then
-    tiobnum=(trank+1)*ttmst/nproc_ob-trank*ttmst/nproc_ob
-  else if(iparaway_ob==2)then
-    if(mod(ttmst,tproc)==0)then
-      tiobnum=ttmst/tproc
-    else
-      if(trank<mod(ttmst,tproc))then
-        tiobnum=ttmst/tproc+1
-      else
-        tiobnum=ttmst/tproc
-      end if
-    end if
-  end if
+  tiobnum=(trank+1)*ttmst/nproc_ob-trank*ttmst/nproc_ob
   
   if(ispin==1)then
     tiobnum=tiobnum*2

--- a/src/common/check_corrkob.f90
+++ b/src/common/check_corrkob.f90
@@ -18,13 +18,13 @@ module check_corrkob_sub
 
 contains
 
-subroutine check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst)
+subroutine check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,k_sta,k_end,mst)
   use salmon_parallel, only: nproc_id_kgrid
   use calc_iquotient_sub
   implicit none
   integer,intent(in)  :: iob,ik
   integer,intent(out) :: icorr_p
-  integer,intent(in)  :: ilsda,nproc_ob,iparaway_ob,k_sta,k_end,mst(2)
+  integer,intent(in)  :: ilsda,nproc_ob,k_sta,k_end,mst(2)
   integer :: iquotient
   integer :: iob_tmp
 
@@ -34,19 +34,11 @@ subroutine check_corrkob(iob,ik,icorr_p,ilsda,nproc_ob,iparaway_ob,k_sta,k_end,m
     iob_tmp=iob-mst(1)
   end if 
 
-  if(iparaway_ob==1)then
-    call calc_iquotient(iob_tmp,nproc_ob,mst(1),iquotient)
-    if(nproc_id_kgrid==iquotient.and.ik>=k_sta.and.ik<=k_end)then
-      icorr_p=1
-    else
-      icorr_p=0
-    end if
-  else if(iparaway_ob==2)then
-    if(nproc_id_kgrid==mod(iob_tmp-1,nproc_ob).and.ik>=k_sta.and.ik<=k_end)then
-      icorr_p=1
-    else
-      icorr_p=0
-    end if
+  call calc_iquotient(iob_tmp,nproc_ob,mst(1),iquotient)
+  if(nproc_id_kgrid==iquotient.and.ik>=k_sta.and.ik<=k_end)then
+    icorr_p=1
+  else
+    icorr_p=0
   end if
   
 end subroutine check_corrkob

--- a/src/common/inner_product5.f90
+++ b/src/common/inner_product5.f90
@@ -1,4 +1,4 @@
-subroutine inner_product5(mg,iparaway_ob,itotmst,mst,iobnum,zmatbox1,zmatbox2,zbox,hvol)
+subroutine inner_product5(mg,itotmst,mst,iobnum,zmatbox1,zmatbox2,zbox,hvol)
   use structures, only: s_rgrid
   use salmon_parallel, only: nproc_group_korbital
   use salmon_communication, only: comm_summation
@@ -7,7 +7,6 @@ subroutine inner_product5(mg,iparaway_ob,itotmst,mst,iobnum,zmatbox1,zmatbox2,zb
   !$ use omp_lib
   implicit none
   type(s_rgrid),intent(in) :: mg
-  integer,intent(in)  :: iparaway_ob
   integer,intent(in)  :: itotmst
   integer,intent(in)  :: mst(2)
   integer,intent(in)  :: iobnum
@@ -22,7 +21,7 @@ subroutine inner_product5(mg,iparaway_ob,itotmst,mst,iobnum,zmatbox1,zmatbox2,zb
   
   zbox2(:)=0.d0
   do iob=1,iobnum
-    call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
     sum0=0.d0
     !$OMP parallel do collapse(2) reduction(+ : sum0)
     do iz=mg%is(3),mg%ie(3)

--- a/src/common/inner_product7.f90
+++ b/src/common/inner_product7.f90
@@ -14,7 +14,7 @@
 !  limitations under the License.
 !
 !=======================================================================
-subroutine inner_product7(mg,iparaway_ob,itotmst,mst,iobnum,rmatbox1,rmatbox2,rbox2,hvol)
+subroutine inner_product7(mg,itotmst,mst,iobnum,rmatbox1,rmatbox2,rbox2,hvol)
   use structures, only: s_rgrid
   use salmon_parallel, only: nproc_group_korbital
   use salmon_communication, only: comm_summation
@@ -22,7 +22,6 @@ subroutine inner_product7(mg,iparaway_ob,itotmst,mst,iobnum,rmatbox1,rmatbox2,rb
   use calc_allob_sub
   implicit none
   type(s_rgrid),intent(in) :: mg
-  integer,intent(in)  :: iparaway_ob
   integer,intent(in)  :: itotmst
   integer,intent(in)  :: mst(2)
   integer,intent(in)  :: iobnum
@@ -36,7 +35,7 @@ subroutine inner_product7(mg,iparaway_ob,itotmst,mst,iobnum,rmatbox1,rmatbox2,rb
   rbox1(:)=0.d0
  
   do iob=1,iobnum
-    call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+    call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
     rbox=0.d0
     !$omp parallel do private(iz,iy,ix) collapse(2) reduction(+ : rbox)
     do iz=mg%is(3),mg%ie(3)

--- a/src/gs/rmmdiis.f90
+++ b/src/gs/rmmdiis.f90
@@ -29,7 +29,7 @@ contains
 
 subroutine rmmdiis(mg,system,info,stencil,srg_ob_1,spsi,energy,itotmst  &
                   ,mst,iflag_diisjump,norm_diff_psi_stock  &
-                  ,info_ob,ppg,vlocal,iparaway_ob)
+                  ,info_ob,ppg,vlocal)
   use inputoutput, only: ncg,lambda1_diis,lambda2_diis
   use structures, only: s_rgrid,s_dft_system,s_orbital_parallel,s_orbital,   &
                         s_dft_energy,s_stencil,s_scalar,s_pp_grid
@@ -54,7 +54,6 @@ subroutine rmmdiis(mg,system,info,stencil,srg_ob_1,spsi,energy,itotmst  &
   real(8),intent(out)   :: norm_diff_psi_stock(itotmst,1)
   type(s_orbital_parallel)       :: info_ob
   real(8),intent(in)    :: vlocal(mg%is(1):mg%ie(1),mg%is(2):mg%ie(2),mg%is(3):mg%ie(3),system%nspin)
-  integer,intent(in)    :: iparaway_ob
   integer,parameter :: nd=4
   integer :: iob,iob_allob,iter,ix,iy,iz
   integer :: nspin_1
@@ -135,7 +134,7 @@ subroutine rmmdiis(mg,system,info,stencil,srg_ob_1,spsi,energy,itotmst  &
   iflag_diisjump=0
   
   do iob=1,system%nspin*numo
-    call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,system%nspin*numo)
+    call calc_allob(iob,iob_allob,itotmst,mst,system%nspin*numo)
     if(iob>numo)then
       is=2
     else
@@ -261,7 +260,7 @@ subroutine rmmdiis(mg,system,info,stencil,srg_ob_1,spsi,energy,itotmst  &
   
   iflag_diisjump=0
   do iob=1,system%nspin*numo
-    call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,system%nspin*numo)
+    call calc_allob(iob,iob_allob,itotmst,mst,system%nspin*numo)
     if(iob>numo)then
       is=2
     else
@@ -293,7 +292,7 @@ subroutine rmmdiis(mg,system,info,stencil,srg_ob_1,spsi,energy,itotmst  &
       psi_stock(mg_xs:mg_xe,mg_ys:mg_ye,mg_zs:mg_ze,1:system%nspin,  &
                       1:numo,info%ik_s:info%ik_e,1)
     do iob=1,system%nspin*numo
-      call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,system%nspin*numo)
+      call calc_allob(iob,iob_allob,itotmst,mst,system%nspin*numo)
       if(iob>numo)then
         is=2
       else

--- a/src/gs/scf_iteration.f90
+++ b/src/gs/scf_iteration.f90
@@ -19,7 +19,7 @@ module scf_iteration_sub
 
 contains
 
-subroutine scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,srho,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob, &
+subroutine scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,srho,iflag,itotmst,mst,ilsda,nproc_ob, &
                num_kpoints_rd,k_rd,cg,   &
                info_ob,ppg,vlocal,  &
                iflag_diisjump,energy, &
@@ -53,7 +53,6 @@ subroutine scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,srho,iflag,itotmst
   integer,               intent(in)    :: mst(2)
   integer,               intent(in)    :: ilsda
   integer,               intent(in)    :: nproc_ob
-  integer,               intent(in)    :: iparaway_ob
   integer,               intent(in)    :: num_kpoints_rd
   real(8),               intent(in)    :: k_rd(3,num_kpoints_rd)
   type(s_cg),            intent(inout) :: cg
@@ -78,19 +77,19 @@ subroutine scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,srho,iflag,itotmst
     case(0)
       select case(gscg)
       case('y')
-        call sgscg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,cg, &
+        call sgscg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,cg, &
                    info_ob,ppg,vlocal)
       case('n')
-        call dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,   &
+        call dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,   &
                   info_ob,ppg,vlocal)
       end select
     case(3)
       select case(gscg)
       case('y')
-        call gscg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,cg,   &
+        call gscg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,cg,   &
                            info_ob,ppg,vlocal,num_kpoints_rd,k_rd)
       case('n')
-        call dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,   &
+        call dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,   &
                            info_ob,ppg,vlocal,num_kpoints_rd,k_rd)
       end select
     end select
@@ -99,7 +98,7 @@ subroutine scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,srho,iflag,itotmst
     case(0)
       call rmmdiis(mg,system,info,stencil,srg_ob_1,spsi,energy,itotmst,mst,   &
                    iflag_diisjump, &
-                   norm_diff_psi_stock,info_ob,ppg,vlocal,iparaway_ob)
+                   norm_diff_psi_stock,info_ob,ppg,vlocal)
     case(3)
       stop "rmmdiis method is not implemented for periodic systems."
     end select
@@ -115,11 +114,11 @@ subroutine scf_iteration(mg,system,info,stencil,srg_ob_1,spsi,srho,iflag,itotmst
     if(miter>iditer_nosubspace_diag)then
       select case(iperiodic)
       case(0)      
-        call subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iparaway_ob,iobnum,itotmst,   &
+        call subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iobnum,itotmst,   &
                            mst,ifmst,info_ob,ppg,vlocal)
 
       case(3)
-        call subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iparaway_ob,  &
+        call subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,  &
                                     iobnum,itotmst,mst,ifmst,   &
                                     info_ob,ppg,vlocal,num_kpoints_rd,k_rd)
       end select

--- a/src/gs/subspace_diag.f90
+++ b/src/gs/subspace_diag.f90
@@ -18,7 +18,7 @@ module subspace_diag_sub
 
 contains
 
-subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iparaway_ob,iobnum,itotmst,mst,ifmst,  &
+subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iobnum,itotmst,mst,ifmst,  &
                 info_ob,ppg,vlocal)
 
   use inputoutput, only: ispin
@@ -43,7 +43,6 @@ subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,ipa
   type(s_pp_grid) :: ppg
   integer,intent(in)  :: ilsda
   integer,intent(in)  :: nproc_ob
-  integer,intent(in)  :: iparaway_ob
   integer,intent(in)  :: iobnum
   integer,intent(in)  :: itotmst
   integer,intent(in)  :: mst(2),ifmst(2)
@@ -151,8 +150,8 @@ subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,ipa
       end do
     
       do job=iobsta(is),iobend(is)
-        call calc_myob(job,job_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-        call check_corrkob(job,1,icorr_j,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+        call calc_myob(job,job_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+        call check_corrkob(job,1,icorr_j,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
         if(icorr_j==1)then
   !$OMP parallel do private(iz,iy,ix)
           do iz=mg%is(3),mg%ie(3)
@@ -172,11 +171,11 @@ subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,ipa
           end do
           end do
         end if
-        call calc_iroot(job,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+        call calc_iroot(job,iroot,ilsda,nproc_ob,itotmst,mst)
         call comm_bcast(htpsi,nproc_group_kgrid,iroot)
         
         do iob=1,iobnum
-          call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+          call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
           if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
             rbox=0.d0
   !$OMP parallel do reduction(+:rbox) private(iz,iy,ix)
@@ -197,7 +196,7 @@ subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,ipa
       call eigen_subdiag(amat,evec,iter,ier2)
      
       do job=1,iobnum
-        call calc_allob(job,job_allob,iparaway_ob,itotmst,mst,iobnum)
+        call calc_allob(job,job_allob,itotmst,mst,iobnum)
         if(job_allob>=iobsta(is).and.job_allob<=iobend(is))then
   !$OMP parallel do private(iz,iy,ix)
           do iz=mg%is(3),mg%ie(3)
@@ -212,8 +211,8 @@ subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,ipa
       end do
        
       do job=iobsta(is),iobend(is)
-        call calc_myob(job,job_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-        call check_corrkob(job,1,icorr_j,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+        call calc_myob(job,job_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+        call check_corrkob(job,1,icorr_j,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
         if(icorr_j==1)then
   !$OMP parallel do private(iz,iy,ix)
           do iz=mg%is(3),mg%ie(3)
@@ -224,10 +223,10 @@ subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,ipa
           end do
           end do
         end if
-        call calc_iroot(job,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+        call calc_iroot(job,iroot,ilsda,nproc_ob,itotmst,mst)
         call comm_bcast(rmatbox_m,nproc_group_kgrid,iroot)
         do iob=1,iobnum
-          call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+          call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
           if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
   !$OMP parallel do private(iz,iy,ix)
             do iz=mg%is(3),mg%ie(3)
@@ -244,7 +243,7 @@ subroutine subspace_diag(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,ipa
       end do
     
       do iob=1,iobnum
-        call calc_allob(iob,iob_allob,iparaway_ob,itotmst,mst,iobnum)
+        call calc_allob(iob,iob_allob,itotmst,mst,iobnum)
         if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
           rbox=0.d0
   !$OMP parallel do reduction(+:rbox) private(iz,iy,ix)

--- a/src/gs/subspace_diag_periodic.f90
+++ b/src/gs/subspace_diag_periodic.f90
@@ -18,7 +18,7 @@ module subspace_diag_periodic_sub
 
 contains
 
-subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,iparaway_ob,  &
+subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,nproc_ob,  &
                                   iobnum,itotmst,mst,ifmst,   &
                                   info_ob,ppg,vlocal,num_kpoints_rd,k_rd)
 
@@ -45,7 +45,6 @@ subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,npr
   type(s_pp_grid) :: ppg
   integer,intent(in)  :: ilsda
   integer,intent(in)  :: nproc_ob
-  integer,intent(in)  :: iparaway_ob
   integer,intent(in)  :: iobnum
   integer,intent(in)  :: itotmst
   integer,intent(in)  :: mst(2),ifmst(2)
@@ -177,7 +176,7 @@ subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,npr
     
   !do jj=1,itotmst
       do jj=1,iobnum
-        call calc_allob(jj,j_allob,iparaway_ob,itotmst,mst,iobnum)
+        call calc_allob(jj,j_allob,itotmst,mst,iobnum)
         if(j_allob>=iobsta(is).and.j_allob<=iobend(is))then
   !$OMP parallel do private(iz,iy,ix)
           do iz=mg%is(3),mg%ie(3)
@@ -200,8 +199,8 @@ subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,npr
       end do
     
       do jj=iobsta(is),iobend(is)
-        call calc_myob(jj,j_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-        call check_corrkob(jj,ik,icorr_j,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+        call calc_myob(jj,j_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+        call check_corrkob(jj,ik,icorr_j,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
         if(icorr_j==1)then
   !$OMP parallel do private(iz,iy,ix)
           do iz=mg%is(3),mg%ie(3)
@@ -212,10 +211,10 @@ subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,npr
           end do
           end do
         end if
-        call calc_iroot(jj,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+        call calc_iroot(jj,iroot,ilsda,nproc_ob,itotmst,mst)
         call comm_bcast(htpsi,nproc_group_kgrid,iroot)
         do ii=1,iobnum
-          call calc_allob(ii,i_allob,iparaway_ob,itotmst,mst,iobnum)
+          call calc_allob(ii,i_allob,itotmst,mst,iobnum)
           if(i_allob>=iobsta(is).and.i_allob<=iobend(is))then
             cbox=0.d0
   !$OMP parallel do private(iz,iy,ix) reduction (+ : cbox)
@@ -245,7 +244,7 @@ subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,npr
 
       call timer_begin(LOG_DIAG_SET_ORBITAL)
       do jj=1,iobnum
-        call calc_allob(jj,j_allob,iparaway_ob,itotmst,mst,iobnum)
+        call calc_allob(jj,j_allob,itotmst,mst,iobnum)
         if(j_allob>=iobsta(is).and.j_allob<=iobend(is))then
   !$OMP parallel do private(iz,iy,ix)
           do iz=mg%is(3),mg%ie(3)
@@ -263,8 +262,8 @@ subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,npr
 
       call timer_begin(LOG_DIAG_UPDATE)
       do jj=iobsta(is),iobend(is)
-        call calc_myob(jj,j_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,iobnum)
-        call check_corrkob(jj,ik,icorr_j,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+        call calc_myob(jj,j_myob,ilsda,nproc_ob,itotmst,mst,iobnum)
+        call check_corrkob(jj,ik,icorr_j,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
         if(icorr_j==1)then
   !$OMP parallel do private(iz,iy,ix)
           do iz=mg%is(3),mg%ie(3)
@@ -275,10 +274,10 @@ subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,npr
           end do
           end do
         end if
-        call calc_iroot(jj,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+        call calc_iroot(jj,iroot,ilsda,nproc_ob,itotmst,mst)
         call comm_bcast(htpsi,nproc_group_kgrid,iroot)
         do ii=1,iobnum
-          call calc_allob(ii,i_allob,iparaway_ob,itotmst,mst,iobnum)
+          call calc_allob(ii,i_allob,itotmst,mst,iobnum)
           if(i_allob>=iobsta(is).and.i_allob<=iobend(is))then
   !$OMP parallel do private(iz,iy,ix)
             do iz=mg%is(3),mg%ie(3)
@@ -294,7 +293,7 @@ subroutine subspace_diag_periodic(mg,system,info,stencil,srg_ob_1,spsi,ilsda,npr
       end do
     
       do ii=1,iobnum
-        call calc_allob(ii,i_allob,iparaway_ob,itotmst,mst,iobnum)
+        call calc_allob(ii,i_allob,itotmst,mst,iobnum)
         if(i_allob>=iobsta(is).and.i_allob<=iobend(is))then
           rbox=0.d0
   !$OMP parallel do private(iz,iy,ix) reduction(+:rbox)

--- a/src/gs/ybcg.f90
+++ b/src/gs/ybcg.f90
@@ -21,7 +21,7 @@ contains
 !=======================================================================
 !======================================= Conjugate-Gradient minimization
 
-subroutine dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,  &
+subroutine dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,  &
                 info_ob,ppg,vlocal)
   use inputoutput, only: ncg,ispin
   use structures, only: s_rgrid,s_dft_system,s_orbital_parallel,s_orbital,s_stencil,s_scalar,s_pp_grid
@@ -50,7 +50,6 @@ subroutine dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,npr
   integer,intent(in)    :: mst(2)
   integer,intent(in)    :: ilsda
   integer,intent(in)    :: nproc_ob
-  integer,intent(in)    :: iparaway_ob
   type(s_orbital_parallel)       :: info_ob
   real(8),intent(in)    :: vlocal(mg%is(1):mg%ie(1),mg%is(2):mg%ie(2),mg%is(3):mg%ie(3),ispin+1)
   integer,parameter :: nd=4
@@ -127,8 +126,8 @@ subroutine dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,npr
     end do
 
   orbital : do iob=iobsta(is),iobend(is)
-    call calc_myob(iob,iob_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,system%nspin*info%numo)
-    call check_corrkob(iob,1,icorr,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+    call calc_myob(iob,iob_myob,ilsda,nproc_ob,itotmst,mst,system%nspin*info%numo)
+    call check_corrkob(iob,1,icorr,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
 
   
     if(icorr==1)then
@@ -180,13 +179,13 @@ subroutine dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,npr
         end do
         end do
       end if
-      call calc_iroot(iob,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+      call calc_iroot(iob,iroot,ilsda,nproc_ob,itotmst,mst)
       call comm_bcast(gk,nproc_group_grid,iroot)
   
       do job=iobsta(is),iob-1
         sum0=0.d0
-        call calc_myob(job,job_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,system%nspin*info%numo)
-        call check_corrkob(job,1,jcorr,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+        call calc_myob(job,job_myob,ilsda,nproc_ob,itotmst,mst,system%nspin*info%numo)
+        call check_corrkob(job,1,jcorr,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
         if(jcorr==1)then
   !$OMP parallel do reduction(+ : sum0) private(iz,iy,ix) 
           do iz=mg%is(3),mg%ie(3)
@@ -208,7 +207,7 @@ subroutine dtcg(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,npr
           end do
         end if
   
-        call calc_iroot(job,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+        call calc_iroot(job,iroot,ilsda,nproc_ob,itotmst,mst)
         call comm_bcast(gk,nproc_group_grid,iroot)
       end do
   

--- a/src/gs/ybcg_periodic.f90
+++ b/src/gs/ybcg_periodic.f90
@@ -21,7 +21,7 @@ contains
 !=======================================================================
 !======================================= Conjugate-Gradient minimization
 
-subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,iparaway_ob,   &
+subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,ilsda,nproc_ob,   &
                          info_ob,ppg,vlocal,num_kpoints_rd,k_rd)
   use inputoutput, only: ncg
   use structures, only: s_rgrid,s_dft_system,s_orbital_parallel,s_orbital,s_stencil,s_scalar,s_pp_grid
@@ -48,7 +48,6 @@ subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,
   integer,intent(in)    :: mst(2)
   integer,intent(in)    :: ilsda
   integer,intent(in)    :: nproc_ob
-  integer,intent(in)    :: iparaway_ob
   type(s_orbital_parallel)       :: info_ob
   real(8),intent(in)    :: vlocal(mg%is(1):mg%ie(1),mg%is(2):mg%ie(2),mg%is(3):mg%ie(3),system%nspin)
   integer,intent(in)    :: num_kpoints_rd
@@ -152,8 +151,8 @@ subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,
     end do
     call update_kvector_nonlocalpt(ppg,stencil%vec_kAc,1,1)
 
-    call calc_myob(p,p_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,system%nspin*info%numo)
-    call check_corrkob(p,ik,icorr_p,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+    call calc_myob(p,p_myob,ilsda,nproc_ob,itotmst,mst,system%nspin*info%numo)
+    call check_corrkob(p,ik,icorr_p,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
   
 
   
@@ -183,8 +182,8 @@ subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,
       end do
     else
       do q=pstart(is),p-1
-        call calc_myob(q,q_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,system%nspin*info%numo)
-        call check_corrkob(q,ik,icorr_q,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+        call calc_myob(q,q_myob,ilsda,nproc_ob,itotmst,mst,system%nspin*info%numo)
+        call check_corrkob(q,ik,icorr_q,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
         if(icorr_q==1)then
   !$omp parallel do
           do iz=mg%is(3),mg%ie(3)
@@ -195,7 +194,7 @@ subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,
           end do
           end do
         end if
-        call calc_iroot(q,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+        call calc_iroot(q,iroot,ilsda,nproc_ob,itotmst,mst)
         call comm_bcast(zmatbox_m,nproc_group_kgrid,iroot)
         sum0=0.d0
         if(icorr_p==1)then
@@ -268,7 +267,7 @@ subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,
       end do
     end if
   
-    call calc_iroot(p,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+    call calc_iroot(p,iroot,ilsda,nproc_ob,itotmst,mst)
     call comm_bcast(xk,nproc_group_kgrid,iroot)
     call comm_bcast(hxk,nproc_group_kgrid,iroot)
     call comm_bcast(txk,nproc_group_kgrid,iroot)
@@ -310,8 +309,8 @@ subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,
         end do
       else
         do q=pstart(is),p-1
-          call calc_myob(q,q_myob,ilsda,nproc_ob,iparaway_ob,itotmst,mst,system%nspin*info%numo)
-          call check_corrkob(q,ik,icorr_q,ilsda,nproc_ob,iparaway_ob,info%ik_s,info%ik_e,mst)
+          call calc_myob(q,q_myob,ilsda,nproc_ob,itotmst,mst,system%nspin*info%numo)
+          call check_corrkob(q,ik,icorr_q,ilsda,nproc_ob,info%ik_s,info%ik_e,mst)
           if(icorr_q==1)then
   !$omp parallel do
             do iz=mg%is(3),mg%ie(3)
@@ -322,7 +321,7 @@ subroutine dtcg_periodic(mg,system,info,stencil,srg_ob_1,spsi,iflag,itotmst,mst,
             end do
             end do
           end if
-          call calc_iroot(q,iroot,ilsda,nproc_ob,iparaway_ob,itotmst,mst)
+          call calc_iroot(q,iroot,ilsda,nproc_ob,itotmst,mst)
           call comm_bcast(zmatbox_m,nproc_group_kgrid,iroot)
           sum0=0.d0
   !$omp parallel do reduction(+ : sum0)

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -501,14 +501,12 @@ contains
       & oc_rt
 
     namelist/group_others/ &
-      & iparaway_ob, &
       & iscf_order, &
       & iswitch_orbital_mesh, &
       & iflag_psicube, &
       & lambda1_diis, &
       & lambda2_diis, &
       & file_ini, &
-      & iparaway_ob, &
       & num_projection, &
       & iwrite_projection_ob, &
       & iwrite_projection_k, &
@@ -841,7 +839,6 @@ contains
     ic_rt = 0
     oc_rt = 0
 !! == default for &group_others
-    iparaway_ob = 2
     iscf_order  = 1
     iswitch_orbital_mesh = 0
     iflag_psicube        = 0
@@ -1282,14 +1279,12 @@ contains
     call comm_bcast(ic_rt,nproc_group_global)
     call comm_bcast(oc_rt,nproc_group_global)
 !! == bcast for &group_others
-    call comm_bcast(iparaway_ob         ,nproc_group_global)
     call comm_bcast(iscf_order          ,nproc_group_global)
     call comm_bcast(iswitch_orbital_mesh,nproc_group_global)
     call comm_bcast(iflag_psicube       ,nproc_group_global)
     call comm_bcast(lambda1_diis        ,nproc_group_global)
     call comm_bcast(lambda2_diis        ,nproc_group_global)
     call comm_bcast(file_ini            ,nproc_group_global)
-    call comm_bcast(iparaway_ob         ,nproc_group_global)
     call comm_bcast(num_projection      ,nproc_group_global)
     call comm_bcast(iwrite_projection_ob,nproc_group_global)
     call comm_bcast(iwrite_projection_k ,nproc_group_global)
@@ -1950,14 +1945,12 @@ contains
 
       if(inml_group_others >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'group_others', inml_group_others
-      write(fh_variables_log, '("#",4X,A,"=",I2)') 'iparaway_ob', iparaway_ob
       write(fh_variables_log, '("#",4X,A,"=",I2)') 'iscf_order', iscf_order
       write(fh_variables_log, '("#",4X,A,"=",I2)') 'iswitch_orbital_mesh', iswitch_orbital_mesh
       write(fh_variables_log, '("#",4X,A,"=",I2)') 'iflag_psicube', iflag_psicube
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'lambda1_diis', lambda1_diis
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'lambda2_diis', lambda2_diis
       write(fh_variables_log, '("#",4X,A,"=",A)') 'file_ini', file_ini
-      write(fh_variables_log, '("#",4X,A,"=",I2)') 'iparaway_ob', iparaway_ob
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'num_projection', num_projection
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'num_projection', num_projection
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'iwrite_projection_ob(1)', iwrite_projection_ob(1)

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -331,7 +331,6 @@ module salmon_global
   integer        :: oc_rt
 
 !! &group_others
-  integer        :: iparaway_ob
   integer        :: iscf_order
   integer        :: iswitch_orbital_mesh
   integer        :: iflag_psicube


### PR DESCRIPTION
I remove function of iparaway_ob. From now on, block distribution is applied to orbitals. 