### PR TITLE
Create_sendrecv_neig subroutines

### DIFF
--- a/src/GCEED/modules/init_sendrecv.f90
+++ b/src/GCEED/modules/init_sendrecv.f90
@@ -15,359 +15,290 @@
 !
 MODULE init_sendrecv_sub
 
-use scf_data
 implicit none 
-integer :: iup_array(4)
-integer :: idw_array(4)
-integer :: jup_array(4)
-integer :: jdw_array(4)
-integer :: kup_array(4)
-integer :: kdw_array(4)
 
 CONTAINS
 
 !=======================================================================
 !=======================================================================
 
-SUBROUTINE init_updown(info)
-use inputoutput, only: iperiodic, process_allocation
-use salmon_parallel
-use salmon_communication, only: comm_proc_null
-use new_world_sub
-use structures, only: s_orbital_parallel
+subroutine create_sendrecv_neig_mg(neig_mg, ob_para_info, iperiodic)
+  use structures, only: s_orbital_parallel
+  use sendrecv_grid, only: init_sendrecv_grid
+  use salmon_communication, only: comm_proc_null
 
-implicit none
-type(s_orbital_parallel),intent(in) :: info
+  use scf_data, only: imr, nproc_d_o
+  ! Note: the above will be moved to s_parallel in near future
 
-iup_array(1)=info%id_r+1
-idw_array(1)=info%id_r-1
-select case(iperiodic)
-case(0)
-  if(imr(1)==nproc_d_o(1)-1) iup_array(1)=comm_proc_null
-  if(imr(1)==0) idw_array(1)=comm_proc_null
-case(3)
-  if(imr(1)==nproc_d_o(1)-1) then
-    iup_array(1)=info%id_r-(nproc_d_o(1)-1)
-  end if
-  if(imr(1)==0) then
-    idw_array(1)=info%id_r+(nproc_d_o(1)-1)
-  end if
-end select
+  implicit none
+  integer, intent(out) :: neig_mg(1:2, 1:3)
+  type(s_orbital_parallel), intent(in) :: ob_para_info
+  integer, intent(in) :: iperiodic
 
