### PR TITLE
Bugfix: calculation error of hand-vectorized stencil when not dividing real-space.

### DIFF
--- a/src/GCEED/rt/real_time_dft.f90
+++ b/src/GCEED/rt/real_time_dft.f90
@@ -450,9 +450,17 @@ contains
 
 subroutine init_code_optimization
   implicit none
+  integer :: ignum(3)
+
   call switch_stencil_optimization(mg%num)
   call switch_openmp_parallelization(mg%num)
-  call set_modulo_tables(mg%num + (nd*2))
+
+  if(iperiodic==3 .and. nproc_d_o(1)*nproc_d_o(2)*nproc_d_o(3)==1) then
+    ignum = mg%num
+  else
+    ignum = mg%num + (nd*2)
+  end if
+  call set_modulo_tables(ignum)
 
   if (comm_is_root(nproc_id_global)) then
     call optimization_log(nproc_k, nproc_ob, nproc_d_o, nproc_d_g)

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -1089,9 +1089,17 @@ end subroutine get_fourier_grid_G
 
 subroutine init_code_optimization
   implicit none
+  integer :: ignum(3)
+
   call switch_stencil_optimization(mg%num)
   call switch_openmp_parallelization(mg%num)
-  call set_modulo_tables(mg%num + (nd*2))
+
+  if(iperiodic==3 .and. nproc_d_o(1)*nproc_d_o(2)*nproc_d_o(3)==1) then
+    ignum = mg%num
+  else
+    ignum = mg%num + (nd*2)
+  end if
+  call set_modulo_tables(ignum)
 
   if (comm_is_root(nproc_id_global)) then
     call optimization_log(nproc_k, nproc_ob, nproc_d_o, nproc_d_g)


### PR DESCRIPTION
I received a bug report of hand-vectorized stencil code, from @syamada0 san and @mn2007 san.
I found and fixed a bug of modulo tables when not dividing real-space.