### PR TITLE
Fix: module/subroutine name conflict.

### DIFF
--- a/src/ARTED/RT/dt_evolve.f90
+++ b/src/ARTED/RT/dt_evolve.f90
@@ -124,7 +124,7 @@ Subroutine dt_evolve_omp_KB(zu)
     tjr2_t=tjr2
   end if
 
-  call hamiltonian(zu,.false.)
+  call hamiltonian_arted(zu,.false.)
 
   call psi_rho_RT(zu)
   if(yn_fix_func=='n')then
@@ -155,7 +155,7 @@ Subroutine dt_evolve_omp_KB(zu)
   end select
 ! yabana
 
-  call hamiltonian(zu,.true.)
+  call hamiltonian_arted(zu,.true.)
 
   call psi_rho_RT(zu)
 
@@ -195,7 +195,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
 !Constructing nonlocal part
   call update_projector(kac)
 
-  call hamiltonian(zu,.false.)
+  call hamiltonian_arted(zu,.false.)
 
   Vloc_t=Vloc
   Vloc_new(:) = 3d0*Vloc(:) - 3d0*Vloc_old(:,1) + Vloc_old(:,2)
@@ -218,7 +218,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
         zu_GS(:,ib,ik)=zu(:,ib,ik)
      end do
 
-     call hamiltonian(zu,.false.)
+     call hamiltonian_arted(zu,.false.)
 
      call psi_rho_RT(zu)
 
@@ -242,7 +242,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
   end select
 
 
-  call hamiltonian(zu,.true.)
+  call hamiltonian_arted(zu,.true.)
 
   call psi_rho_RT(zu)
 
@@ -298,7 +298,7 @@ Subroutine dt_evolve_omp_KB_MS(zu)
     tjr2_t=tjr2
   end if
 
-  call hamiltonian(zu,.false.)
+  call hamiltonian_arted(zu,.false.)
 
   call psi_rho_RT(zu)
   if(yn_fix_func=='n')then
@@ -328,7 +328,7 @@ Subroutine dt_evolve_omp_KB_MS(zu)
   end select
 ! yabana
 
-  call hamiltonian(zu,.true.)
+  call hamiltonian_arted(zu,.true.)
 
   call psi_rho_RT(zu)
 

--- a/src/ARTED/RT/hamiltonian.f90
+++ b/src/ARTED/RT/hamiltonian.f90
@@ -16,7 +16,7 @@
 #define TIMER_BEG(id) call timer_thread_begin(id)
 #define TIMER_END(id) call timer_thread_end(id)
 
-subroutine hamiltonian(zu,flag_current)
+subroutine hamiltonian_arted(zu,flag_current)
   use Global_Variables
   use timer
   use omp_lib


### PR DESCRIPTION
Several compiler fails object linking due to following name conflict...

1. src/ARTED/RT/hamiltonian.f90 (external procedure `hamiltonian`)
2. src/common/hamiltonian.f90 (module `hamiltonian`)