-jup_array(1)=info%id_r+nproc_d_o(1)
-jdw_array(1)=info%id_r-nproc_d_o(1)
-select case(iperiodic)
-case(0)
-  if(imr(2)==nproc_d_o(2)-1) jup_array(1)=comm_proc_null
-  if(imr(2)==0) jdw_array(1)=comm_proc_null
-case(3)
-  if(imr(2)==nproc_d_o(2)-1) then
-    jup_array(1)=info%id_r-(nproc_d_o(2)-1)*nproc_d_o(1)
-  end if
-  if(imr(2)==0) then
-    jdw_array(1)=info%id_r+(nproc_d_o(2)-1)*nproc_d_o(1)
-  end if
-end select
-
-kup_array(1)=info%id_r+nproc_d_o(1)*nproc_d_o(2)
-kdw_array(1)=info%id_r-nproc_d_o(1)*nproc_d_o(2)
-select case(iperiodic)
-case(0)
-  if(imr(3)==nproc_d_o(3)-1) kup_array(1)=comm_proc_null
-  if(imr(3)==0) kdw_array(1)=comm_proc_null
-case(3)
-  if(imr(3)==nproc_d_o(3)-1) then
-    kup_array(1)=info%id_r-(nproc_d_o(3)-1)*nproc_d_o(1)*nproc_d_o(2)
-  end if
-  if(imr(3)==0) then
-    kdw_array(1)=info%id_r+(nproc_d_o(3)-1)*nproc_d_o(1)*nproc_d_o(2)
-  end if
-end select
-
-if(process_allocation=='orbital_sequential')then
-  if(imr(1)==nproc_d_o(1)-1.and.imrs(1)==nproc_d_g_dm(1)-1) then
-    select case(iperiodic)
-    case(0)
-      iup_array(2)=comm_proc_null
-    case(3)
-      iup_array(2)=nproc_id_global+nproc_d_g_mul_dm-nproc_d_g_dm(1)+1-nproc_d_g_mul_dm*nproc_d_o(1)
-    end select
-  else if(imrs(1)==nproc_d_g_dm(1)-1) then
-    iup_array(2)=nproc_id_global+nproc_d_g_mul_dm-nproc_d_g_dm(1)+1
-  else
-    iup_array(2)=nproc_id_global+1
-  end if
-else if(process_allocation=='grid_sequential')then
-  if(imr(1)==nproc_d_o(1)-1.and.imrs(1)==nproc_d_g_dm(1)-1) then
-    select case(iperiodic)
-    case(0)
-      iup_array(2)=comm_proc_null
-    case(3)
-      iup_array(2)=nproc_id_global+nproc_d_o_mul+1-nproc_d_o_mul*nproc_d_g_dm(1)-nproc_d_o(1)
-    end select
-  else if(imrs(1)==nproc_d_g_dm(1)-1) then
-    iup_array(2)=nproc_id_global+nproc_d_o_mul+1-nproc_d_o_mul*nproc_d_g_dm(1)
-  else
-    iup_array(2)=nproc_id_global+nproc_d_o_mul
-  end if
-end if
-
-if(process_allocation=='grid_sequential')then
-  if(nproc_d_o(1)==1.and.nproc_d_g_dm(1)==1)then
-    iup_array(4)=comm_proc_null
-  else if(imr(1)==nproc_d_o(1)-1.and.imrs(1)==nproc_d_g_dm(1)-1) then
-    iup_array(4)=nproc_id_global+nproc_d_o_mul+1-nproc_d_o_mul*nproc_d_g_dm(1)-nproc_d_o(1)
-  else if(imrs(1)==nproc_d_g_dm(1)-1) then
-    iup_array(4)=nproc_id_global+nproc_d_o_mul+1-nproc_d_o_mul*nproc_d_g_dm(1)
-  else
-    iup_array(4)=nproc_id_global+nproc_d_o_mul
-  end if
-end if
-
-if(process_allocation=='orbital_sequential')then
-  if(imr(1)==0.and.imrs(1)==0) then
-    select case(iperiodic)
-    case(0)
-      idw_array(2)=comm_proc_null
-    case(3)
-      idw_array(2)=nproc_id_global-nproc_d_g_mul_dm+nproc_d_g_dm(1)-1+nproc_d_g_mul_dm*nproc_d_o(1)
-    end select
-  else if(imrs(1)==0) then
-    idw_array(2)=nproc_id_global-nproc_d_g_mul_dm+nproc_d_g_dm(1)-1
-  else
-    idw_array(2)=nproc_id_global-1
-  end if
-else if(process_allocation=='grid_sequential')then
-  if(imr(1)==0.and.imrs(1)==0) then
-    select case(iperiodic)
-    case(0)
-      idw_array(2)=comm_proc_null
-    case(3)
-      idw_array(2)=nproc_id_global-nproc_d_o_mul-1+nproc_d_o_mul*nproc_d_g_dm(1)+nproc_d_o(1)
-    end select
-  else if(imrs(1)==0) then
-    idw_array(2)=nproc_id_global-nproc_d_o_mul-1+nproc_d_o_mul*nproc_d_g_dm(1)
-  else
-    idw_array(2)=nproc_id_global-nproc_d_o_mul
-  end if
-end if
-
-if(process_allocation=='grid_sequential')then
-  if(nproc_d_o(1)==1.and.nproc_d_g_dm(1)==1)then
-    idw_array(4)=comm_proc_null
-  else if(imr(1)==0.and.imrs(1)==0) then
-    idw_array(4)=nproc_id_global-nproc_d_o_mul-1+nproc_d_o_mul*nproc_d_g_dm(1)+nproc_d_o(1)
-  else if(imrs(1)==0) then
-    idw_array(4)=nproc_id_global-nproc_d_o_mul-1+nproc_d_o_mul*nproc_d_g_dm(1)
-  else
-    idw_array(4)=nproc_id_global-nproc_d_o_mul
-  end if
-end if
-
-if(process_allocation=='orbital_sequential')then
-  if(imr(2)==nproc_d_o(2)-1.and.imrs(2)==nproc_d_g_dm(2)-1) then
-    select case(iperiodic)
-    case(0)
-      jup_array(2)=comm_proc_null
-    case(3)
-      jup_array(2)=nproc_id_global+nproc_d_g_mul_dm*nproc_d_o(1)    &
-                                    -(nproc_d_g_dm(2)-1)*nproc_d_g_dm(1)-nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2)
-    end select 
-  else if(imrs(2)==nproc_d_g_dm(2)-1) then
-    jup_array(2)=nproc_id_global+nproc_d_g_mul_dm*nproc_d_o(1)    &
-                                    -(nproc_d_g_dm(2)-1)*nproc_d_g_dm(1)
-  else
-    jup_array(2)=nproc_id_global+nproc_d_g_dm(1)
-  end if
-else if(process_allocation=='grid_sequential')then
-  if(imr(2)==nproc_d_o(2)-1.and.imrs(2)==nproc_d_g_dm(2)-1) then
-    select case(iperiodic)
-    case(0)
-      jup_array(2)=comm_proc_null
-    case(3)
-      jup_array(2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)  &
-            +nproc_d_o(1)-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)-nproc_d_o(1)*nproc_d_o(2)
-    end select
-  else if(imrs(2)==nproc_d_g_dm(2)-1) then
-    jup_array(2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)  &
-            +nproc_d_o(1)-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  else
-    jup_array(2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)
-  end if
-end if
-
-if(process_allocation=='grid_sequential')then
-  if(nproc_d_o(2)==1.and.nproc_d_g_dm(2)==1)then
-    jup_array(4)=comm_proc_null
-  else if(imr(2)==nproc_d_o(2)-1.and.imrs(2)==nproc_d_g_dm(2)-1) then
-    jup_array(4)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)  &
-            +nproc_d_o(1)-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
-            -nproc_d_o(1)*nproc_d_o(2)
-  else if(imrs(2)==nproc_d_g_dm(2)-1) then
-    jup_array(4)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)  &
-            +nproc_d_o(1)-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  else
-    jup_array(4)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)
-  end if
-end if
-
-if(process_allocation=='orbital_sequential')then
-  if(imr(2)==0.and.imrs(2)==0) then
-    select case(iperiodic)
-    case(0)
-      jdw_array(2)=comm_proc_null
-    case(3)
-      jdw_array(2)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)    &
-                                    +(nproc_d_g_dm(2)-1)*nproc_d_g_dm(1)+nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2)
-    end select
-  else if(imrs(2)==0) then
-    jdw_array(2)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)    &
-                                    +(nproc_d_g_dm(2)-1)*nproc_d_g_dm(1)
-  else
-    jdw_array(2)=nproc_id_global-nproc_d_g_dm(1)
-  end if
-else if(process_allocation=='grid_sequential')then
-  if(imr(2)==0.and.imrs(2)==0) then
-    select case(iperiodic)
-    case(0)
-      jdw_array(2)=comm_proc_null
-    case(3)
-      jdw_array(2)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)  &
-            -nproc_d_o(1)+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)+nproc_d_o(1)*nproc_d_o(2)
-    end select
-  else if(imrs(2)==0) then
-    jdw_array(2)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)  &
-              -nproc_d_o(1)+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  else
-    jdw_array(2)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)
-  end if
-end if
-
-if(process_allocation=='grid_sequential')then
-  if(nproc_d_o(2)==1.and.nproc_d_g_dm(2)==1)then
-    jdw_array(4)=comm_proc_null
-  else if(imr(2)==0.and.imrs(2)==0) then
-    jdw_array(4)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)  &
-              -nproc_d_o(1)+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
-              +nproc_d_o(1)*nproc_d_o(2)
-  else if(imrs(2)==0) then
-    jdw_array(4)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)  &
-              -nproc_d_o(1)+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  else
-    jdw_array(4)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)
-  end if
-end if
+  neig_mg(1, 1)=ob_para_info%id_r+1
+  neig_mg(2, 1)=ob_para_info%id_r-1
+  select case(iperiodic)
+  case(0)
+    if(imr(1)==nproc_d_o(1)-1) neig_mg(1, 1)=comm_proc_null
+    if(imr(1)==0) neig_mg(2, 1)=comm_proc_null
+  case(3)
+    if(imr(1)==nproc_d_o(1)-1) then
+      neig_mg(1, 1)=ob_para_info%id_r-(nproc_d_o(1)-1)
+    end if
+    if(imr(1)==0) then
+      neig_mg(2, 1)=ob_para_info%id_r+(nproc_d_o(1)-1)
+    end if
+  end select
+  
+  neig_mg(1, 2)=ob_para_info%id_r+nproc_d_o(1)
+  neig_mg(2, 2)=ob_para_info%id_r-nproc_d_o(1)
+  select case(iperiodic)
+  case(0)
+    if(imr(2)==nproc_d_o(2)-1) neig_mg(1, 2)=comm_proc_null
+    if(imr(2)==0) neig_mg(2, 2)=comm_proc_null
+  case(3)
+    if(imr(2)==nproc_d_o(2)-1) then
+      neig_mg(1, 2)=ob_para_info%id_r-(nproc_d_o(2)-1)*nproc_d_o(1)
+    end if
+    if(imr(2)==0) then
+      neig_mg(2, 2)=ob_para_info%id_r+(nproc_d_o(2)-1)*nproc_d_o(1)
+    end if
+  end select
+  
+  neig_mg(1, 3)=ob_para_info%id_r+nproc_d_o(1)*nproc_d_o(2)
+  neig_mg(2, 3)=ob_para_info%id_r-nproc_d_o(1)*nproc_d_o(2)
+  select case(iperiodic)
+  case(0)
+    if(imr(3)==nproc_d_o(3)-1) neig_mg(1, 3)=comm_proc_null
+    if(imr(3)==0) neig_mg(2, 3)=comm_proc_null
+  case(3)
+    if(imr(3)==nproc_d_o(3)-1) then
+      neig_mg(1, 3)=ob_para_info%id_r-(nproc_d_o(3)-1)*nproc_d_o(1)*nproc_d_o(2)
+    end if
+    if(imr(3)==0) then
+      neig_mg(2, 3)=ob_para_info%id_r+(nproc_d_o(3)-1)*nproc_d_o(1)*nproc_d_o(2)
+    end if
+  end select
+  
+  return
+end subroutine create_sendrecv_neig_mg
 
 
-if(process_allocation=='orbital_sequential')then
-  if(imr(3)==nproc_d_o(3)-1.and.imrs(3)==nproc_d_g_dm(3)-1) then
-    select case(iperiodic)
-    case(0)
-      kup_array(2)=comm_proc_null
-    case(3)
-      kup_array(2)=nproc_id_global+nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2) &
-                                    -(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2) &
-                                    -nproc_d_g_mul_dm*nproc_d_o_mul
-    end select
-  else if(imrs(3)==nproc_d_g_dm(3)-1) then
-    kup_array(2)=nproc_id_global+nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2)   &
-                                    -(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  else
-    kup_array(2)=nproc_id_global+nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  end if
-else if(process_allocation=='grid_sequential')then
-  if(imr(3)==nproc_d_o(3)-1.and.imrs(3)==nproc_d_g_dm(3)-1) then
-    select case(iperiodic)
-    case(0)
-      kup_array(2)=comm_proc_null
-    case(3)
-      kup_array(2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2) &
-              +nproc_d_o(1)*nproc_d_o(2)   &
-              -nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)-nproc_d_o_mul
-    end select
-  else if(imrs(3)==nproc_d_g_dm(3)-1) then
-    kup_array(2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
-              +nproc_d_o(1)*nproc_d_o(2)   &
-              -nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)
-  else
-    kup_array(2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  end if
-end if
+subroutine create_sendrecv_neig_ng(neig_ng, ob_para_info, iperiodic)
+  use structures, only: s_orbital_parallel
+  use sendrecv_grid, only: init_sendrecv_grid
+  use salmon_parallel, only: nproc_id_global
+  use salmon_communication, only: comm_proc_null
+  use inputoutput, only: process_allocation
 
-if(process_allocation=='grid_sequential')then
-  if(nproc_d_o(3)==1.and.nproc_d_g_dm(3)==1)then
-    kup_array(4)=comm_proc_null
-  else if(imr(3)==nproc_d_o(3)-1.and.imrs(3)==nproc_d_g_dm(3)-1) then
-    kup_array(4)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
-              +nproc_d_o(1)*nproc_d_o(2)   &
-              -nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)  &
-              -nproc_d_o_mul
-  else if(imrs(3)==nproc_d_g_dm(3)-1) then
-    kup_array(4)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
-              +nproc_d_o(1)*nproc_d_o(2)   &
-              -nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)
-  else
-    kup_array(4)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  end if
-end if
+  use scf_data, only: imr, imrs, nproc_d_o, nproc_d_g_dm, nproc_d_g_mul_dm, nproc_d_o_mul
 
