### PR TITLE
Add OpenACC pragma

### DIFF
--- a/src/common/density_matrix.f90
+++ b/src/common/density_matrix.f90
@@ -58,7 +58,6 @@ contains
 
     if(allocated(psi%rwf)) then
 
-#ifndef USE_OPENACC
       do im=info%im_s,info%im_e
       do ispin=1,nspin
         call timer_begin(LOG_DENSITY_CALC)
@@ -99,7 +98,6 @@ contains
         call timer_end(LOG_DENSITY_COMM_COLL)
       end do
       end do
-#endif
 
     else
 

--- a/src/common/zstencil_core/typical/seq.f90
+++ b/src/common/zstencil_core/typical/seq.f90
@@ -17,6 +17,7 @@
 subroutine zstencil_typical_seq(is_array,ie_array,is,ie,idx,idy,idz,igs,ige &
                                ,tpsi,htpsi,V_local,lap0,lapt,nabt &
                                )
+  !$acc routine worker
   implicit none
 
   integer,intent(in) :: is_array(3),ie_array(3),is(3),ie(3)
@@ -53,6 +54,7 @@ subroutine zstencil_typical_seq(is_array,ie_array,is,ie,idx,idy,idz,igs,ige &
 #define DY(dt) ix,idy(iy+(dt)),iz
 #define DZ(dt) ix,iy,idz(iz+(dt))
 
+  !$acc loop collapse(3)
   do iz=igs(3),ige(3)
   do iy=igs(2),ige(2)
 

--- a/src/gs/conjugate_gradient.f90
+++ b/src/gs/conjugate_gradient.f90
@@ -383,8 +383,8 @@ subroutine gscg_zwf(ncg,mg,system,info,stencil,ppg,vlocal,srg,spsi,cg)
     call allocate_orbital_complex(nspin,mg,info,cg%gk)
     call allocate_orbital_complex(nspin,mg,info,cg%pko)
     call allocate_orbital_complex(nspin,mg,info,cg%hwf)
+    !$acc enter data copyin(cg)
   end if
-  !$acc enter data copyin(cg)
 
 !$omp parallel do private(ik,io,ispin,iz,iy) collapse(5)
   do ik=ik_s,ik_e

--- a/src/poisson/poisson_periodic.f90
+++ b/src/poisson/poisson_periodic.f90
@@ -36,18 +36,21 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   integer :: ix,iy,iz,kx,ky,kz
 
 #ifdef USE_OPENACC
-!$acc kernels
+!$acc kernels copyin(poisson)
 #else
 !$omp workshare
 #endif
   poisson%ff1z = 0d0
-#ifdef USE_OPENACC
-!$acc end kernels
-#else
+#ifndef USE_OPENACC
 !$omp end workshare
 #endif
 
+
+#ifdef USE_OPENACC
+!$acc loop private(iz,iy,ix)
+#else
 !$OMP parallel do private(iz,iy,ix)
+#endif
   do iz=mg%is(3),mg%ie(3)
   do iy=mg%is(2),mg%ie(2)
   do ix=mg%is(1),mg%ie(1)
@@ -55,22 +58,27 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
 
   call comm_summation(poisson%ff1z,poisson%ff2z,mg%num(1)*mg%num(2)*lg%num(3),info%icomm_z)
 
 #ifdef USE_OPENACC
-!$acc kernels
+!$acc kernels copyin(poisson)
 #else
 !$omp workshare
 #endif
   poisson%ff1y = 0d0
-#ifdef USE_OPENACC
-!$acc end kernels
-#else
+#ifndef USE_OPENACC
 !$omp end workshare
 #endif
 
+#ifdef USE_OPENACC
+!$acc loop private(kz,iy,ix)
+#else
 !$OMP parallel do private(kz,iy,ix)
+#endif
   do kz = mg%is(3),mg%ie(3)
   do iy = mg%is(2),mg%ie(2)
   do ix = mg%is(1),mg%ie(1)
@@ -78,21 +86,26 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
   call comm_summation(poisson%ff1y,poisson%ff2y,mg%num(1)*lg%num(2)*mg%num(3),info%icomm_y)
 
 #ifdef USE_OPENACC
-!$acc kernels
+!$acc kernels copyin(poisson)
 #else
 !$omp workshare
 #endif
   poisson%ff1x = 0.d0
-#ifdef USE_OPENACC
-!$acc end kernels
-#else
+#ifndef USE_OPENACC
 !$omp end workshare
 #endif
 
+#ifdef USE_OPENACC
+!$acc loop private(kz,ky,ix)
+#else
 !$OMP parallel do private(kz,ky,ix)
+#endif
   do kz = mg%is(3),mg%ie(3)
   do ky = mg%is(2),mg%ie(2)
   do ix = mg%is(1),mg%ie(1)
@@ -100,10 +113,18 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
 
   call comm_summation(poisson%ff1x,poisson%ff2x,lg%num(1)*mg%num(2)*mg%num(3),info%icomm_x)
 
+#ifdef USE_OPENACC
+!$acc kernels copyin(poisson)
+!$acc loop private(kz,ky,kx)
+#else
 !$OMP parallel do private(kz,ky,kx)
+#endif
   do kz = mg%is(3),mg%ie(3)
   do ky = mg%is(2),mg%ie(2)
   do kx = mg%is(1),mg%ie(1)
@@ -111,22 +132,27 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
 
   call comm_summation(poisson%ff1x,poisson%ff2x,lg%num(1)*mg%num(2)*mg%num(3),info%icomm_x)
 
 #ifdef USE_OPENACC
-!$acc kernels
+!$acc kernels copyin(poisson)
 #else
 !$omp workshare
 #endif
   poisson%ff1z = 0.d0
-#ifdef USE_OPENACC
-!$acc end kernels
-#else
+#ifndef USE_OPENACC
 !$omp end workshare
 #endif
 
+#ifdef USE_OPENACC
+!$acc loop private(kz,ky,kx)
+#else
 !$OMP parallel do private(kz,ky,kx)
+#endif
   do kz = mg%is(3),mg%ie(3)
   do ky = mg%is(2),mg%ie(2)
   do kx = mg%is(1),mg%ie(1)
@@ -135,22 +161,27 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
 
   call comm_summation(poisson%ff1z,poisson%ff2z,mg%num(1)*mg%num(2)*lg%num(3),info%icomm_z)
 
 #ifdef USE_OPENACC
-!$acc kernels
+!$acc kernels copyin(poisson)
 #else
 !$omp workshare
 #endif
   poisson%ff1y = 0.d0
-#ifdef USE_OPENACC
-!$acc end kernels
-#else
+#ifndef USE_OPENACC
 !$omp end workshare
 #endif
 
+#ifdef USE_OPENACC
+!$acc loop private(iz,ky,kx)
+#else
 !$OMP parallel do private(iz,ky,kx)
+#endif
   do iz = mg%is(3),mg%ie(3)
   do ky = mg%is(2),mg%ie(2)
   do kx = mg%is(1),mg%ie(1)
@@ -158,21 +189,26 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
   call comm_summation(poisson%ff1y,poisson%ff2y,mg%num(1)*lg%num(2)*mg%num(3),info%icomm_y)
 
 #ifdef USE_OPENACC
-!$acc kernels
+!$acc kernels copyin(poisson)
 #else
 !$omp workshare
 #endif
   poisson%ff1x = 0.d0
-#ifdef USE_OPENACC
-!$acc end kernels
-#else
+#ifndef USE_OPENACC
 !$omp end workshare
 #endif
 
+#ifdef USE_OPENACC
+!$acc loop private(iz,iy,kx)
+#else
 !$OMP parallel do private(iz,iy,kx)
+#endif
   do iz = mg%is(3),mg%ie(3)
   do iy = mg%is(2),mg%ie(2)
   do kx = mg%is(1),mg%ie(1)
@@ -180,9 +216,17 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
   call comm_summation(poisson%ff1x,poisson%ff2x,lg%num(1)*mg%num(2)*mg%num(3),info%icomm_x)
 
+#ifdef USE_OPENACC
+!$acc kernels copyin(poisson)
+!$acc loop private(iz,iy,ix)
+#else
 !$OMP parallel do private(iz,iy,ix)
+#endif
   do iz = mg%is(3),mg%ie(3)
   do iy = mg%is(2),mg%ie(2)
   do ix = mg%is(1),mg%ie(1)
@@ -190,6 +234,9 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
 
   return
 end subroutine poisson_ft

--- a/src/poisson/poisson_periodic.f90
+++ b/src/poisson/poisson_periodic.f90
@@ -35,9 +35,17 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   !
   integer :: ix,iy,iz,kx,ky,kz
 
+#ifdef USE_OPENACC
+!$acc kernels
+#else
 !$omp workshare
+#endif
   poisson%ff1z = 0d0
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end workshare
+#endif
 
 !$OMP parallel do private(iz,iy,ix)
   do iz=mg%is(3),mg%ie(3)
@@ -50,9 +58,17 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
 
   call comm_summation(poisson%ff1z,poisson%ff2z,mg%num(1)*mg%num(2)*lg%num(3),info%icomm_z)
 
+#ifdef USE_OPENACC
+!$acc kernels
+#else
 !$omp workshare
+#endif
   poisson%ff1y = 0d0
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end workshare
+#endif
 
 !$OMP parallel do private(kz,iy,ix)
   do kz = mg%is(3),mg%ie(3)
@@ -64,9 +80,17 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   call comm_summation(poisson%ff1y,poisson%ff2y,mg%num(1)*lg%num(2)*mg%num(3),info%icomm_y)
 
+#ifdef USE_OPENACC
+!$acc kernels
+#else
 !$omp workshare
+#endif
   poisson%ff1x = 0.d0
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end workshare
+#endif
 
 !$OMP parallel do private(kz,ky,ix)
   do kz = mg%is(3),mg%ie(3)
@@ -90,9 +114,17 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
 
   call comm_summation(poisson%ff1x,poisson%ff2x,lg%num(1)*mg%num(2)*mg%num(3),info%icomm_x)
 
+#ifdef USE_OPENACC
+!$acc kernels
+#else
 !$omp workshare
+#endif
   poisson%ff1z = 0.d0
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end workshare
+#endif
 
 !$OMP parallel do private(kz,ky,kx)
   do kz = mg%is(3),mg%ie(3)
@@ -106,9 +138,17 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
 
   call comm_summation(poisson%ff1z,poisson%ff2z,mg%num(1)*mg%num(2)*lg%num(3),info%icomm_z)
 
+#ifdef USE_OPENACC
+!$acc kernels
+#else
 !$omp workshare
+#endif
   poisson%ff1y = 0.d0
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end workshare
+#endif
 
 !$OMP parallel do private(iz,ky,kx)
   do iz = mg%is(3),mg%ie(3)
@@ -120,9 +160,17 @@ subroutine poisson_ft(lg,mg,info,fg,rho,Vh,poisson)
   end do
   call comm_summation(poisson%ff1y,poisson%ff2y,mg%num(1)*lg%num(2)*mg%num(3),info%icomm_y)
 
+#ifdef USE_OPENACC
+!$acc kernels
+#else
 !$omp workshare
+#endif
   poisson%ff1x = 0.d0
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end workshare
+#endif
 
 !$OMP parallel do private(iz,iy,kx)
   do iz = mg%is(3),mg%ie(3)

--- a/src/xc/builtin_pz.f90
+++ b/src/xc/builtin_pz.f90
@@ -32,7 +32,11 @@ contains
     ! rho_s=rho*0.5d0
     ! if(flag_nlcc)rho_s = rho_s + 0.5d0*rho_nlcc
     
+#ifdef USE_OPENACC
+!$acc kernels loop private(i,trho,e_xc,de_xc_drho)
+#else
 !$omp parallel do private(i,trho,e_xc,de_xc_drho)
+#endif
     do i=1,NL
       trho=2*rho_s(i)
       call PZxc(trho,e_xc,de_xc_drho)
@@ -40,12 +44,16 @@ contains
       Eexc(i)=e_xc*trho
       Vexc(i)=e_xc+trho*de_xc_drho
     enddo
+#ifdef USE_OPENACC
+!$acc end kernels
+#endif
     return
   end subroutine exc_cor_pz
 
 
 
   Subroutine PZxc(trho,exc,dexc_drho)
+    !$acc routine seq
     implicit none
     real(8),parameter :: Pi=3.141592653589793d0
     real(8),parameter :: gammaU=-0.1423d0,beta1U=1.0529d0


### PR DESCRIPTION
Add OpenACC pragma for Nvidia A100.
Fix minor non-conformance.

## Include content
Following subroutines are support OpenACC.
 - exc_cor_pz
 - poisson_ft 
 - hpsi
 - stencil_current (called by calc_current)
 - stencil_current_local (called by calc_current)

Followings are adjusted.
 -  incorrect macro in `allocated(psi%rwf)` branch at calc_density subroutine.
 - `copyin` at gscg_zwf.

## How to build
Build:
```bash
module load hpc_sdk/20.9
mkdir build
cd build
python3 ../configure.py --enable-mpi --arch=pgi-openacc
make -j
```

## Validation
I run bulkSi(https://github.com/SALMON-TDDFT/SALMON2-evaluation-scripts/tree/master/nvidia-gpu/bulkSi) step2 with A100. I compared Intel CPU result with A100 result. The difference were less than 1e-08.