### PR TITLE
Bugfix: declared a new variable as shared in omp parallelization.

### DIFF
--- a/src/common/force.f90
+++ b/src/common/force.f90
@@ -190,6 +190,7 @@ contains
 !$omp   private(jlma,l,n,m1,m2,ddm_mms_nla,gtpsi) &
 !$omp   shared(im,ik_s,ik_e,io_s,io_e,nspin,tpsi,mg,stencil,system,ppg,uVpsibox2,yn_periodic) &
 !$omp   shared(PLUS_U_ON,Nlma_ao,phipsibox2,iorb,zF_tmp,U_eff,dm_mms_nla) &
+!$omp   shared(dden) &
 !$omp   reduction(+:F_tmp) &
 !$omp   if(force_omp_mode)
 


### PR DESCRIPTION
In the pull request #867, a new valuable `dden` was introduced. However, the valuable was not declared in the OMP directive, and `default(none)` is used int the code. As a result, the compilation of SALMON seems to fail in some compilers with some options; I failed to compile SALMON with gfortran.

In this pull request, `dden` is now declared as a shared valuable.