### PR TITLE
can select PZFFT3DV parallelized directions.

### DIFF
--- a/src/atom/pp/prep_pp.f90
+++ b/src/atom/pp/prep_pp.f90
@@ -390,27 +390,27 @@ subroutine calc_vpsl_periodic(lg,mg,system,info,pp,fg,poisson,vpsl,ppg,property)
     select case (ffte_parallel)
     case ('xy')
       !$OMP parallel do private(iz,iy,ix,iix,iiy) collapse(2)
-      do ix = 1,mg%num(1)
       do iy = 1,mg%num(2)
+      do ix = 1,mg%num(1)
       do iz = mg%is(3),mg%ie(3)
-        iix=ix+mg%is(1)-1
         iiy=iy+mg%is(2)-1
-        poisson%b_ffte(iz,iy,ix) = vtmp2(iix,iiy,iz,1) ! V_ion(G)
+        iix=ix+mg%is(1)-1
+        poisson%b_ffte(iz,ix,iy) = vtmp2(iix,iiy,iz,1) ! V_ion(G)
       end do
       end do
       end do
       call comm_summation(poisson%b_ffte,poisson%a_ffte,size(poisson%a_ffte),info%icomm_z)
 
-      CALL PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(3),lg%num(2),lg%num(1),   &
-                        info%isize_y,info%isize_x,1, &
-                        info%icomm_y,info%icomm_x)
+      CALL PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(3),lg%num(1),lg%num(2),   &
+                        info%isize_x,info%isize_y,1, &
+                        info%icomm_x,info%icomm_y)
 
       !$OMP parallel do private(iz,iy,iix,iiy) collapse(2)
-      do ix = 1,mg%num(1)
       do iy = 1,mg%num(2)
-        iix=ix+mg%is(1)-1
+      do ix = 1,mg%num(1)
         iiy=iy+mg%is(2)-1
-        Vpsl%f(iix,iiy,mg%is(3):mg%ie(3)) = poisson%b_ffte(mg%is(3):mg%ie(3),iy,ix)*system%ngrid
+        iix=ix+mg%is(1)-1
+        Vpsl%f(iix,iiy,mg%is(3):mg%ie(3)) = poisson%b_ffte(mg%is(3):mg%ie(3),ix,iy)*system%ngrid
       end do
       end do
 

--- a/src/common/initialization.f90
+++ b/src/common/initialization.f90
@@ -500,13 +500,13 @@ subroutine check_ffte_condition(info,pinfo,lg)
 
     select case(ffte_parallel)
     case ('xy')
-      mz = mod(lg%num(3), pinfo%nprgrid(2))
-      my = mod(lg%num(2), pinfo%nprgrid(2))
-      if (mz /= 0 .or. my /= 0) stop 'Both lg%num(3) and lg%num(2) must be divisible by nproc_rgrid(2)'
-
-      my = mod(lg%num(2), pinfo%nprgrid(1))
+      mz = mod(lg%num(3), pinfo%nprgrid(1))
       mx = mod(lg%num(1), pinfo%nprgrid(1))
-      if (my /= 0 .or. mx /= 0) stop 'Both lg%num(2) and lg%num(1) must be divisible by nproc_rgrid(1)'
+      if (mz /= 0 .or. mx /= 0) stop 'Both lg%num(3) and lg%num(1) must be divisible by nproc_rgrid(1)'
+
+      mx = mod(lg%num(1), pinfo%nprgrid(2))
+      my = mod(lg%num(2), pinfo%nprgrid(2))
+      if (mx /= 0 .or. my /= 0) stop 'Both lg%num(1) and lg%num(2) must be divisible by nproc_rgrid(2)'
     case ('yz')
       mx = mod(lg%num(1), pinfo%nprgrid(2))
       my = mod(lg%num(2), pinfo%nprgrid(2))
@@ -774,8 +774,8 @@ subroutine init_reciprocal_grid(lg,mg,fg,system,info,poisson)
   ! FFTE
   select case(ffte_parallel)
   case ('xy')
