### PR TITLE
FFTE: fix performance and redundant communicators.

### DIFF
--- a/src/atom/pp/prep_pp.f90
+++ b/src/atom/pp/prep_pp.f90
@@ -642,14 +642,11 @@ subroutine calc_Vpsl_periodic_FFTE(lg,mg,ng,system,info_field,pp,ppg,poisson,sVp
     end do
     end do
 
-    call comm_summation(poisson%a_ffte_tmp,poisson%a_ffte,size(poisson%a_ffte),info_field%icomm_ffte(1))
+    call comm_summation(poisson%a_ffte_tmp,poisson%a_ffte,size(poisson%a_ffte),info_field%icomm(1))
 
     CALL PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(1),lg%num(2),lg%num(3),   &
-                      info_field%isize_ffte(2),info_field%isize_ffte(3),0, &
-                      info_field%icomm_ffte(2),info_field%icomm_ffte(3))
-    CALL PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(1),lg%num(2),lg%num(3),   &
-                      info_field%isize_ffte(2),info_field%isize_ffte(3),1, &
-                      info_field%icomm_ffte(2),info_field%icomm_ffte(3))
+                      info_field%isize(2),info_field%isize(3),1, &
+                      info_field%icomm(2),info_field%icomm(3))
 
 !$OMP parallel do private(iiz,iiy)
     do iz=1,ng%num(3)

--- a/src/common/structures.f90
+++ b/src/common/structures.f90
@@ -160,12 +160,10 @@ module structures
     integer :: iaddress(3) ! address of MPI under 3-d field (X,Y,Z)
     integer,allocatable :: imap(:,:,:) ! address map
     integer :: icomm_all,id_all,isize_all ! communicator, process ID, & # of processes
-    integer :: icomm(3)  ! 1: x-direction, 2: y-direction, 3: z-direction
+    integer :: icomm(3) ! 1: x-direction, 2: y-direction, 3: z-direction
+                        ! Inside core FFTE routine, x-direction is redundant and
+                        ! yz-direction is parallel.
     integer :: id(3), isize(3)
-    integer :: icomm_ffte(3) ! 1: x-direction, 2: y-direction, 3: z-direction
-                             ! Inside core FFTE routine, x-direction is redundant and
-                             ! yz-direction is parallel.
-    integer :: id_ffte(3), isize_ffte(3)
     integer :: icomm_xy,id_xy,isize_xy ! for singlescale FDTD
   end type s_field_parallel
 

--- a/src/maxwell/fdtd_coulomb_gauge.f90
+++ b/src/maxwell/fdtd_coulomb_gauge.f90
@@ -636,9 +636,9 @@ subroutine fourier_singlescale(lg,mg,ng,info_field,trho,tvh,trhoG_ele,trhoG_ele_
     stop 'poisson_ffte: array is not allocated'
   end if
   
-  if(info_field%isize_ffte(1) < 4) stop "isize_ffte(1) must be > 3"
+  if(info_field%isize(1) < 4) stop "isize(1) must be > 3"
   
-  i = mod(info_field%id_ffte(1),4) ! i=0,1,2,3
+  i = mod(info_field%id(1),4) ! i=0,1,2,3
 
   inv_lgnum3=1.d0/(lg%num(1)*lg%num(2)*lg%num(3))
 
@@ -660,16 +660,13 @@ subroutine fourier_singlescale(lg,mg,ng,info_field,trho,tvh,trhoG_ele,trhoG_ele_
   end do
   end do
   
-  call comm_summation(singlescale%b_ffte,singlescale%a_ffte,size(singlescale%a_ffte),info_field%icomm_ffte(1))
+  call comm_summation(singlescale%b_ffte,singlescale%a_ffte,size(singlescale%a_ffte),info_field%icomm(1))
 
   CALL PZFFT3DV_MOD(singlescale%a_ffte(:,:,:,i),singlescale%b_ffte(:,:,:,i),lg%num(1),lg%num(2),lg%num(3),   &
-                    info_field%isize_ffte(2),info_field%isize_ffte(3),0, &
-                    info_field%icomm_ffte(2),info_field%icomm_ffte(3))
-  CALL PZFFT3DV_MOD(singlescale%a_ffte(:,:,:,i),singlescale%b_ffte(:,:,:,i),lg%num(1),lg%num(2),lg%num(3),   &
-                    info_field%isize_ffte(2),info_field%isize_ffte(3),-1, &
-                    info_field%icomm_ffte(2),info_field%icomm_ffte(3))
+                    info_field%isize(2),info_field%isize(3),-1, &
+                    info_field%icomm(2),info_field%icomm(3))
 
-  call comm_bcast(singlescale%b_ffte(:,:,:,0),info_field%icomm_ffte(1), 0)
+  call comm_bcast(singlescale%b_ffte(:,:,:,0),info_field%icomm(1), 0)
 
 ! Poisson eq.: singlescale%b_ffte(ix,iy,iz,0)=rho(G) --> poisson%b_ffte(ix,iy,iz)=Vh(G)
   trhoG_ele_tmp=0d0
@@ -731,13 +728,13 @@ subroutine fourier_singlescale(lg,mg,ng,info_field,trho,tvh,trhoG_ele,trhoG_ele_
   !$omp end parallel do
 
   CALL PZFFT3DV_MOD(singlescale%b_ffte(:,:,:,i),singlescale%a_ffte(:,:,:,i),lg%num(1),lg%num(2),lg%num(3), &
-                    info_field%isize_ffte(2),info_field%isize_ffte(3),1, &
-                    info_field%icomm_ffte(2),info_field%icomm_ffte(3))
+                    info_field%isize(2),info_field%isize(3),1, &
+                    info_field%icomm(2),info_field%icomm(3))
 
-  call comm_bcast(singlescale%a_ffte(:,:,:,0),info_field%icomm_ffte(1), 0)
-  call comm_bcast(singlescale%a_ffte(:,:,:,1),info_field%icomm_ffte(1), 1)
-  call comm_bcast(singlescale%a_ffte(:,:,:,2),info_field%icomm_ffte(1), 2)
-  call comm_bcast(singlescale%a_ffte(:,:,:,3),info_field%icomm_ffte(1), 3)
+  call comm_bcast(singlescale%a_ffte(:,:,:,0),info_field%icomm(1), 0)
+  call comm_bcast(singlescale%a_ffte(:,:,:,1),info_field%icomm(1), 1)
+  call comm_bcast(singlescale%a_ffte(:,:,:,2),info_field%icomm(1), 2)
+  call comm_bcast(singlescale%a_ffte(:,:,:,3),info_field%icomm(1), 3)
   
   !$OMP parallel do private(iiz,iiy,ix,iy,iz)
   do iz=1,ng%num(3)
@@ -927,14 +924,11 @@ contains
       fw%b_ffte(ng%is(1):ng%ie(1),iy,iz,0) = Vh%f(ng%is(1):ng%ie(1),iiy,iiz)
     end do
     end do
-    call comm_summation(fw%b_ffte,fw%a_ffte,size(fw%a_ffte),info_field%icomm_ffte(1))
+    call comm_summation(fw%b_ffte,fw%a_ffte,size(fw%a_ffte),info_field%icomm(1))
 
     CALL PZFFT3DV_MOD(fw%a_ffte(:,:,:,0),fw%Vh_ffte_old,lg%num(1),lg%num(2),lg%num(3),   &
-                      info_field%isize_ffte(2),info_field%isize_ffte(3),0, &
-                      info_field%icomm_ffte(2),info_field%icomm_ffte(3))
-    CALL PZFFT3DV_MOD(fw%a_ffte(:,:,:,0),fw%Vh_ffte_old,lg%num(1),lg%num(2),lg%num(3),   &
-                      info_field%isize_ffte(2),info_field%isize_ffte(3),-1, &
-                      info_field%icomm_ffte(2),info_field%icomm_ffte(3))
+                      info_field%isize(2),info_field%isize(3),-1, &
+                      info_field%icomm(2),info_field%icomm(3))
   
     return
   end subroutine calc_Vh_ffte