-if(process_allocation=='orbital_sequential')then
-  if(imr(3)==0.and.imrs(3)==0) then
-    select case(iperiodic)
-    case(0)
-      kdw_array(2)=comm_proc_null
-    case(3)
-      kdw_array(2)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2) &
-                                    +(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2) &
-                                    +nproc_d_g_mul_dm*nproc_d_o_mul
-    end select
-  else if(imrs(3)==0) then
-    kdw_array(2)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2)   &
-                                    +(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  else
-    kdw_array(2)=nproc_id_global-nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  end if
-else if(process_allocation=='grid_sequential')then
-  if(imr(3)==0.and.imrs(3)==0) then
-    select case(iperiodic)
-    case(0)
-      kdw_array(2)=comm_proc_null
-    case(3)
-      kdw_array(2)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2) &
-                                    +(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2) &
-                                    +nproc_d_g_mul_dm*nproc_d_o_mul
-    end select
-  else if(imrs(3)==0) then
-    kdw_array(2)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
-              -nproc_d_o(1)*nproc_d_o(2)   &
-              +nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)
-  else
-    kdw_array(2)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  end if
-end if
+  ! Note: the above will be moved to s_parallel in near future
 
-if(process_allocation=='grid_sequential')then
-  if(nproc_d_o(3)==1.and.nproc_d_g_dm(3)==1)then
-    kdw_array(4)=comm_proc_null
-  else if(imr(3)==0.and.imrs(3)==0) then
-    kdw_array(4)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
-              -nproc_d_o(1)*nproc_d_o(2)   &
-              +nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)  &
-              +nproc_d_o_mul
-  else if(imrs(3)==0) then
-    kdw_array(4)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
-              -nproc_d_o(1)*nproc_d_o(2)   &
-              +nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)
-  else
-    kdw_array(4)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
-  end if
-end if
+  implicit none
+  integer, intent(out) :: neig_ng(1:2, 1:3)
+  type(s_orbital_parallel), intent(in) :: ob_para_info
+  integer, intent(in) :: iperiodic
+  
 
