### PR TITLE
fix test 301.

### DIFF
--- a/testsuites/CMakeLists.txt
+++ b/testsuites/CMakeLists.txt
@@ -12,7 +12,8 @@ message(STATUS "testing command: ${TEST_COMMAND}")
 add_custom_target("check_test_requirements" COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS ${TARGET_NAME})
 add_custom_target("test_preparations" ALL
                   COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan "generate ctest scripts"
-                  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/pseudo" "${CMAKE_CURRENT_BINARY_DIR}/pseudo")
+                  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/pseudo" "${CMAKE_CURRENT_BINARY_DIR}/pseudo"
+                  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/examples"       "${CMAKE_BINARY_DIR}/examples")
 
 # test directories
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/001_bulk_gs")


### PR DESCRIPTION
Test 301 failed due to example directory is not found into the build directory. I fix it.