### PR TITLE
replace_old_ng

### DIFF
--- a/src/GCEED/common/OUT_IN_data.f90
+++ b/src/GCEED/common/OUT_IN_data.f90
@@ -15,8 +15,8 @@
 !
 !=======================================================================
 
-SUBROUTINE OUT_data(mixing)
-use structures, only: s_mixing
+SUBROUTINE OUT_data(ng,mixing)
+use structures, only: s_rgrid, s_mixing
 use salmon_parallel, only: nproc_id_global, nproc_size_global, nproc_group_global, nproc_group_h
 use salmon_communication, only: comm_is_root, comm_summation, comm_bcast
 use calc_myob_sub
@@ -27,6 +27,7 @@ use read_pslfile_sub
 use allocate_psl_sub
 use allocate_mat_sub
 implicit none
+type(s_rgrid), intent(in)    :: ng
 type(s_mixing),intent(inout) :: mixing
 integer :: is,iob,jj,ik
 integer :: ix,iy,iz
@@ -246,12 +247,12 @@ else if(OC==3)then
 end if
 
 matbox2=0.d0
-matbox2(ng_sta(1):ng_end(1),   &
-        ng_sta(2):ng_end(2),   &
-        ng_sta(3):ng_end(3))   &
-   = rho(ng_sta(1):ng_end(1),   &
-        ng_sta(2):ng_end(2),   &
-        ng_sta(3):ng_end(3))
+matbox2(ng%is(1):ng%ie(1),   &
+        ng%is(2):ng%ie(2),   &
+        ng%is(3):ng%ie(3))   &
+   = rho(ng%is(1):ng%ie(1),   &
+        ng%is(2):ng%ie(2),   &
+        ng%is(3):ng%ie(3))
 
 call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -261,12 +262,12 @@ end if
 
 do ii=1,mixing%num_rho_stock+1
   matbox2=0.d0
-  matbox2(ng_sta(1):ng_end(1),   &
-          ng_sta(2):ng_end(2),   &
-          ng_sta(3):ng_end(3))   &
-     = mixing%srho_in(ii)%f(ng_sta(1):ng_end(1),   &
-          ng_sta(2):ng_end(2),   &
-          ng_sta(3):ng_end(3))
+  matbox2(ng%is(1):ng%ie(1),   &
+          ng%is(2):ng%ie(2),   &
+          ng%is(3):ng%ie(3))   &
+     = mixing%srho_in(ii)%f(ng%is(1):ng%ie(1),   &
+          ng%is(2):ng%ie(2),   &
+          ng%is(3):ng%ie(3))
 
   call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -277,12 +278,12 @@ end do
 
 do ii=1,mixing%num_rho_stock
   matbox2=0.d0
-  matbox2(ng_sta(1):ng_end(1),   &
-          ng_sta(2):ng_end(2),   &
-          ng_sta(3):ng_end(3))   &
-     = mixing%srho_out(ii)%f(ng_sta(1):ng_end(1),   &
-          ng_sta(2):ng_end(2),   &
-          ng_sta(3):ng_end(3))
+  matbox2(ng%is(1):ng%ie(1),   &
+          ng%is(2):ng%ie(2),   &
+          ng%is(3):ng%ie(3))   &
+     = mixing%srho_out(ii)%f(ng%is(1):ng%ie(1),   &
+          ng%is(2):ng%ie(2),   &
+          ng%is(3):ng%ie(3))
 
   call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
   if(comm_is_root(nproc_id_global))then
@@ -293,12 +294,12 @@ end do
 if(ilsda == 1)then
   do is=1,2
     matbox2=0.d0
-    matbox2(ng_sta(1):ng_end(1),   &
-            ng_sta(2):ng_end(2),   &
-            ng_sta(3):ng_end(3))   &
-      = rho_s(ng_sta(1):ng_end(1),   &
-              ng_sta(2):ng_end(2),   &
-              ng_sta(3):ng_end(3),is)
+    matbox2(ng%is(1):ng%ie(1),   &
+            ng%is(2):ng%ie(2),   &
+            ng%is(3):ng%ie(3))   &
+      = rho_s(ng%is(1):ng%ie(1),   &
+              ng%is(2):ng%ie(2),   &
+              ng%is(3):ng%ie(3),is)
 
     call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -308,12 +309,12 @@ if(ilsda == 1)then
 
     do ii=1,mixing%num_rho_stock+1
       matbox2=0.d0
-      matbox2(ng_sta(1):ng_end(1),   &
-              ng_sta(2):ng_end(2),   &
-              ng_sta(3):ng_end(3))   &
-        = mixing%srho_s_in(ii,is)%f(ng_sta(1):ng_end(1),   &
-                ng_sta(2):ng_end(2),   &
-                ng_sta(3):ng_end(3))
+      matbox2(ng%is(1):ng%ie(1),   &
+              ng%is(2):ng%ie(2),   &
+              ng%is(3):ng%ie(3))   &
+        = mixing%srho_s_in(ii,is)%f(ng%is(1):ng%ie(1),   &
+                ng%is(2):ng%ie(2),   &
+                ng%is(3):ng%ie(3))
 
       call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -324,12 +325,12 @@ if(ilsda == 1)then
 
     do ii=1,mixing%num_rho_stock
       matbox2=0.d0
-      matbox2(ng_sta(1):ng_end(1),   &
-              ng_sta(2):ng_end(2),   &
-              ng_sta(3):ng_end(3))   &
-        = mixing%srho_s_out(ii,is)%f(ng_sta(1):ng_end(1),   &
-                ng_sta(2):ng_end(2),   &
-                ng_sta(3):ng_end(3))
+      matbox2(ng%is(1):ng%ie(1),   &
+              ng%is(2):ng%ie(2),   &
+              ng%is(3):ng%ie(3))   &
+        = mixing%srho_s_out(ii,is)%f(ng%is(1):ng%ie(1),   &
+                ng%is(2):ng%ie(2),   &
+                ng%is(3):ng%ie(3))
 
       call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -347,12 +348,12 @@ if(comm_is_root(nproc_id_global))then
 end if
 
 matbox2=0.d0
-matbox2(ng_sta(1):ng_end(1),   &
-        ng_sta(2):ng_end(2),   &
-        ng_sta(3):ng_end(3))   &
-   = Vh(ng_sta(1):ng_end(1),   &
-        ng_sta(2):ng_end(2),   &
-        ng_sta(3):ng_end(3))
+matbox2(ng%is(1):ng%ie(1),   &
+        ng%is(2):ng%ie(2),   &
+        ng%is(3):ng%ie(3))   &
+   = Vh(ng%is(1):ng%ie(1),   &
+        ng%is(2):ng%ie(2),   &
+        ng%is(3):ng%ie(3))
 
 call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -362,12 +363,12 @@ end if
 
 if(ilsda == 0)then
   matbox2=0.d0
-  matbox2(ng_sta(1):ng_end(1),   &
-          ng_sta(2):ng_end(2),   &
-          ng_sta(3):ng_end(3))   &
-     = Vxc(ng_sta(1):ng_end(1),   &
-          ng_sta(2):ng_end(2),   &
-          ng_sta(3):ng_end(3))
+  matbox2(ng%is(1):ng%ie(1),   &
+          ng%is(2):ng%ie(2),   &
+          ng%is(3):ng%ie(3))   &
+     = Vxc(ng%is(1):ng%ie(1),   &
+          ng%is(2):ng%ie(2),   &
+          ng%is(3):ng%ie(3))
 
   call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -377,12 +378,12 @@ if(ilsda == 0)then
 else if(ilsda == 1) then
   do is=1,2
     matbox2=0.d0
-    matbox2(ng_sta(1):ng_end(1),   &
-            ng_sta(2):ng_end(2),   &
-            ng_sta(3):ng_end(3))   &
-     = Vxc_s(ng_sta(1):ng_end(1),   &
-            ng_sta(2):ng_end(2),   &
-            ng_sta(3):ng_end(3),is)
+    matbox2(ng%is(1):ng%ie(1),   &
+            ng%is(2):ng%ie(2),   &
+            ng%is(3):ng%ie(3))   &
+     = Vxc_s(ng%is(1):ng%ie(1),   &
+            ng%is(2):ng%ie(2),   &
+            ng%is(3):ng%ie(3),is)
 
     call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -394,12 +395,12 @@ end if
 
 
 matbox2=0.d0
