### PR TITLE
Fixed: array size error: FionE.

### DIFF
--- a/src/GCEED/rt/time_evolution_step.f90
+++ b/src/GCEED/rt/time_evolution_step.f90
@@ -71,7 +71,7 @@ SUBROUTINE time_evolution_step(lg,mg,ng,system,rt,info,info_field,stencil,xc_fun
   integer :: ix,iy,iz,nspin
   integer :: iatom
   integer :: idensity, idiffDensity, ielf
-  real(8) :: rNe, FionE(3,MI)
+  real(8) :: rNe, FionE(3,system%nion)
   real(8) :: curr_e_tmp(3,2), curr_i_tmp(3)  !??curr_e_tmp(3,nspin) ?
   integer :: is
   character(100) :: comment_line
@@ -309,7 +309,7 @@ SUBROUTINE time_evolution_step(lg,mg,ng,system,rt,info,info_field,stencil,xc_fun
      call calc_force_salmon(system,pp,fg,info,mg,stencil,srg,ppg,spsi_out)
 
      !force on ion directly from field --- should put in calc_force_salmon?
-     do iatom=1,MI
+     do iatom=1,system%nion
         FionE(:,iatom) = pp%Zps(Kion(iatom)) * E_tot(:,itt)
      enddo
      system%Force(:,:) = system%Force(:,:) + FionE(:,:)


### PR DESCRIPTION
In debug build with `-check all,noarg_temp_created,noassume -traceback`, test 124 shows in following error:
```
56: Image              PC                Routine            Line        Source
56: salmon.cpu         00000000012E99C6  Unknown               Unknown  Unknown
56: salmon.cpu         0000000000937F9E  time_evolution_st         315  time_evolution_step.f90
56: salmon.cpu         000000000091047C  main_tddft_               527  main_tddft.f90
56: salmon.cpu         0000000000408829  MAIN__                     41  main.f90
56: salmon.cpu         00000000004084E2  Unknown               Unknown  Unknown
56: libc-2.17.so       00002B8FE56CF505  __libc_start_main     Unknown  Unknown
56: salmon.cpu         00000000004083E9  Unknown               Unknown  Unknown
56: forrtl: warning (406): fort: (33): Shape mismatch: The extent of dimension 2 of array SYSTEM is 3 and the corresponding extent of array FIONE is 0
```

Maybe, variable `MI` is not initialized by  `system%nion`. I fixed it.