--- a/src/parallel/init_communicator.f90
+++ b/src/parallel/init_communicator.f90
@@ -196,14 +196,6 @@ subroutine init_communicator_dft(comm,pinfo,info,info_field)
   info_field%icomm_xy = comm_create_group_byid(comm, iranklists(1:nl))
   call comm_get_groupinfo(info_field%icomm_xy, info_field%id_xy, info_field%isize_xy)
 
-
-! communicators for FFTE routine
-  info_field%icomm_ffte(1:3) = info_field%icomm(1:3)
-
-  call comm_get_groupinfo(info_field%icomm_ffte(1), info_field%id_ffte(1), info_field%isize_ffte(1))
-  call comm_get_groupinfo(info_field%icomm_ffte(2), info_field%id_ffte(2), info_field%isize_ffte(2))
-  call comm_get_groupinfo(info_field%icomm_ffte(3), info_field%id_ffte(3), info_field%isize_ffte(3))
-
 end subroutine init_communicator_dft
 
 END MODULE init_communicator

--- a/src/poisson/init_poisson.f90
+++ b/src/poisson/init_poisson.f90
@@ -324,8 +324,8 @@ subroutine init_poisson_fft(lg,ng,system,info_field,poisson)
   
   integer :: npuy,npuz
 
-  npuy=info_field%isize_ffte(2)
-  npuz=info_field%isize_ffte(3)
+  npuy=info_field%isize(2)
+  npuz=info_field%isize(3)
 
   if(.not.allocated(poisson%coef))then
     allocate(poisson%coef(lg%num(1),lg%num(2)/npuy,lg%num(3)/npuz))
@@ -351,8 +351,8 @@ subroutine init_poisson_fft(lg,ng,system,info_field,poisson)
   kz_sta=1
   kz_end=lg_num_2(3)/npuz
 
-  ky_shift=info_field%id_ffte(2)*lg_num_2(2)/npuy
-  kz_shift=info_field%id_ffte(3)*lg_num_2(3)/npuz
+  ky_shift=info_field%id(2)*lg_num_2(2)/npuy
+  kz_shift=info_field%id(3)*lg_num_2(3)/npuz
 
   do kz = kz_sta,kz_end
   do ky = ky_sta,ky_end


### PR DESCRIPTION
1. Move FFTE initialization process to `init_dft`.
2. Remove comm_summation in `poisson_ffte`.
3. Remove `icomm_ffte`.

`poisson_ffte` performance approximately 4 times faster than so far.