### PR TITLE
Fix MPI dummy module.

### DIFF
--- a/src/parallel/salmon_communication_dummy.f90
+++ b/src/parallel/salmon_communication_dummy.f90
@@ -1080,7 +1080,7 @@ contains
     integer, intent(in)  :: ngroup
     UNUSED_VARIABLE(ngroup)
     !NOP! ABORT_MESSAGE(ngroup,"comm_allgatherv_array1d_double")
-    outvalue(displs(1)+1:displs(1)+ncounts(1)-1) = invalue(1:ncounts(1)-1)
+    outvalue(displs(1)+1:displs(1)+1+ncounts(1)-1) = invalue(1:ncounts(1)-1)
   end subroutine
 
 


### PR DESCRIPTION
This bug causes the verification error of tests 111, 112, and 113 with non-MPI version.

NOTE: Jenkins is stopped now due to the system protects from blackout by typhoon 19. We will power on the system tomorrow (October 15, JST).