-    allocate(poisson%a_ffte(lg%num(3),mg%num(2),mg%num(1)))
-    allocate(poisson%b_ffte(lg%num(3),mg%num(2),mg%num(1)))
+    allocate(poisson%a_ffte(lg%num(3),mg%num(1),mg%num(2)))
+    allocate(poisson%b_ffte(lg%num(3),mg%num(1),mg%num(2)))
   case ('yz')
     allocate(poisson%a_ffte(lg%num(1),mg%num(2),mg%num(3)))
     allocate(poisson%b_ffte(lg%num(1),mg%num(2),mg%num(3)))
@@ -784,9 +784,9 @@ subroutine init_reciprocal_grid(lg,mg,fg,system,info,poisson)
   ! FFTE initialization step
   select case(ffte_parallel)
   case ('xy')
-    call PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(3),lg%num(2),lg%num(1), &
-                      info%isize_y,info%isize_x,0, &
-                      info%icomm_y,info%icomm_x)
+    call PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(3),lg%num(1),lg%num(2), &
+                      info%isize_x,info%isize_y,0, &
+                      info%icomm_x,info%icomm_y)
   case ('yz')
     call PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(1),lg%num(2),lg%num(3), &
                       info%isize_y,info%isize_z,0, &

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -240,6 +240,7 @@ contains
       & nproc_ob, &
       & nproc_rgrid, &
       & yn_ffte, &
+      & ffte_parallel, &
       & yn_scalapack, &
       & yn_scalapack_red_mem, &
       & yn_eigenexa, &
@@ -583,6 +584,7 @@ contains
     nproc_ob             = 0
     nproc_rgrid          = 0
     yn_ffte              = 'n'
+    ffte_parallel        = 'yz'
     yn_scalapack         = 'n'
     yn_scalapack_red_mem = 'n'
     yn_eigenexa          = 'n'
@@ -973,6 +975,7 @@ contains
     call comm_bcast(nproc_ob            ,nproc_group_global)
     call comm_bcast(nproc_rgrid         ,nproc_group_global)
     call comm_bcast(yn_ffte             ,nproc_group_global)
+    call comm_bcast(ffte_parallel       ,nproc_group_global)
     call comm_bcast(yn_scalapack        ,nproc_group_global)
     call comm_bcast(yn_scalapack_red_mem ,nproc_group_global)
     call comm_bcast(yn_eigenexa         ,nproc_group_global)
@@ -1748,6 +1751,7 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",I5)') 'nproc_rgrid(2)', nproc_rgrid(2)
       write(fh_variables_log, '("#",4X,A,"=",I5)') 'nproc_rgrid(3)', nproc_rgrid(3)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'yn_ffte', yn_ffte
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'ffte_parallel', ffte_parallel
       write(fh_variables_log, '("#",4X,A,"=",A)') 'yn_scalapack', yn_scalapack
       write(fh_variables_log, '("#",4X,A,"=",A)') 'yn_scalapack_red_mem', yn_scalapack_red_mem
       write(fh_variables_log, '("#",4X,A,"=",A)') 'yn_eigenexa', yn_eigenexa

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -75,6 +75,7 @@ module salmon_global
   integer        :: nproc_ob
   integer        :: nproc_rgrid(3)
   character(1)   :: yn_ffte
+  character(2)   :: ffte_parallel
   character(1)   :: yn_scalapack
   character(1)   :: yn_scalapack_red_mem
   character(1)   :: yn_eigenexa

--- a/src/poisson/poisson_periodic.f90
+++ b/src/poisson/poisson_periodic.f90
@@ -151,6 +151,7 @@ end subroutine poisson_ft
 subroutine poisson_ffte(lg,mg,info,fg,rho,Vh,poisson)
   use structures
   use communication, only: comm_summation
+  use salmon_global, only: ffte_parallel
   implicit none
   type(s_rgrid)          ,intent(in) :: lg
   type(s_rgrid)          ,intent(in) :: mg
