### PR TITLE
removal of scalapack variliables in scf_data

### DIFF
--- a/src/GCEED/modules/scf_data.f90
+++ b/src/GCEED/modules/scf_data.f90
@@ -21,8 +21,5 @@ implicit none
 integer :: itt
 integer :: itotNtime
 
-integer :: CONTEXT, IAM, MYCOL, MYROW, NPCOL, NPROCS2, NPROW
-integer :: DESCA( 50 ), DESCZ( 50 )
-
 END MODULE scf_data
 


### PR DESCRIPTION
I remove scalapack variliables in scf_data.