-END SUBROUTINE init_updown
+  if(process_allocation=='orbital_sequential')then
+    if(imr(1)==nproc_d_o(1)-1.and.imrs(1)==nproc_d_g_dm(1)-1) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(1, 1)=comm_proc_null
+      case(3)
+        neig_ng(1, 1)=nproc_id_global+nproc_d_g_mul_dm-nproc_d_g_dm(1)+1-nproc_d_g_mul_dm*nproc_d_o(1)
+      end select
+    else if(imrs(1)==nproc_d_g_dm(1)-1) then
+      neig_ng(1, 1)=nproc_id_global+nproc_d_g_mul_dm-nproc_d_g_dm(1)+1
+    else
+      neig_ng(1, 1)=nproc_id_global+1
+    end if
+  else if(process_allocation=='grid_sequential')then
+    if(imr(1)==nproc_d_o(1)-1.and.imrs(1)==nproc_d_g_dm(1)-1) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(1, 1)=comm_proc_null
+      case(3)
+        neig_ng(1, 1)=nproc_id_global+nproc_d_o_mul+1-nproc_d_o_mul*nproc_d_g_dm(1)-nproc_d_o(1)
+      end select
+    else if(imrs(1)==nproc_d_g_dm(1)-1) then
+      neig_ng(1, 1)=nproc_id_global+nproc_d_o_mul+1-nproc_d_o_mul*nproc_d_g_dm(1)
+    else
+      neig_ng(1, 1)=nproc_id_global+nproc_d_o_mul
+    end if
+  end if
+  
+  if(process_allocation=='orbital_sequential')then
+    if(imr(1)==0.and.imrs(1)==0) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(2, 1)=comm_proc_null
+      case(3)
+        neig_ng(2, 1)=nproc_id_global-nproc_d_g_mul_dm+nproc_d_g_dm(1)-1+nproc_d_g_mul_dm*nproc_d_o(1)
+      end select
+    else if(imrs(1)==0) then
+      neig_ng(2, 1)=nproc_id_global-nproc_d_g_mul_dm+nproc_d_g_dm(1)-1
+    else
+      neig_ng(2, 1)=nproc_id_global-1
+    end if
+  else if(process_allocation=='grid_sequential')then
+    if(imr(1)==0.and.imrs(1)==0) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(2, 1)=comm_proc_null
+      case(3)
+        neig_ng(2, 1)=nproc_id_global-nproc_d_o_mul-1+nproc_d_o_mul*nproc_d_g_dm(1)+nproc_d_o(1)
+      end select
+    else if(imrs(1)==0) then
+      neig_ng(2, 1)=nproc_id_global-nproc_d_o_mul-1+nproc_d_o_mul*nproc_d_g_dm(1)
+    else
+      neig_ng(2, 1)=nproc_id_global-nproc_d_o_mul
+    end if
+  end if
+  
+  if(process_allocation=='orbital_sequential')then
+    if(imr(2)==nproc_d_o(2)-1.and.imrs(2)==nproc_d_g_dm(2)-1) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(1, 2)=comm_proc_null
+      case(3)
+        neig_ng(1, 2)=nproc_id_global+nproc_d_g_mul_dm*nproc_d_o(1)    &
+                                      -(nproc_d_g_dm(2)-1)*nproc_d_g_dm(1)-nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2)
+      end select 
+    else if(imrs(2)==nproc_d_g_dm(2)-1) then
+      neig_ng(1, 2)=nproc_id_global+nproc_d_g_mul_dm*nproc_d_o(1)    &
+                                      -(nproc_d_g_dm(2)-1)*nproc_d_g_dm(1)
+    else
+      neig_ng(1, 2)=nproc_id_global+nproc_d_g_dm(1)
+    end if
+  else if(process_allocation=='grid_sequential')then
+    if(imr(2)==nproc_d_o(2)-1.and.imrs(2)==nproc_d_g_dm(2)-1) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(1, 2)=comm_proc_null
+      case(3)
+        neig_ng(1, 2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)  &
+              +nproc_d_o(1)-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)-nproc_d_o(1)*nproc_d_o(2)
+      end select
+    else if(imrs(2)==nproc_d_g_dm(2)-1) then
+      neig_ng(1, 2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)  &
+              +nproc_d_o(1)-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
+    else
+      neig_ng(1, 2)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)
+    end if
+  end if
+  
+  if(process_allocation=='orbital_sequential')then
+    if(imr(2)==0.and.imrs(2)==0) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(2, 2)=comm_proc_null
+      case(3)
+        neig_ng(2, 2)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)    &
+                                      +(nproc_d_g_dm(2)-1)*nproc_d_g_dm(1)+nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2)
+      end select
+    else if(imrs(2)==0) then
+      neig_ng(2, 2)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)    &
+                                      +(nproc_d_g_dm(2)-1)*nproc_d_g_dm(1)
+    else
+      neig_ng(2, 2)=nproc_id_global-nproc_d_g_dm(1)
+    end if
+  else if(process_allocation=='grid_sequential')then
+    if(imr(2)==0.and.imrs(2)==0) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(2, 2)=comm_proc_null
+      case(3)
+        neig_ng(2, 2)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)  &
+              -nproc_d_o(1)+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)+nproc_d_o(1)*nproc_d_o(2)
+      end select
+    else if(imrs(2)==0) then
+      neig_ng(2, 2)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)  &
+                -nproc_d_o(1)+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
+    else
+      neig_ng(2, 2)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)
+    end if
+  end if
+
+  if(process_allocation=='orbital_sequential')then
+    if(imr(3)==nproc_d_o(3)-1.and.imrs(3)==nproc_d_g_dm(3)-1) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(1, 3)=comm_proc_null
+      case(3)
+        neig_ng(1, 3)=nproc_id_global+nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2) &
+                                      -(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2) &
+                                      -nproc_d_g_mul_dm*nproc_d_o_mul
+      end select
+    else if(imrs(3)==nproc_d_g_dm(3)-1) then
+      neig_ng(1, 3)=nproc_id_global+nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2)   &
+                                      -(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2)
+    else
+      neig_ng(1, 3)=nproc_id_global+nproc_d_g_dm(1)*nproc_d_g_dm(2)
+    end if
+  else if(process_allocation=='grid_sequential')then
+    if(imr(3)==nproc_d_o(3)-1.and.imrs(3)==nproc_d_g_dm(3)-1) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(1, 3)=comm_proc_null
+      case(3)
+        neig_ng(1, 3)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2) &
+                +nproc_d_o(1)*nproc_d_o(2)   &
+                -nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)-nproc_d_o_mul
+      end select
+    else if(imrs(3)==nproc_d_g_dm(3)-1) then
+      neig_ng(1, 3)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
+                +nproc_d_o(1)*nproc_d_o(2)   &
+                -nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)
+    else
+      neig_ng(1, 3)=nproc_id_global+nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
+    end if
+  end if
+  
+  if(process_allocation=='orbital_sequential')then
+    if(imr(3)==0.and.imrs(3)==0) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(2, 3)=comm_proc_null
+      case(3)
+        neig_ng(2, 3)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2) &
+                                      +(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2) &
+                                      +nproc_d_g_mul_dm*nproc_d_o_mul
+      end select
+    else if(imrs(3)==0) then
+      neig_ng(2, 3)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2)   &
+                                      +(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2)
+    else
+      neig_ng(2, 3)=nproc_id_global-nproc_d_g_dm(1)*nproc_d_g_dm(2)
+    end if
+  else if(process_allocation=='grid_sequential')then
+    if(imr(3)==0.and.imrs(3)==0) then
+      select case(iperiodic)
+      case(0)
+        neig_ng(2, 3)=comm_proc_null
+      case(3)
+        neig_ng(2, 3)=nproc_id_global-nproc_d_g_mul_dm*nproc_d_o(1)*nproc_d_o(2) &
+                                      +(nproc_d_g_dm(3)-1)*nproc_d_g_dm(1)*nproc_d_g_dm(2) &
+                                      +nproc_d_g_mul_dm*nproc_d_o_mul
+      end select
+    else if(imrs(3)==0) then
+      neig_ng(2, 3)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)  &
+                -nproc_d_o(1)*nproc_d_o(2)   &
+                +nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)*nproc_d_g_dm(3)
+    else
+      neig_ng(2, 3)=nproc_id_global-nproc_d_o_mul*nproc_d_g_dm(1)*nproc_d_g_dm(2)
+    end if
+  end if
+  
+  return
+end subroutine create_sendrecv_neig_ng
+
 
 !=====================================================================
 subroutine init_itype
 use salmon_parallel, only: nproc_size_global, nproc_id_global