@@ -165,6 +166,58 @@ subroutine poisson_ffte(lg,mg,info,fg,rho,Vh,poisson)
   real(8) :: inv_lgnum3
 
   inv_lgnum3=1.d0/(lg%num(1)*lg%num(2)*lg%num(3))
+
+  select case (ffte_parallel)
+  case ('xy')
+
+  poisson%b_ffte=0.d0
+!$OMP parallel do private(iiz,iiy,ix) collapse(2)
+  do ix=1,mg%num(1)
+  do iy=1,mg%num(2)
+    iix=ix+mg%is(1)-1
+    iiy=iy+mg%is(2)-1
+    poisson%b_ffte(mg%is(3):mg%ie(3),iy,ix) = cmplx(rho%f(iix,iiy,mg%is(3):mg%ie(3)))
+  end do
+  end do
+  call comm_summation(poisson%b_ffte,poisson%a_ffte,size(poisson%a_ffte),info%icomm_z)
+
+  CALL PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(3),lg%num(2),lg%num(1),   &
+                    info%isize_y,info%isize_x,-1, &
+                    info%icomm_y,info%icomm_x)
+
+  poisson%zrhoG_ele=0d0
+!$omp parallel do collapse(2) default(none) &
+!$omp             private(iz,iy,ix,iiy,iiz,iix) &
+!$omp             shared(mg,lg,poisson,inv_lgnum3,fg)
+  do ix=1,mg%num(1)
+  do iy=1,mg%num(2)
+    iix=ix+mg%is(1)-1
+    iiy=iy+mg%is(2)-1
+    do iz=1,mg%num(3)
+      iiz=iz+mg%is(3)-1
+      poisson%zrhoG_ele(iix,iiy,iiz) = poisson%b_ffte(iiz,iy,ix)*inv_lgnum3
+    end do
+    do iz=1,lg%num(3)
+      poisson%b_ffte(iz,iy,ix) = poisson%b_ffte(iz,iy,ix) * fg%coef(iix,iiy,iz)
+    end do
+  end do
+  end do
+!$omp end parallel do
+
+  CALL PZFFT3DV_MOD(poisson%b_ffte,poisson%a_ffte,lg%num(3),lg%num(2),lg%num(1), &
+                    info%isize_y,info%isize_x,1, &
+                    info%icomm_y,info%icomm_x)
+
+!$OMP parallel do private(iix,iiy) collapse(2)
+  do ix=1,mg%num(1)
+  do iy=1,mg%num(2)
+    iix=ix+mg%is(1)-1
+    iiy=iy+mg%is(2)-1
+    Vh%f(iix,iiy,mg%is(3):mg%ie(3)) = poisson%a_ffte(mg%is(3):mg%ie(3),iy,ix)
+  end do
+  end do
+
+  case ('yz')
 
   poisson%b_ffte=0.d0
 !$OMP parallel do private(iiz,iiy,ix) collapse(2)
@@ -212,6 +265,8 @@ subroutine poisson_ffte(lg,mg,info,fg,rho,Vh,poisson)
     Vh%f(mg%is(1):mg%ie(1),iiy,iiz) = poisson%a_ffte(mg%is(1):mg%ie(1),iy,iz)
   end do
   end do
+
+  end select ! ffte_parallel
 
   return
 end subroutine poisson_ffte

--- a/src/poisson/poisson_periodic.f90
+++ b/src/poisson/poisson_periodic.f90
@@ -172,48 +172,48 @@ subroutine poisson_ffte(lg,mg,info,fg,rho,Vh,poisson)
 
   poisson%b_ffte=0.d0
 !$OMP parallel do private(iix,iiy,ix) collapse(2)
-  do ix=1,mg%num(1)
   do iy=1,mg%num(2)
-    iix=ix+mg%is(1)-1
+  do ix=1,mg%num(1)
     iiy=iy+mg%is(2)-1
-    poisson%b_ffte(mg%is(3):mg%ie(3),iy,ix) = cmplx(rho%f(iix,iiy,mg%is(3):mg%ie(3)))
+    iix=ix+mg%is(1)-1
+    poisson%b_ffte(mg%is(3):mg%ie(3),ix,iy) = cmplx(rho%f(iix,iiy,mg%is(3):mg%ie(3)))
   end do
   end do
   call comm_summation(poisson%b_ffte,poisson%a_ffte,size(poisson%a_ffte),info%icomm_z)
 