-matbox2(ng_sta(1):ng_end(1),   &
-        ng_sta(2):ng_end(2),   &
-        ng_sta(3):ng_end(3))   &
-   = Vpsl(ng_sta(1):ng_end(1),   &
-          ng_sta(2):ng_end(2),   &
-          ng_sta(3):ng_end(3))
+matbox2(ng%is(1):ng%ie(1),   &
+        ng%is(2):ng%ie(2),   &
+        ng%is(3):ng%ie(3))   &
+   = Vpsl(ng%is(1):ng%ie(1),   &
+          ng%is(2):ng%ie(2),   &
+          ng%is(3):ng%ie(3))
 
   call comm_summation(matbox2,matbox,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
@@ -757,7 +758,7 @@ call setk(k_sta, k_end, k_num, num_kpoints_rd, nproc_k, info%id_k)
 call calc_iobnum(itotMST,nproc_id_kgrid,iobnum,nproc_ob)
 
 if(iSCFRT==2)then
-  call allocate_mat
+  call allocate_mat(ng)
   call set_icoo1d
 end if
 
@@ -779,9 +780,9 @@ if(iSCFRT==1)then
 &                   1:iobnum,k_sta:k_end) )
     end if
     if(iswitch_orbital_mesh==1.or.iflag_subspace_diag==1)then
-      allocate( psi_mesh(ng_sta(1):ng_end(1),  &
-                       ng_sta(2):ng_end(2),   &
-                       ng_sta(3):ng_end(3), &
+      allocate( psi_mesh(ng%is(1):ng%ie(1),  &
+                       ng%is(2):ng%ie(2),   &
+                       ng%is(3):ng%ie(3), &
                        1:itotMST,num_kpoints_rd) )
     end if
   case(3)
@@ -791,9 +792,9 @@ if(iSCFRT==1)then
       &                    1:iobnum,k_sta:k_end) )
     end if
     if(iswitch_orbital_mesh==1.or.iflag_subspace_diag==1)then