+use scf_data, only: inum_Mxin, inum_Mxin_s, nd
 
 implicit none
 
@@ -493,7 +424,8 @@ end subroutine init_itype
 
 !======================================================================
 subroutine init_sendrecv_matrix
-use salmon_parallel, only: nproc_size_global, nproc_id_global
+use salmon_parallel, only: nproc_size_global
+use scf_data, only: inum_Mxin_s, inum_Mxin
 integer :: inum_Mxin2(3,0:nproc_size_global-1)
 
 inum_Mxin2(1:3,0:nproc_size_global-1)=inum_Mxin_s(1:3,0:nproc_size_global-1)

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -156,7 +156,6 @@ if(iopt==1)then
 
   end select
 
-  call init_updown(info)
   call init_itype
   call init_sendrecv_matrix
   select case(iperiodic)
@@ -169,24 +168,13 @@ if(iopt==1)then
   call set_icoo1d
   call init_code_optimization
 
-  ! Initialization of s_sendrecv_grid structure (experimental implementation)
-  neig(1, 1) = iup_array(1)
-  neig(2, 1) = idw_array(1)
-  neig(1, 2) = jup_array(1)
-  neig(2, 2) = jdw_array(1)
-  neig(1, 3) = kup_array(1)
-  neig(2, 3) = kdw_array(1)
+  ! sendrecv_grid object for wavefunction updates
+  call create_sendrecv_neig_mg(neig, info, iperiodic) ! neighboring node array
   call init_sendrecv_grid(srg, mg, iobnum * k_num, info%icomm_r, neig)