-  CALL PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(3),lg%num(2),lg%num(1),   &
-                    info%isize_y,info%isize_x,-1, &
-                    info%icomm_y,info%icomm_x)
+  CALL PZFFT3DV_MOD(poisson%a_ffte,poisson%b_ffte,lg%num(3),lg%num(1),lg%num(2),   &
+                    info%isize_x,info%isize_y,-1, &
+                    info%icomm_x,info%icomm_y)
 
   poisson%zrhoG_ele=0d0
 !$omp parallel do collapse(2) default(none) &
 !$omp             private(iz,iy,ix,iiy,iiz,iix) &
 !$omp             shared(mg,lg,poisson,inv_lgnum3,fg)
-  do ix=1,mg%num(1)
   do iy=1,mg%num(2)
-    iix=ix+mg%is(1)-1
+  do ix=1,mg%num(1)
     iiy=iy+mg%is(2)-1
+    iix=ix+mg%is(1)-1
     do iz=1,mg%num(3)
       iiz=iz+mg%is(3)-1
-      poisson%zrhoG_ele(iix,iiy,iiz) = poisson%b_ffte(iiz,iy,ix)*inv_lgnum3
+      poisson%zrhoG_ele(iix,iiy,iiz) = poisson%b_ffte(iiz,ix,iy)*inv_lgnum3
     end do
     do iz=1,lg%num(3)
-      poisson%b_ffte(iz,iy,ix) = poisson%b_ffte(iz,iy,ix) * fg%coef(iix,iiy,iz)
+      poisson%b_ffte(iz,ix,iy) = poisson%b_ffte(iz,ix,iy) * fg%coef(iix,iiy,iz)
     end do
   end do
   end do
 !$omp end parallel do
 
-  CALL PZFFT3DV_MOD(poisson%b_ffte,poisson%a_ffte,lg%num(3),lg%num(2),lg%num(1), &
-                    info%isize_y,info%isize_x,1, &
-                    info%icomm_y,info%icomm_x)
+  CALL PZFFT3DV_MOD(poisson%b_ffte,poisson%a_ffte,lg%num(3),lg%num(1),lg%num(2), &
+                    info%isize_x,info%isize_y,1, &
+                    info%icomm_x,info%icomm_y)
 
 !$OMP parallel do private(iix,iiy) collapse(2)
-  do ix=1,mg%num(1)
   do iy=1,mg%num(2)
-    iix=ix+mg%is(1)-1
+  do ix=1,mg%num(1)
     iiy=iy+mg%is(2)-1
-    Vh%f(iix,iiy,mg%is(3):mg%ie(3)) = poisson%a_ffte(mg%is(3):mg%ie(3),iy,ix)
+    iix=ix+mg%is(1)-1
+    Vh%f(iix,iiy,mg%is(3):mg%ie(3)) = poisson%a_ffte(mg%is(3):mg%ie(3),ix,iy)
   end do
   end do
 

--- a/src/poisson/poisson_periodic.f90
+++ b/src/poisson/poisson_periodic.f90
@@ -171,7 +171,7 @@ subroutine poisson_ffte(lg,mg,info,fg,rho,Vh,poisson)
   case ('xy')
 
   poisson%b_ffte=0.d0
-!$OMP parallel do private(iiz,iiy,ix) collapse(2)
+!$OMP parallel do private(iix,iiy,ix) collapse(2)
   do ix=1,mg%num(1)
   do iy=1,mg%num(2)
     iix=ix+mg%is(1)-1


### PR DESCRIPTION
```
&parallel
  yn_ffte = 'y'
  ffte_parallel = 'yz' or 'xy'
/
```

- `ffte_parallel = 'yz'`
    - default, usual parallelization.
- `ffte_parallel = 'xy'`
    - swap XY and Z direction. (XYZ -> ZXY)