-      allocate( zpsi_mesh(ng_sta(1):ng_end(1),  &
-                          ng_sta(2):ng_end(2),   &
-                          ng_sta(3):ng_end(3), &
+      allocate( zpsi_mesh(ng%is(1):ng%ie(1),  &
+                          ng%is(2):ng%ie(2),   &
+                          ng%is(3):ng%ie(3), &
                           1:itotMST,num_kpoints_rd) )
     end if
   end select
@@ -1124,9 +1125,9 @@ if(IC<=2)then
     end if
     if(iSCFRT==1)then
       call comm_bcast(matbox_read,nproc_group_global)
-      do iz=ng_sta(3),ng_end(3)
-      do iy=ng_sta(2),ng_end(2)
-      do ix=ng_sta(1),ng_end(1)
+      do iz=ng%is(3),ng%ie(3)
+      do iy=ng%is(2),ng%ie(2)
+      do ix=ng%is(1),ng%ie(1)
         mixing%srho_in(mixing%num_rho_stock+1)%f(ix,iy,iz)=matbox_read(ix,iy,iz)
       end do
       end do
@@ -1138,9 +1139,9 @@ if(IC<=2)then
     end if
     if(iSCFRT==1)then
       call comm_bcast(matbox_read,nproc_group_global)
-      do iz=ng_sta(3),ng_end(3)
-      do iy=ng_sta(2),ng_end(2)
-      do ix=ng_sta(1),ng_end(1)
+      do iz=ng%is(3),ng%ie(3)
+      do iy=ng%is(2),ng%ie(2)
+      do ix=ng%is(1),ng%ie(1)
         mixing%srho_out(mixing%num_rho_stock)%f(ix,iy,iz)=matbox_read(ix,iy,iz)
       end do
       end do
@@ -1165,9 +1166,9 @@ if(IC<=2)then
           read(96) ((( matbox_read(ix,iy,iz),ix=ig_sta(1),ig_end(1)),iy=ig_sta(2),ig_end(2)),iz=ig_sta(3),ig_end(3))
         end if
         call comm_bcast(matbox_read,nproc_group_global)
-        do iz=ng_sta(3),ng_end(3)
-        do iy=ng_sta(2),ng_end(2)
-        do ix=ng_sta(1),ng_end(1)
+        do iz=ng%is(3),ng%ie(3)
+        do iy=ng%is(2),ng%ie(2)
+        do ix=ng%is(1),ng%ie(1)
           mixing%srho_s_in(mixing%num_rho_stock,is)%f(ix,iy,iz)=matbox_read(ix,iy,iz)
         end do
         end do
@@ -1177,9 +1178,9 @@ if(IC<=2)then
           read(96) ((( matbox_read(ix,iy,iz),ix=ig_sta(1),ig_end(1)),iy=ig_sta(2),ig_end(2)),iz=ig_sta(3),ig_end(3))
         end if
         call comm_bcast(matbox_read,nproc_group_global)
-        do iz=ng_sta(3),ng_end(3)
-        do iy=ng_sta(2),ng_end(2)
-        do ix=ng_sta(1),ng_end(1)
+        do iz=ng%is(3),ng%ie(3)
+        do iy=ng%is(2),ng%ie(2)
+        do ix=ng%is(1),ng%ie(1)
           mixing%srho_s_out(mixing%num_rho_stock,is)%f(ix,iy,iz)=matbox_read(ix,iy,iz)
         end do
         end do
@@ -1194,9 +1195,9 @@ if(IC<=2)then
       end if
       if(iSCFRT==1)then
         call comm_bcast(matbox_read,nproc_group_global)
-        do iz=ng_sta(3),ng_end(3)
-        do iy=ng_sta(2),ng_end(2)
-        do ix=ng_sta(1),ng_end(1)
+        do iz=ng%is(3),ng%ie(3)
+        do iy=ng%is(2),ng%ie(2)
+        do ix=ng%is(1),ng%ie(1)
           mixing%srho_in(ii)%f(ix,iy,iz)=matbox_read(ix,iy,iz)
         end do
         end do
@@ -1210,9 +1211,9 @@ if(IC<=2)then
       end if
       if(iSCFRT==1)then
         call comm_bcast(matbox_read,nproc_group_global)
-        do iz=ng_sta(3),ng_end(3)
-        do iy=ng_sta(2),ng_end(2)
-        do ix=ng_sta(1),ng_end(1)
+        do iz=ng%is(3),ng%ie(3)
+        do iy=ng%is(2),ng%ie(2)
+        do ix=ng%is(1),ng%ie(1)
           mixing%srho_out(ii)%f(ix,iy,iz)=matbox_read(ix,iy,iz)
         end do
         end do
@@ -1240,9 +1241,9 @@ if(IC<=2)then
           end if
           if(iSCFRT==1)then
             call comm_bcast(matbox_read,nproc_group_global)
-            do iz=ng_sta(3),ng_end(3)
-            do iy=ng_sta(2),ng_end(2)
-            do ix=ng_sta(1),ng_end(1)
+            do iz=ng%is(3),ng%ie(3)
+            do iy=ng%is(2),ng%ie(2)
+            do ix=ng%is(1),ng%ie(1)
               mixing%srho_s_in(ii,is)%f(ix,iy,iz)=matbox_read(ix,iy,iz)
             end do
             end do
@@ -1256,9 +1257,9 @@ if(IC<=2)then
           end if
           if(iSCFRT==1)then
             call comm_bcast(matbox_read,nproc_group_global)
-            do iz=ng_sta(3),ng_end(3)
-            do iy=ng_sta(2),ng_end(2)
-            do ix=ng_sta(1),ng_end(1)
+            do iz=ng%is(3),ng%ie(3)
+            do iy=ng%is(2),ng%ie(2)
+            do ix=ng%is(1),ng%ie(1)
               mixing%srho_s_out(ii,is)%f(ix,iy,iz)=matbox_read(ix,iy,iz)
             end do
             end do
@@ -1383,7 +1384,7 @@ if(iSCFRT==2)then
   end do
 end if
 
-call wrapper_allgatherv_vlocal(info)
+call wrapper_allgatherv_vlocal(ng,info)
 
 if(iscfrt==2.and.propagator=='etrs')then
   if(ilsda==0)then

--- a/src/GCEED/common/calcELF.f90
+++ b/src/GCEED/common/calcELF.f90
@@ -13,7 +13,7 @@
 !  See the License for the specific language governing permissions and
 !  limitations under the License.
 !
-subroutine calcELF(info,srho,ttmp)
+subroutine calcELF(ng,info,srho,ttmp)
 use structures
 use salmon_parallel, only: nproc_group_global
 use salmon_communication, only: comm_summation
@@ -24,6 +24,7 @@ use gradient_sub
 use allocate_mat_sub
 use new_world_sub
 implicit none
+type(s_rgrid),intent(in)            :: ng
 type(s_orbital_parallel),intent(in) :: info
 type(s_scalar),intent(in) :: srho
 integer :: iob,ix,iy,iz
@@ -134,9 +135,9 @@ if(iSCFRT==1)then
 
 
   call calc_gradient(rho_half(:,:,:),gradrho(:,:,:,:))
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     gradrho2(ix,iy,iz)=gradrho(1,ix,iy,iz)**2      &
           +gradrho(2,ix,iy,iz)**2      &
           +gradrho(3,ix,iy,iz)**2
@@ -230,9 +231,9 @@ else
 
 
 
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     gradrho2(ix,iy,iz)=gradrho(1,ix,iy,iz)**2      &
           +gradrho(2,ix,iy,iz)**2      &
           +gradrho(3,ix,iy,iz)**2
@@ -249,9 +250,9 @@ end if
 
 ! matbox_l stores ELF
 matbox_l=0.d0
-do iz=ng_sta(3),ng_end(3)
-do iy=ng_sta(2),ng_end(2)
-do ix=ng_sta(1),ng_end(1)
+do iz=ng%is(3),ng%ie(3)
+do iy=ng%is(2),ng%ie(2)
+do ix=ng%is(1),ng%ie(1)
   elfcuni(ix,iy,iz)=3.d0/5.d0*(6.d0*Pi**2)**(2.d0/3.d0)      &
             *rho_half(ix,iy,iz)**(5.d0/3.d0)
   matbox_l(ix,iy,iz)=1.d0/(1.d0+elfc(ix,iy,iz)**2/elfcuni(ix,iy,iz)**2)

--- a/src/GCEED/common/calcVpsl_periodic_FFTE.f90
+++ b/src/GCEED/common/calcVpsl_periodic_FFTE.f90
@@ -13,7 +13,8 @@
 !  See the License for the specific language governing permissions and
 !  limitations under the License.
 !
-subroutine calcVpsl_periodic_FFTE
+subroutine calcVpsl_periodic_FFTE(ng)
+  use structures,      only: s_rgrid
   use salmon_parallel, only: nproc_group_global, nproc_size_global, nproc_id_global
   use salmon_parallel, only: nproc_id_icommy, nproc_id_icommz
   use salmon_communication, only: comm_bcast, comm_summation, comm_is_root
@@ -22,6 +23,7 @@ subroutine calcVpsl_periodic_FFTE
   use allocate_psl_sub
   use allocate_mat_sub
   implicit none
+  type(s_rgrid),intent(in) :: ng
   
   integer :: ii,ix,iy,iz,ak
   integer :: iix,iiy,iiz
@@ -181,7 +183,7 @@ subroutine calcVpsl_periodic_FFTE
       iiz=iz+nproc_id_icommz*lg_num(3)/NPUZ
       do iy=iy_sta,iy_end
         iiy=iy+nproc_id_icommy*lg_num(2)/NPUY
-        do iix=ng_sta(1),ng_end(1)
+        do iix=ng%is(1),ng%ie(1)
           ix=iix-lg_sta(1)+1
           matbox_l(iix,iiy,iiz)=A_FFTE(ix,iy,iz)
         end do

--- a/src/GCEED/common/prep_poisson_fft.f90
+++ b/src/GCEED/common/prep_poisson_fft.f90
@@ -13,13 +13,15 @@
 !  See the License for the specific language governing permissions and
 !  limitations under the License.
 !
-subroutine prep_poisson_fft
+subroutine prep_poisson_fft(ng)
+  use structures,      only: s_rgrid
   use salmon_parallel, only: nproc_id_icommy
   use salmon_parallel, only: nproc_id_icommz
   use scf_data
   use new_world_sub
   use allocate_mat_sub
   implicit none
+  type(s_rgrid),intent(in) :: ng
   integer :: ng_sta_2(3),ng_end_2(3),ng_num_2(3)
   integer :: lg_sta_2(3),lg_end_2(3),lg_num_2(3)
   real(8) :: Gx,Gy,Gz
@@ -38,9 +40,9 @@ subroutine prep_poisson_fft
   lg_end_2(1:3)=lg_end(1:3)
   lg_num_2(1:3)=lg_num(1:3)
   
-  ng_sta_2(1:3)=ng_sta(1:3)
-  ng_end_2(1:3)=ng_end(1:3)
-  ng_num_2(1:3)=ng_num(1:3)
+  ng_sta_2(1:3)=ng%is(1:3)
+  ng_end_2(1:3)=ng%ie(1:3)
+  ng_num_2(1:3)=ng%num(1:3)
 
   bLx=2.d0*Pi/(Hgs(1)*dble(lg_num_2(1)))
   bLy=2.d0*Pi/(Hgs(2)*dble(lg_num_2(2)))

--- a/src/GCEED/common/psl.f90
+++ b/src/GCEED/common/psl.f90
@@ -13,13 +13,15 @@
 !  See the License for the specific language governing permissions and
 !  limitations under the License.
 !
-SUBROUTINE init_ps(alat,brl,matrix_A,icomm_r)
+SUBROUTINE init_ps(ng,alat,brl,matrix_A,icomm_r)
+use structures,      only: s_rgrid
 use salmon_parallel, only: nproc_id_global
 use salmon_communication, only: comm_is_root
 use scf_data
 use allocate_psl_sub
 use prep_pp_sub, only: init_uvpsi_summation
 implicit none
+type(s_rgrid),intent(in) :: ng
 real(8),intent(in) :: alat(3,3),brl(3,3),matrix_A(3,3)
 integer,intent(in) :: icomm_r
 
@@ -44,7 +46,7 @@ case(3)
   case(2)
     call calcVpsl_periodic(matrix_A,brl)
   case(4)
-    call calcVpsl_periodic_FFTE
+    call calcVpsl_periodic_FFTE(ng)
   end select
   call calcJxyz_all_periodic(alat,matrix_A)
   call calcuV

--- a/src/GCEED/modules/CMakeLists.txt
+++ b/src/GCEED/modules/CMakeLists.txt
@@ -2,7 +2,6 @@ set(SOURCES
     allocate_mat.f90
     allocate_psl.f90
     change_order.f90
-    copy_psi_mesh.f90
     deallocate_mat.f90
     gradient2.f90
     gradient.f90
@@ -12,7 +11,6 @@ set(SOURCES
     read_pslfile.f90
     scf_data.f90
     sendrecv.f90
-    writebox_rt.f90
     persistent_comm.f90
     )
 

--- a/src/GCEED/modules/allocate_mat.f90
+++ b/src/GCEED/modules/allocate_mat.f90
@@ -59,8 +59,10 @@ CONTAINS
 !=======================================================================
 !=======================================================================
 
-SUBROUTINE allocate_mat
+SUBROUTINE allocate_mat(ng)
+  use structures, only: s_rgrid
   implicit none
+  type(s_rgrid),intent(in) :: ng
 
 allocate (vecR(3,lg_sta(1):lg_end(1),    &
              lg_sta(2):lg_end(2),      &
@@ -97,15 +99,15 @@ allocate (cmatbox_l2(lg_sta(1):lg_end(1),    &
              lg_sta(2):lg_end(2),      &
              lg_sta(3):lg_end(3)) )
 
-allocate (wk_s_h(ng_sta(1)-Ndh:ng_end(1)+Ndh,   &
-             ng_sta(2)-Ndh:ng_end(2)+Ndh,   &
-             ng_sta(3)-Ndh:ng_end(3)+Ndh))
-allocate (wk2_s_h(ng_sta(1):ng_end(1),   &
-              ng_sta(2):ng_end(2),   &
-              ng_sta(3):ng_end(3)))
-allocate (lap_wk_s_h(ng_sta(1):ng_end(1),   &
-                 ng_sta(2):ng_end(2),   &
-                 ng_sta(3):ng_end(3)))
+allocate (wk_s_h(ng%is(1)-Ndh:ng%ie(1)+Ndh,   &
+             ng%is(2)-Ndh:ng%ie(2)+Ndh,   &
+             ng%is(3)-Ndh:ng%ie(3)+Ndh))
+allocate (wk2_s_h(ng%is(1):ng%ie(1),   &
+              ng%is(2):ng%ie(2),   &
+              ng%is(3):ng%ie(3)))
+allocate (lap_wk_s_h(ng%is(1):ng%ie(1),   &
+                 ng%is(2):ng%ie(2),   &
+                 ng%is(3):ng%ie(3)))
 
 allocate (wkbound_h(lg_num(1)*lg_num(2)*lg_num(3)/minval(lg_num(1:3))*6*Ndh) )
 allocate (wk2bound_h(lg_num(1)*lg_num(2)*lg_num(3)/minval(lg_num(1:3))*6*Ndh) )
@@ -127,14 +129,14 @@ else if(iSCFRT==2.and.icalcforce==1)then
                     mg_sta(3):mg_end(3),1:iobnum,k_sta:k_end,3))
 end if
 
-allocate (rho_tmp(ng_num(1), ng_num(2), ng_num(3)))
-allocate (rho_s_tmp(ng_num(1), ng_num(2), ng_num(3), 2))
-allocate (vxc_tmp(ng_num(1), ng_num(2), ng_num(3)))
-allocate (vxc_s_tmp(ng_num(1), ng_num(2), ng_num(3), 2))
-allocate (eexc_tmp(ng_num(1), ng_num(2), ng_num(3)))
-allocate (exc_dummy(ng_num(1), ng_num(2), ng_num(3)))
-allocate (exc_dummy2(ng_num(1), ng_num(2), ng_num(3),2))
-allocate (exc_dummy3(ng_num(1), ng_num(2), ng_num(3),3))
+allocate (rho_tmp(ng%num(1), ng%num(2), ng%num(3)))
+allocate (rho_s_tmp(ng%num(1), ng%num(2), ng%num(3), 2))
+allocate (vxc_tmp(ng%num(1), ng%num(2), ng%num(3)))
+allocate (vxc_s_tmp(ng%num(1), ng%num(2), ng%num(3), 2))
+allocate (eexc_tmp(ng%num(1), ng%num(2), ng%num(3)))
+allocate (exc_dummy(ng%num(1), ng%num(2), ng%num(3)))
+allocate (exc_dummy2(ng%num(1), ng%num(2), ng%num(3),2))
+allocate (exc_dummy3(ng%num(1), ng%num(2), ng%num(3),3))
 
 select case(iperiodic)
 case(3)

--- a/src/GCEED/modules/new_world.f90
+++ b/src/GCEED/modules/new_world.f90
@@ -558,9 +558,11 @@ call comm_get_groupinfo(nproc_group_korbital_vhxc, nproc_id_korbital_vhxc, nproc
 end subroutine make_new_world
 
 !=====================================================================
-subroutine make_corr_pole
+subroutine make_corr_pole(ng)
+use structures, only: s_rgrid
 implicit none
 
+type(s_rgrid), intent(in) :: ng
 integer :: a,i
 integer :: ix,iy,iz
 integer :: ibox
@@ -585,11 +587,11 @@ if(layout_multipole==2)then
 
   iamax=amax
   allocate(icount_pole(1:amax))
-  allocate(nearatomnum(ng_sta(1):ng_end(1),ng_sta(2):ng_end(2),ng_sta(3):ng_end(3)))
+  allocate(nearatomnum(ng%is(1):ng%ie(1),ng%is(2):ng%ie(2),ng%is(3):ng%ie(3)))
   icount_pole=0
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     rmin=1.d6
     do a=1,amax
       r=sqrt( (gridcoo(ix,1)-Rion2(1,a))**2      &
@@ -624,9 +626,9 @@ if(layout_multipole==2)then
 
   icount_pole(:)=0
 
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     ibox=inv_icorr_polenum(nearatomnum(ix,iy,iz))
     icount_pole(ibox)=icount_pole(ibox)+1
     icorr_xyz_pole(1,icount_pole(ibox),ibox)=ix
@@ -665,9 +667,9 @@ else if(layout_multipole==3)then
 
   iflag_pole=0
 
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     do i=1,num_pole
       if(ista_Mxin_pole(3,i-1)<=iz.and.iend_Mxin_pole(3,i-1)>=iz.and.   &
          ista_Mxin_pole(2,i-1)<=iy.and.iend_Mxin_pole(2,i-1)>=iy.and.   &
@@ -700,9 +702,9 @@ else if(layout_multipole==3)then
 
   icount_pole=0
 
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     do i=1,num_pole_myrank
       if(ista_Mxin_pole(3,icorr_polenum(i)-1)<=iz.and.iend_Mxin_pole(3,icorr_polenum(i)-1)>=iz.and.   &
          ista_Mxin_pole(2,icorr_polenum(i)-1)<=iy.and.iend_Mxin_pole(2,icorr_polenum(i)-1)>=iy.and.   &
@@ -719,9 +721,9 @@ else if(layout_multipole==3)then
  
   icount_pole=0
 
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     do i=1,num_pole_myrank
       if(ista_Mxin_pole(3,icorr_polenum(i)-1)<=iz.and.iend_Mxin_pole(3,icorr_polenum(i)-1)>=iz.and.   &
          ista_Mxin_pole(2,icorr_polenum(i)-1)<=iy.and.iend_Mxin_pole(2,icorr_polenum(i)-1)>=iy.and.   &
@@ -744,9 +746,11 @@ end if
 end subroutine make_corr_pole
 
 !=====================================================================
-subroutine make_icoobox_bound
+subroutine make_icoobox_bound(ng)
 use salmon_parallel
+use structures, only: s_rgrid
 implicit none
+type(s_rgrid), intent(in) :: ng
 integer :: ix,iy,iz
 integer :: ibox
 integer :: icount
@@ -758,8 +762,8 @@ ibox_icoobox_bound=ibox
 allocate( icoobox_bound(3,ibox,3) )
 
 icount=0
-do iz=ng_sta(3),ng_end(3)
-do iy=ng_sta(2),ng_end(2)
+do iz=ng%is(3),ng%ie(3)
+do iy=ng%is(2),ng%ie(2)
 do ix=lg_sta(1)-Ndh,lg_sta(1)-1
   icount=icount+1
   icoobox_bound(1,icount,1)=ix
@@ -768,8 +772,8 @@ do ix=lg_sta(1)-Ndh,lg_sta(1)-1
 end do
 end do
 end do
-do iz=ng_sta(3),ng_end(3)
-do iy=ng_sta(2),ng_end(2)
+do iz=ng%is(3),ng%ie(3)
+do iy=ng%is(2),ng%ie(2)
 do ix=lg_end(1)+1,lg_end(1)+Ndh
   icount=icount+1
   icoobox_bound(1,icount,1)=ix
@@ -779,9 +783,9 @@ end do
 end do
 end do
 icount=0
-do iz=ng_sta(3),ng_end(3)
+do iz=ng%is(3),ng%ie(3)
 do iy=lg_sta(2)-Ndh,lg_sta(2)-1
-do ix=ng_sta(1),ng_end(1)
+do ix=ng%is(1),ng%ie(1)
   icount=icount+1
   icoobox_bound(1,icount,2)=ix
   icoobox_bound(2,icount,2)=iy
@@ -789,9 +793,9 @@ do ix=ng_sta(1),ng_end(1)
 end do
 end do
 end do
-do iz=ng_sta(3),ng_end(3)
+do iz=ng%is(3),ng%ie(3)
 do iy=lg_end(2)+1,lg_end(2)+Ndh
-do ix=ng_sta(1),ng_end(1)
+do ix=ng%is(1),ng%ie(1)
   icount=icount+1
   icoobox_bound(1,icount,2)=ix
   icoobox_bound(2,icount,2)=iy
@@ -801,8 +805,8 @@ end do
 end do
 icount=0
 do iz=lg_sta(3)-Ndh,lg_sta(3)-1
-do iy=ng_sta(2),ng_end(2)
-do ix=ng_sta(1),ng_end(1)
+do iy=ng%is(2),ng%ie(2)
+do ix=ng%is(1),ng%ie(1)
   icount=icount+1
   icoobox_bound(1,icount,3)=ix
   icoobox_bound(2,icount,3)=iy
@@ -811,8 +815,8 @@ end do
 end do
 end do
 do iz=lg_end(3)+1,lg_end(3)+Ndh
-do iy=ng_sta(2),ng_end(2)
-do ix=ng_sta(1),ng_end(1)
+do iy=ng%is(2),ng%ie(2)
+do ix=ng%is(1),ng%ie(1)
   icount=icount+1
   icoobox_bound(1,icount,3)=ix
   icoobox_bound(2,icount,3)=iy
@@ -826,12 +830,13 @@ end subroutine make_icoobox_bound
 
 !=====================================================================
 !======================================================================
-subroutine allgatherv_vlocal(info,nspin,Vh,Vpsl,Vxc,Vlocal)
-use structures, only: s_orbital_parallel, s_scalar
+subroutine allgatherv_vlocal(ng,info,nspin,Vh,Vpsl,Vxc,Vlocal)
+use structures, only: s_rgrid, s_orbital_parallel, s_scalar
 use salmon_parallel, only: nproc_id_global
 use salmon_communication, only: comm_allgatherv
 use timer
 implicit none
+type(s_rgrid),           intent(in) :: ng
 type(s_orbital_parallel),intent(in) :: info
 integer       ,intent(in) :: nspin
 type(s_scalar),intent(in) :: Vh,Vpsl,Vxc(nspin)
@@ -873,11 +878,11 @@ end do
 
 do is=1,nspin
 !$OMP parallel do private(ibox3,ix,iy,iz)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
-    ibox3=ix-ng_sta(1)+(iy-ng_sta(2))*inum_Mxin_s(1,nproc_id_global)   &
-                  +(iz-ng_sta(3))*inum_Mxin_s(1,nproc_id_global)*inum_Mxin_s(2,nproc_id_global)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
+    ibox3=ix-ng%is(1)+(iy-ng%is(2))*inum_Mxin_s(1,nproc_id_global)   &
+                  +(iz-ng%is(3))*inum_Mxin_s(1,nproc_id_global)*inum_Mxin_s(2,nproc_id_global)
     matbox11(ibox3) = Vpsl%f(ix,iy,iz) + Vh%f(ix,iy,iz) + Vxc(is)%f(ix,iy,iz)
   end do
   end do
@@ -946,9 +951,10 @@ CONTAINS
   end subroutine copyVlocal
 end subroutine allgatherv_vlocal
 
-subroutine wrapper_allgatherv_vlocal(info) ! --> remove (future works)
+subroutine wrapper_allgatherv_vlocal(ng,info) ! --> remove (future works)
   use structures
   implicit none
+  type(s_rgrid),           intent(in) :: ng
   type(s_orbital_parallel),intent(in) :: info
   type(s_scalar) :: sVh,sVpsl
   type(s_scalar),allocatable :: sVlocal(:),sVxc(:)
@@ -973,7 +979,7 @@ subroutine wrapper_allgatherv_vlocal(info) ! --> remove (future works)
     sVxc(1)%f = Vxc
   end if
 
-  call allgatherv_vlocal(info,nspin,sVh,sVpsl,sVxc,sVlocal)
+  call allgatherv_vlocal(ng,info,nspin,sVh,sVpsl,sVxc,sVlocal)
 
   do jspin=1,nspin
     Vlocal(:,:,:,jspin) = sVlocal(jspin)%f
@@ -984,87 +990,6 @@ subroutine wrapper_allgatherv_vlocal(info) ! --> remove (future works)
   call deallocate_scalar(sVpsl)
   return
 end subroutine wrapper_allgatherv_vlocal
-
-!======================================================================
-subroutine mpibcast_mesh_s_kxc(Vbox)
-use salmon_parallel, only: nproc_id_global, nproc_group_h, nproc_id_h
-use salmon_communication, only: comm_allgatherv
-
-implicit none
-integer :: i
-integer :: i1,i2,i3
-integer :: ix,iy,iz
-integer :: ibox,ibox2,ibox3
-real(8),allocatable :: matbox1(:),matbox2(:)
-real(8) :: Vbox(mg_sta(1):mg_end(1),  &
-                mg_sta(2):mg_end(2),  &
-                mg_sta(3):mg_end(3))
-integer :: iscnt
-integer,allocatable :: ircnt(:)
-integer,allocatable :: idisp(:)
-
-if(nproc_ob/=1.or.nproc_d_o_mul/=1)then
-
-  allocate(ircnt(0:nproc_d_g_mul_dm-1))
-  allocate(idisp(0:nproc_d_g_mul_dm-1))
-
-  iscnt=inum_Mxin_s(1,nproc_id_global)*inum_Mxin_s(2,nproc_id_global)*inum_Mxin_s(3,nproc_id_global)
-  do i=0,nproc_d_g_mul_dm-1
-    ibox=mod(nproc_id_global,nproc_d_o_mul)+i*nproc_d_o_mul
-    ircnt(i)=inum_Mxin_s(1,ibox)*inum_Mxin_s(2,ibox)*inum_Mxin_s(3,ibox)
-  end do
-
-  idisp(0)=0
-  do i=1,nproc_d_g_mul_dm-1
-    idisp(i)=idisp(i-1)+ircnt(i-1)
-  end do
-
-  allocate (matbox1(0:(inum_Mxin_s(1,nproc_id_global)*inum_Mxin_s(2,nproc_id_global)*inum_Mxin_s(3,nproc_id_global))-1))
-  allocate (matbox2(0:(mg_num(1)*mg_num(2)*mg_num(3))-1))
-  
-!$OMP parallel do private(ibox3,ix,iy,iz)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
-    ibox3=ix-ng_sta(1)+(iy-ng_sta(2))*inum_Mxin_s(1,nproc_id_global)   &
-                  +(iz-ng_sta(3))*inum_Mxin_s(1,nproc_id_global)*inum_Mxin_s(2,nproc_id_global)
-    matbox1(ibox3) = Vbox(ix,iy,iz)
-  end do
-  end do
-  end do
-
-  call comm_allgatherv(matbox1,matbox2,ircnt,idisp,nproc_group_h)
-   
-  do i3=0,nproc_d_g_dm(3)-1
-  do i2=0,nproc_d_g_dm(2)-1
-  do i1=0,nproc_d_g_dm(1)-1
-    ibox=mod(nproc_id_global,nproc_d_o_mul)    &
-          +(i1+i2*nproc_d_g_dm(1)+i3*nproc_d_g_dm(1)*nproc_d_g_dm(2))*nproc_d_o_mul
-    ibox2=i1+i2*nproc_d_g_dm(1)+i3*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-
-    if(nproc_id_h/=ibox2)then
-!$OMP parallel do private(ibox3,ix,iy,iz)
-      do iz=ista_Mxin_s(3,ibox),iend_Mxin_s(3,ibox)
-      do iy=ista_Mxin_s(2,ibox),iend_Mxin_s(2,ibox)
-      do ix=ista_Mxin_s(1,ibox),iend_Mxin_s(1,ibox)
-        ibox3=idisp(ibox2)+ix-ista_Mxin_s(1,ibox)+(iy-ista_Mxin_s(2,ibox))*inum_Mxin_s(1,ibox)   &
-                      +(iz-ista_Mxin_s(3,ibox))*inum_Mxin_s(1,ibox)*inum_Mxin_s(2,ibox)
-        Vbox(ix,iy,iz) = matbox2(ibox3) 
-      end do
-      end do
-      end do
-    end if
-  end do
-  end do
-  end do
-
-  deallocate (ircnt,idisp)
-  deallocate (matbox1)
-  deallocate (matbox2)
-
-end if
-
-end subroutine mpibcast_mesh_s_kxc
 
 END MODULE new_world_sub
 

--- a/src/GCEED/rt/CMakeLists.txt
+++ b/src/GCEED/rt/CMakeLists.txt
@@ -16,7 +16,6 @@ set(SOURCES
     set_vonf_sd.f90
     taylor_coe.f90
     time_evolution_step.f90
-    xc_fast.f90
     )
   #    aft_fourier.f90 # Is this single program?
 

--- a/src/GCEED/rt/calcEstatic.f90
+++ b/src/GCEED/rt/calcEstatic.f90
@@ -20,15 +20,15 @@ use new_world_sub
 use structures, only: s_rgrid, s_orbital_parallel, s_scalar, s_sendrecv_grid
 use sendrecv_grid, only: update_overlap_real8
 implicit none
-type(s_rgrid),intent(in) :: ng
+type(s_rgrid),intent(in)            :: ng
 type(s_orbital_parallel),intent(in) :: info
 type(s_scalar),intent(in) :: sVh
 type(s_sendrecv_grid),intent(inout) :: srg_ng
 
 integer :: ist,ix,iy,iz
-real(8) :: Vh_wk(ng_sta(1)-Ndh:ng_end(1)+Ndh,   &
-                 ng_sta(2)-Ndh:ng_end(2)+Ndh,   &
-                 ng_sta(3)-Ndh:ng_end(3)+Ndh)
+real(8) :: Vh_wk(ng%is(1)-Ndh:ng%ie(1)+Ndh,   &
+                 ng%is(2)-Ndh:ng%ie(2)+Ndh,   &
+                 ng%is(3)-Ndh:ng%ie(3)+Ndh)
 real(8) :: Ex_static2(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
 real(8) :: Ey_static2(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
 real(8) :: Ez_static2(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
@@ -38,18 +38,18 @@ call make_iwksta_iwkend
 
 
 !$OMP parallel do private(iz,iy,ix)
-do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
-do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
-do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
+do iz=ng%is(3)-Ndh,ng%ie(3)+Ndh
+do iy=ng%is(2)-Ndh,ng%ie(2)+Ndh
+do ix=ng%is(1)-Ndh,ng%ie(1)+Ndh
   Vh_wk(ix,iy,iz)=0.d0
 end do
 end do
 end do
 
 !$OMP parallel do private(iz,iy,ix)
-do iz=ng_sta(3),ng_end(3)
-do iy=ng_sta(2),ng_end(2)
-do ix=ng_sta(1),ng_end(1)
+do iz=ng%is(3),ng%ie(3)
+do iy=ng%is(2),ng%ie(2)
+do ix=ng%is(1),ng%ie(1)
   Vh_wk(ix,iy,iz) = sVh%f(ix,iy,iz)
 end do
 end do
@@ -57,67 +57,67 @@ end do
 
 call update_overlap_real8(srg_ng, ng, Vh_wk)
 
-if(ng_sta(1)==lg_sta(1))then
+if(ng%is(1)==lg_sta(1))then
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
     do ix=1,Ndh
-      Vh_wk(ng_sta(1)-ix,iy,iz) = Vh_wk(ng_sta(1),iy,iz)
+      Vh_wk(ng%is(1)-ix,iy,iz) = Vh_wk(ng%is(1),iy,iz)
     end do
   end do
   end do
 end if
 
-if(ng_end(1)==lg_end(1))then
+if(ng%ie(1)==lg_end(1))then
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
     do ix=1,Ndh
-      Vh_wk(ng_end(1)+ix,iy,iz) = Vh_wk(ng_end(1),iy,iz)
+      Vh_wk(ng%ie(1)+ix,iy,iz) = Vh_wk(ng%ie(1),iy,iz)
     end do
   end do
   end do
 end if
 
-if(ng_sta(2)==lg_sta(2))then
+if(ng%is(2)==lg_sta(2))then
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do ix=ng%is(1),ng%ie(1)
     do iy=1,Ndh
-      Vh_wk(ix,ng_sta(2)-iy,iz) = Vh_wk(ix,ng_sta(2),iz)
+      Vh_wk(ix,ng%is(2)-iy,iz) = Vh_wk(ix,ng%is(2),iz)
     end do
   end do
   end do
 end if
 
-if(ng_end(2)==lg_end(2))then
+if(ng%ie(2)==lg_end(2))then
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do ix=ng%is(1),ng%ie(1)
     do iy=1,Ndh
-      Vh_wk(ix,ng_end(2)+iy,iz) = Vh_wk(ix,ng_end(2),iz)
+      Vh_wk(ix,ng%ie(2)+iy,iz) = Vh_wk(ix,ng%ie(2),iz)
     end do
   end do
   end do
 end if
 
-if(ng_sta(3)==lg_sta(3))then
+if(ng%is(3)==lg_sta(3))then
 !$OMP parallel do private(iz,iy,ix)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     do iz=1,Ndh
-      Vh_wk(ix,iy,ng_sta(3)-iz) = Vh_wk(ix,iy,ng_sta(3))
+      Vh_wk(ix,iy,ng%is(3)-iz) = Vh_wk(ix,iy,ng%is(3))
     end do
   end do
   end do
 end if
 
-if(ng_end(3)==lg_end(3))then
+if(ng%ie(3)==lg_end(3))then
 !$OMP parallel do private(iz,iy,ix)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     do iz=1,Ndh
-      Vh_wk(ix,iy,ng_end(3)+iz) = Vh_wk(ix,iy,ng_end(3))
+      Vh_wk(ix,iy,ng%ie(3)+iz) = Vh_wk(ix,iy,ng%ie(3))
     end do
   end do
   end do
@@ -135,9 +135,9 @@ end do
 end do
 
 !$OMP parallel do private(iz,iy,ix,ist) 
-do iz=ng_sta(3),ng_end(3)
-do iy=ng_sta(2),ng_end(2)
-do ix=ng_sta(1),ng_end(1)
+do iz=ng%is(3),ng%ie(3)
+do iy=ng%is(2),ng%ie(2)
+do ix=ng%is(1),ng%ie(1)
   do ist=1,Ndh
     Ex_static2(ix,iy,iz)=Ex_static2(ix,iy,iz)               &
        -(bNmat(ist,Ndh)*(Vh_wk(ix+ist,iy,iz)-Vh_wk(ix-ist,iy,iz)))/Hgs(1)

--- a/src/GCEED/rt/real_time_dft.f90
+++ b/src/GCEED/rt/real_time_dft.f90
@@ -177,12 +177,12 @@ if(comm_is_root(nproc_id_global))then
 end if
 
 if(iperiodic==3 .and. iflag_hartree==4)then
-  call prep_poisson_fft
+  call prep_poisson_fft(ng)
 end if
 
 call read_pslfile(system)
 call allocate_psl
-call init_ps(system%primitive_a,system%primitive_b,stencil%rmatrix_A,info%icomm_r)
+call init_ps(ng,system%primitive_a,system%primitive_b,stencil%rmatrix_A,info%icomm_r)
 
 call init_updown(info)
 call init_itype
@@ -198,8 +198,8 @@ else if(ilsda==1)then
   numspin=2
 end if
 
-if(layout_multipole==2.or.layout_multipole==3) call make_corr_pole
-call make_icoobox_bound
+if(layout_multipole==2.or.layout_multipole==3) call make_corr_pole(ng)
+call make_icoobox_bound(ng)
 call timer_end(LOG_READ_LDA_DATA)
 
 
@@ -254,7 +254,7 @@ if(IC_rt==0) then
   itotNtime=Ntime
   Miter_rt=0
 else if(IC_rt==1) then
-  call IN_data_rt(info,Ntime)
+  call IN_data_rt(ng,info,Ntime)
 end if
 call timer_end(LOG_READ_RT_DATA)
 
@@ -338,7 +338,7 @@ call Time_Evolution(lg,mg,ng,system,info,info_field,stencil,fg,energy,md,ofl)
 
 
 call timer_begin(LOG_WRITE_RT_DATA)
-if(OC_rt==1) call OUT_data_rt
+if(OC_rt==1) call OUT_data_rt(ng)
 call timer_end(LOG_WRITE_RT_DATA)
 
 
@@ -787,18 +787,18 @@ end if
 if(IC_rt==0)then
   rbox_array=0.d0
   do i1=1,3
-    do iz=ng_sta(3),ng_end(3)
-    do iy=ng_sta(2),ng_end(2)
-    do ix=ng_sta(1),ng_end(1)
+    do iz=ng%is(3),ng%ie(3)
+    do iy=ng%is(2),ng%ie(2)
+    do ix=ng%is(1),ng%ie(1)
       rbox_array(i1)=rbox_array(i1)+vecR(i1,ix,iy,iz)*rho(ix,iy,iz)
     end do
     end do
     end do
   end do
   
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     rbox_array(4)=rbox_array(4)+rho(ix,iy,iz)
   end do
   end do
@@ -873,7 +873,7 @@ end do
       call writedns(lg,mg,ng,rho,matbox_m,matbox_m2,icoo1d,hgs,igc_is,igc_ie,gridcoo,iscfrt,rho0,itt)
     end if
     if(yn_out_elf_rt=='y')then
-      call calcELF(info,srho,itt)
+      call calcELF(ng,info,srho,itt)
       call writeelf(lg,elf,icoo1d,hgs,igc_is,igc_ie,gridcoo,iscfrt,itt)
     end if
     if(yn_out_estatic_rt=='y')then

--- a/src/GCEED/rt/time_evolution_step.f90
+++ b/src/GCEED/rt/time_evolution_step.f90
@@ -245,7 +245,7 @@ SUBROUTINE time_evolution_step(lg,mg,ng,system,info,info_field,stencil,srg,srg_n
   call timer_end(LOG_CALC_EXC_COR)
 
   call timer_begin(LOG_CALC_VLOCAL) ! FIXME: wrong name
-  call allgatherv_vlocal(info,system%nspin,sVh,sVpsl,sVxc,V_local)
+  call allgatherv_vlocal(ng,info,system%nspin,sVh,sVpsl,sVxc,V_local)
   call timer_end(LOG_CALC_VLOCAL)
 
 ! result
@@ -366,7 +366,7 @@ SUBROUTINE time_evolution_step(lg,mg,ng,system,info,info_field,stencil,srg,srg_n
   end if
   if(yn_out_elf_rt=='y')then
     if(mod(itt,out_elf_rt_step)==0)then
-      call calcELF(info,srho,itt)
+      call calcELF(ng,info,srho,itt)
       call writeelf(lg,elf,icoo1d,hgs,igc_is,igc_ie,gridcoo,iscfrt,itt)
     end if
   end if

--- a/src/GCEED/scf/CMakeLists.txt
+++ b/src/GCEED/scf/CMakeLists.txt
@@ -8,7 +8,6 @@ set(SOURCES
     deallocate_sendrecv.f90
     prep_ini.f90
     real_space_dft.f90
-    subdgemm_lapack.f90
     write_eigen.f90
     )
 

--- a/src/GCEED/scf/copy_density.f90
+++ b/src/GCEED/scf/copy_density.f90
@@ -13,11 +13,12 @@
 !  See the License for the specific language governing permissions and
 !  limitations under the License.
 !
-subroutine copy_density(nspin,srho_s,mixing)
-use structures, only: s_scalar, s_mixing
+subroutine copy_density(nspin,ng,srho_s,mixing)
+use structures, only: s_rgrid, s_scalar, s_mixing
 use scf_data
 implicit none
 integer       ,intent(in) :: nspin
+type(s_rgrid), intent(in) :: ng
 type(s_scalar),intent(in) :: srho_s(nspin)
 type(s_mixing),intent(inout) :: mixing
 integer :: iiter
@@ -26,18 +27,18 @@ integer :: ix,iy,iz
 
 if(Miter==1)then
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     mixing%srho_in(mixing%num_rho_stock+1)%f(ix,iy,iz)=srho_s(1)%f(ix,iy,iz)
   end do
   end do
   end do
   if(ilsda==1)then
 !$OMP parallel do private(iz,iy,ix)
-    do iz=ng_sta(3),ng_end(3)
-    do iy=ng_sta(2),ng_end(2)
-    do ix=ng_sta(1),ng_end(1)
+    do iz=ng%is(3),ng%ie(3)
+    do iy=ng%is(2),ng%ie(2)
+    do ix=ng%is(1),ng%ie(1)
       mixing%srho_s_in(mixing%num_rho_stock+1,1)%f(ix,iy,iz)=srho_s(1)%f(ix,iy,iz)
       mixing%srho_s_in(mixing%num_rho_stock+1,2)%f(ix,iy,iz)=srho_s(2)%f(ix,iy,iz)
     end do
@@ -48,9 +49,9 @@ end if
 
 do iiter=1,mixing%num_rho_stock
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     mixing%srho_in(iiter)%f(ix,iy,iz)=mixing%srho_in(iiter+1)%f(ix,iy,iz)
   end do
   end do
@@ -58,9 +59,9 @@ do iiter=1,mixing%num_rho_stock
 end do
 do iiter=1,mixing%num_rho_stock-1
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     mixing%srho_out(iiter)%f(ix,iy,iz)=mixing%srho_out(iiter+1)%f(ix,iy,iz)
   end do
   end do
@@ -71,9 +72,9 @@ if(ilsda==1)then
   do iiter=1,mixing%num_rho_stock
     do is=1,2
 !$OMP parallel do private(iz,iy,ix)
-      do iz=ng_sta(3),ng_end(3)
-      do iy=ng_sta(2),ng_end(2)
-      do ix=ng_sta(1),ng_end(1)
+      do iz=ng%is(3),ng%ie(3)
+      do iy=ng%is(2),ng%ie(2)
+      do ix=ng%is(1),ng%ie(1)
         mixing%srho_s_in(iiter,is)%f(ix,iy,iz)=mixing%srho_s_in(iiter+1,is)%f(ix,iy,iz)
       end do
       end do
@@ -83,9 +84,9 @@ if(ilsda==1)then
   do iiter=1,mixing%num_rho_stock-1
     do is=1,2
 !$OMP parallel do private(iz,iy,ix)
-      do iz=ng_sta(3),ng_end(3)
-      do iy=ng_sta(2),ng_end(2)
-      do ix=ng_sta(1),ng_end(1)
+      do iz=ng%is(3),ng%ie(3)
+      do iy=ng%is(2),ng%ie(2)
+      do ix=ng%is(1),ng%ie(1)
         mixing%srho_s_out(iiter,is)%f(ix,iy,iz)=mixing%srho_s_out(iiter+1,is)%f(ix,iy,iz)
       end do
       end do

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -23,7 +23,6 @@ use allocate_mat_sub
 use deallocate_mat_sub
 use new_world_sub
 use init_sendrecv_sub
-use copy_psi_mesh_sub
 use change_order_sub
 use read_pslfile_sub
 use allocate_psl_sub
@@ -169,11 +168,11 @@ if(iopt==1)then
   call init_sendrecv_matrix
   select case(iperiodic)
   case(0)
-    if(layout_multipole==2.or.layout_multipole==3) call make_corr_pole
+    if(layout_multipole==2.or.layout_multipole==3) call make_corr_pole(ng)
   end select
-  call make_icoobox_bound
+  call make_icoobox_bound(ng)
 
-  call allocate_mat
+  call allocate_mat(ng)
   call set_icoo1d
   call allocate_sendrecv
   call init_persistent_requests(info)
@@ -273,7 +272,7 @@ if(iopt==1)then
   end if
 
   if(iperiodic==3 .and. iflag_hartree==4)then
-    call prep_poisson_fft
+    call prep_poisson_fft(ng)
   end if
 
   if(.not. allocated(Vpsl)) allocate( Vpsl(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)) )
@@ -283,7 +282,7 @@ if(iopt==1)then
   else
     call read_pslfile(system)
     call allocate_psl
-    call init_ps(system%primitive_a,system%primitive_b,stencil%rmatrix_A,info%icomm_r)
+    call init_ps(ng,system%primitive_a,system%primitive_b,stencil%rmatrix_A,info%icomm_r)
   end if
   sVpsl%f = Vpsl
 
@@ -310,9 +309,9 @@ if(iopt==1)then
     if(iswitch_orbital_mesh==1.or.iflag_subspace_diag==1)then
       select case(iperiodic)
       case(0)
-        allocate( psi_mesh(ng_sta(1):ng_end(1),ng_sta(2):ng_end(2),ng_sta(3):ng_end(3),1:itotMST,1) )
+        allocate( psi_mesh(ng%is(1):ng%ie(1),ng%is(2):ng%ie(2),ng%is(3):ng%ie(3),1:itotMST,1) )
       case(3)
-        allocate( zpsi_mesh(ng_sta(1):ng_end(1),ng_sta(2):ng_end(2),ng_sta(3):ng_end(3),1:itotMST,num_kpoints_rd) )
+        allocate( zpsi_mesh(ng%is(1):ng%ie(1),ng%is(2):ng%ie(2),ng%is(3):ng%ie(3),1:itotMST,num_kpoints_rd) )
       end select
     end if
 
@@ -405,7 +404,7 @@ if(iopt==1)then
 
     call exc_cor_ns(ng, srg_ng, system%nspin, srho_s, ppn, sVxc, energy%E_xc)
 
-    call allgatherv_vlocal(info,system%nspin,sVh,sVpsl,sVxc,V_local)
+    call allgatherv_vlocal(ng,info,system%nspin,sVh,sVpsl,sVxc,V_local)
     do jspin=1,system%nspin
       Vlocal(:,:,:,jspin) = V_local(jspin)%f
     end do
@@ -460,7 +459,7 @@ else if(iopt>=2)then
   Miter = 0        ! Miter: Iteration counter set to zero
   if(iflag_ps/=0) then
     call dealloc_init_ps(ppg,ppg_all,ppn)
-    call init_ps(system%primitive_a,system%primitive_b,stencil%rmatrix_A,info%icomm_r)
+    call init_ps(ng,system%primitive_a,system%primitive_b,stencil%rmatrix_A,info%icomm_r)
     if(iperiodic==3) call get_fourier_grid_G(fg)
 
   end if
@@ -506,27 +505,27 @@ if(img==1.and.iopt==1) allocate(norm_diff_psi_stock(itotMST,1))
 norm_diff_psi_stock=1.0d9
 
 if(img>=2.or.iopt>=2) deallocate(rho_stock,Vlocal_stock)
-allocate(rho_stock(ng_sta(1):ng_end(1),ng_sta(2):ng_end(2),ng_sta(3):ng_end(3),1))
+allocate(rho_stock(ng%is(1):ng%ie(1),ng%is(2):ng%ie(2),ng%is(3):ng%ie(3),1))
 if(ilsda==0)then
-  allocate(Vlocal_stock(ng_sta(1):ng_end(1),ng_sta(2):ng_end(2),ng_sta(3):ng_end(3),1))
+  allocate(Vlocal_stock(ng%is(1):ng%ie(1),ng%is(2):ng%ie(2),ng%is(3):ng%ie(3),1))
 else
-  allocate(Vlocal_stock(ng_sta(1):ng_end(1),ng_sta(2):ng_end(2),ng_sta(3):ng_end(3),1:2))
+  allocate(Vlocal_stock(ng%is(1):ng%ie(1),ng%is(2):ng%ie(2),ng%is(3):ng%ie(3),1:2))
 end if
 
 if(ilsda==0)then
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     rho_stock(ix,iy,iz,1)=rho(ix,iy,iz)
     Vlocal_stock(ix,iy,iz,1)=Vlocal(ix,iy,iz,1)
   end do
   end do
   end do
 else
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     rho_stock(ix,iy,iz,1)=rho(ix,iy,iz)
     Vlocal_stock(ix,iy,iz,1:2)=Vlocal(ix,iy,iz,1:2)
   end do
@@ -575,7 +574,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     end do
   end do
 
-  call copy_density(system%nspin,srho_s,mixing)
+  call copy_density(system%nspin,ng,srho_s,mixing)
 
   if(iscf_order==1)then
 
@@ -598,7 +597,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     end if
     call timer_end(LOG_CALC_EXC_COR)
 
-    call allgatherv_vlocal(info,system%nspin,sVh,sVpsl,sVxc,V_local)
+    call allgatherv_vlocal(ng,info,system%nspin,sVh,sVpsl,sVxc,V_local)
 
     call timer_begin(LOG_CALC_TOTAL_ENERGY)
     call calc_eigen_energy(energy,spsi,shpsi,sttpsi,system,info,mg,V_local,stencil,srg,ppg)
@@ -626,9 +625,9 @@ DFT_Iteration : do iter=1,iDiter(img)
     case('rho_dne')
       sum0=0.d0
 !$OMP parallel do reduction(+:sum0) private(iz,iy,ix)
-      do iz=ng_sta(3),ng_end(3) 
-      do iy=ng_sta(2),ng_end(2)
-      do ix=ng_sta(1),ng_end(1)
+      do iz=ng%is(3),ng%ie(3) 
+      do iy=ng%is(2),ng%ie(2)
+      do ix=ng%is(1),ng%ie(1)
         sum0=sum0+abs(srho%f(ix,iy,iz)-rho_stock(ix,iy,iz,1))
       end do
       end do
@@ -642,9 +641,9 @@ DFT_Iteration : do iter=1,iDiter(img)
     case('norm_rho','norm_rho_dng')
       sum0=0.d0
 !$OMP parallel do reduction(+:sum0) private(iz,iy,ix)
-      do iz=ng_sta(3),ng_end(3) 
-      do iy=ng_sta(2),ng_end(2)
-      do ix=ng_sta(1),ng_end(1)
+      do iz=ng%is(3),ng%ie(3) 
+      do iy=ng%is(2),ng%ie(2)
+      do ix=ng%is(1),ng%ie(1)
         sum0=sum0+(srho%f(ix,iy,iz)-rho_stock(ix,iy,iz,1))**2
       end do
       end do
@@ -656,9 +655,9 @@ DFT_Iteration : do iter=1,iDiter(img)
     case('norm_pot','norm_pot_dng')
       sum0=0.d0
 !$OMP parallel do reduction(+:sum0) private(iz,iy,ix)
-      do iz=ng_sta(3),ng_end(3) 
-      do iy=ng_sta(2),ng_end(2)
-      do ix=ng_sta(1),ng_end(1)
+      do iz=ng%is(3),ng%ie(3) 
+      do iy=ng%is(2),ng%ie(2)
+      do ix=ng%is(1),ng%ie(1)
         sum0=sum0+(V_local(1)%f(ix,iy,iz)-Vlocal_stock(ix,iy,iz,1))**2
       end do
       end do
@@ -709,9 +708,9 @@ DFT_Iteration : do iter=1,iDiter(img)
   end if 
   rNebox1=0.d0 
 !$OMP parallel do reduction(+:rNebox1) private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     rNebox1=rNebox1+srho%f(ix,iy,iz)
   end do
   end do
@@ -725,9 +724,9 @@ DFT_Iteration : do iter=1,iDiter(img)
 
 if(ilsda==0)then
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     rho_stock(ix,iy,iz,1)=srho%f(ix,iy,iz)
     Vlocal_stock(ix,iy,iz,1)=V_local(1)%f(ix,iy,iz)
   end do
@@ -735,9 +734,9 @@ if(ilsda==0)then
   end do
 else if(ilsda==1)then
 !$OMP parallel do private(iz,iy,ix)
-  do iz=ng_sta(3),ng_end(3)
-  do iy=ng_sta(2),ng_end(2)
-  do ix=ng_sta(1),ng_end(1)
+  do iz=ng%is(3),ng%ie(3)
+  do iy=ng%is(2),ng%ie(2)
+  do ix=ng%is(1),ng%ie(1)
     rho_stock(ix,iy,iz,1)=srho%f(ix,iy,iz)
     Vlocal_stock(ix,iy,iz,1)=V_local(1)%f(ix,iy,iz)
     Vlocal_stock(ix,iy,iz,2)=V_local(2)%f(ix,iy,iz)
@@ -914,7 +913,7 @@ end if
 if(yn_out_elf=='y')then
   allocate(elf(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),      &
                lg_sta(3):lg_end(3)))
-  call calcELF(info,srho,0)
+  call calcELF(ng,info,srho,0)
   call writeelf(lg,elf,icoo1d,hgs,igc_is,igc_ie,gridcoo,iscfrt)
   deallocate(elf)
 end if
@@ -925,7 +924,7 @@ call timer_begin(LOG_WRITE_LDA_DATA)
 ! LDA data
 ! subroutines in scf_data.f90
 if ( OC==1.or.OC==2.or.OC==3 ) then
-  call OUT_data(mixing)
+  call OUT_data(ng,mixing)
 end if
 call timer_end(LOG_WRITE_LDA_DATA)
 
@@ -998,6 +997,7 @@ if(comm_is_root(nproc_id_global)) then
   close(1)
 
 end if
+
 call timer_end(LOG_WRITE_LDA_INFOS)
 
 deallocate(Vlocal)


### PR DESCRIPTION
This PR replaces old ng(ng_sta, ng_end, and ng_num) in GCEED(but without subroutine 'setng') to ng(structure) and remove unused subroutines in GCEED.