-
-  neig_ng(1, 1) = iup_array(2)
-  neig_ng(2, 1) = idw_array(2)
-  neig_ng(1, 2) = jup_array(2)
-  neig_ng(2, 2) = jdw_array(2)
-  neig_ng(1, 3) = kup_array(2)
-  neig_ng(2, 3) = kdw_array(2)
-  call init_sendrecv_grid(srg_ng, ng, 1, &
-    & nproc_group_global, neig_ng)
-
+  ! sendrecv_grid object for scalar potential updates
+  call create_sendrecv_neig_ng(neig_ng, info, iperiodic) ! neighboring node array
+  call init_sendrecv_grid(srg_ng, ng, 1, nproc_group_global, neig_ng)
+  
   if(ispin==0)then
     nspin=1
   else

--- a/src/maxwell/eh_init.f90
+++ b/src/maxwell/eh_init.f90
@@ -1487,7 +1487,7 @@ subroutine eh_prep_GCEED(fs,fw)
                                ista_Mxin,iend_Mxin,inum_Mxin,&
                                ista_Mxin_s,iend_Mxin_s,inum_Mxin_s
   use new_world_sub,     only: make_new_world
-  use init_sendrecv_sub, only: init_updown,iup_array,idw_array,jup_array,jdw_array,kup_array,kdw_array
+  use init_sendrecv_sub, only: create_sendrecv_neig_ng
   use sendrecv_grid,     only: init_sendrecv_grid
   use structures,        only: s_fdtd_system, s_orbital_parallel, s_field_parallel
   use salmon_maxwell,    only: ls_fdtd_work
