### PR TITLE
calc_current without density matrix

### DIFF
--- a/src/GCEED/rt/time_evolution_step.f90
+++ b/src/GCEED/rt/time_evolution_step.f90
@@ -21,7 +21,7 @@ SUBROUTINE time_evolution_step(lg,mg,ng,system,info,stencil,srg,srg_ng, &
   use structures
   use salmon_parallel, only: nproc_id_global
   use salmon_communication, only: comm_is_root, comm_summation, comm_bcast
-  use density_matrix, only: calc_density, calc_density_matrix, calc_current
+  use density_matrix, only: calc_density, calc_density_matrix, calc_current, calc_current_use_dmat
   use writefield
   use timer
   use inputoutput

--- a/src/common/density_matrix.f90
+++ b/src/common/density_matrix.f90
@@ -257,7 +257,7 @@ contains
     do im=info%im_s,info%im_e
     do ispin=1,nspin
 
-      wrk3 = 0d0
+      wrk4 = 0d0
       do ik=info%ik_s,info%ik_e
       do io=info%io_s,info%io_e
 
@@ -299,6 +299,8 @@ contains
       integer :: ix,iy,iz
       real(8) :: rtmp
       complex(8) :: cpsi,tmp(3)
+      rtmp = 0d0
+      tmp = 0d0
 !$omp parallel do collapse(2) private(iz,iy,ix,cpsi) reduction(+:rtmp,tmp)
       do iz=is(3),ie(3)
       do iy=is(2),ie(2)


### PR DESCRIPTION
I added a subroutine for calculating the current density without density matrix.