@@ -1527,10 +1527,6 @@ subroutine eh_prep_GCEED(fs,fw)
   fw%ioddeven(:)=imesh_oddeven(:);
   
   !set sendrecv environment
-  call init_updown(info)
-  neig_ng_eh(1,1)=iup_array(2); neig_ng_eh(2,1)=idw_array(2);
-  neig_ng_eh(1,2)=jup_array(2); neig_ng_eh(2,2)=jdw_array(2);
-  neig_ng_eh(1,3)=kup_array(2); neig_ng_eh(2,3)=kdw_array(2);
   !This process about ng is temporal. 
   !With modifying set_ng to be applied to arbitrary Nd, this process will be removed.
   fs%ng%is_overlap(1:3)=fs%ng%is(1:3)-fw%Nd
@@ -1553,6 +1549,8 @@ subroutine eh_prep_GCEED(fs,fw)
     fs%ng%idz(ii)=ii
   end do
   fs%ng%Nd=fw%Nd
+
+  call create_sendrecv_neig_ng(neig_ng_eh, info, iperiodic) ! neighboring node array
   call init_sendrecv_grid(fs%srg_ng,fs%ng,1,nproc_group_global,neig_ng_eh)
-  
+
 end subroutine eh_prep_GCEED


### PR DESCRIPTION
This pull request contains a few subroutines:
* `Create_sendrecv_neig_mg`
* `Create_sendrecv_neig_ng`

to replace the `init_updown` and exclude the global variables:
* `[i-k](up|dw)_array`

