### PR TITLE
Add openacc pragma for bulkSi

### DIFF
--- a/src/common/hamiltonian.f90
+++ b/src/common/hamiltonian.f90
@@ -839,7 +839,12 @@ subroutine update_kvector_nonlocalpt(ik_s,ik_e,system,ppg)
   
   if(.not.allocated(ppg%zekr_uV)) allocate(ppg%zekr_uV(ppg%nps,ppg%nlma,ik_s:ik_e))
 
+#ifdef USE_OPENACC
+!$acc kernels
+!$acc loop collapse(2) private(ik,ilma,iatom,j,x,y,z,ekr)
+#else
 !$omp parallel do collapse(2) private(ik,ilma,iatom,j,x,y,z,ekr)
+#endif
   do ik=ik_s,ik_e
     do ilma=1,ppg%nlma
       iatom = ppg%ia_tbl(ilma)
@@ -852,7 +857,11 @@ subroutine update_kvector_nonlocalpt(ik_s,ik_e,system,ppg)
       end do
     end do
   end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end parallel do  
+#endif
 
   deallocate(kAc)
   return

--- a/src/common/hamiltonian.f90
+++ b/src/common/hamiltonian.f90
@@ -795,7 +795,11 @@ subroutine update_vlocal(mg,nspin,Vh,Vpsl,Vxc,Vlocal)
   integer :: is,ix,iy,iz
 
   do is=1,nspin
+#ifdef USE_OPENACC
+!$acc parallel loop collapse(2) private(ix,iy,iz)
+#else
 !$omp parallel do collapse(2) private(ix,iy,iz)
+#endif
     do iz=mg%is(3),mg%ie(3)
     do iy=mg%is(2),mg%ie(2)
     do ix=mg%is(1),mg%ie(1)
@@ -803,6 +807,9 @@ subroutine update_vlocal(mg,nspin,Vh,Vpsl,Vxc,Vlocal)
     end do
     end do
     end do
+#ifdef USE_OPENACC
+!$acc end parallel
+#endif
   end do
 
   return

--- a/src/common/total_energy.f90
+++ b/src/common/total_energy.f90
@@ -132,6 +132,7 @@ CONTAINS
     !
     integer :: ix,iy,iz,iia,ia,ib,zps1,zps2,ipair
     real(8) :: rr,rab(3),r(3),E_tmp,E_tmp_l,g(3),Gd,sysvol,E_wrk(5),E_sum(5)
+    real(8) :: E_wrk_local_1,E_wrk_local_2
     real(8) :: etmp
     complex(8) :: rho_e,rho_i
 
@@ -145,7 +146,12 @@ CONTAINS
 
       if(ewald%yn_bookkeep=='y') then
 
+#ifdef USE_OPENACC
+!$acc kernels
+!$acc loop private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr) reduction(+:E_tmp)
+#else
 !$omp parallel do private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr) reduction(+:E_tmp)
+#endif
          do iia=1,info%nion_mg
         !do ia=1,system%nion
             ia = info%ia_mg(iia)
@@ -173,7 +179,11 @@ CONTAINS
 
             end do  !ipair
          end do     !ia
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end parallel do
+#endif
 
 
       else
@@ -181,10 +191,15 @@ CONTAINS
 
       endif
 
+#ifdef USE_OPENACC
+!$acc kernels
+!$acc loop collapse(2) reduction(+:E_tmp_l) private(ix,iy,iz,rho_i)
+#else
 !$omp parallel do collapse(2) default(none) &
 !$omp          reduction(+:E_tmp_l) &
 !$omp          private(ix,iy,iz,rho_i) &
 !$omp          shared(fg,aEwald,sysvol,mg,ppg)
+#endif
       do iz=mg%is(3),mg%ie(3)
       do iy=mg%is(2),mg%ie(2)
       do ix=mg%is(1),mg%ie(1)
@@ -193,11 +208,45 @@ CONTAINS
       end do
       end do
       end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end parallel do
+#endif
     end if
 
     etmp = 0d0
     E_wrk = 0d0
+#ifdef USE_OPENACC
+!$acc parallel copyin(yn_jm)
+!$acc loop collapse(2) reduction(+:E_wrk_local_1,E_wrk_local_2,etmp) private(ix,iy,iz,g,rho_i,rho_e,ia,r,Gd)
+    do iz=mg%is(3),mg%ie(3)
+    do iy=mg%is(2),mg%ie(2)
+    do ix=mg%is(1),mg%ie(1)
+      g(1) = fg%vec_G(1,ix,iy,iz)
+      g(2) = fg%vec_G(2,ix,iy,iz)
+      g(3) = fg%vec_G(3,ix,iy,iz)
+      
+      rho_e = poisson%zrhoG_ele(ix,iy,iz)
+      E_wrk_local_1 = E_wrk_local_1 + sysvol* fg%coef(ix,iy,iz) * (abs(rho_e)**2*0.5d0)     ! Hartree
+      
+      if (yn_jm=='n') then
+        rho_i = ppg%zrhoG_ion(ix,iy,iz)
+        E_wrk_local_2 = E_wrk_local_2 + sysvol* fg%coef(ix,iy,iz) * (-rho_e*conjg(rho_i))     ! electron-ion (valence)
+        
+        do ia=info%ia_s,info%ia_e
+          r = system%Rion(1:3,ia)
+          Gd = g(1)*r(1) + g(2)*r(2) + g(3)*r(3)
+          etmp = etmp + conjg(rho_e)*ppg%zVG_ion(ix,iy,iz,Kion(ia))*exp(-zI*Gd)  ! electron-ion (core)
+        end do
+      end if
+    end do
+    end do
+    end do
+!$acc end parallel
+    E_wrk(1) = E_wrk_local_1
+    E_wrk(2) = E_wrk_local_2
+#else
 !$omp parallel do collapse(2) default(none) &
 !$omp          reduction(+:E_wrk,etmp) &
 !$omp          private(ix,iy,iz,g,rho_i,rho_e,ia,r,Gd) &
@@ -226,6 +275,7 @@ CONTAINS
     end do
     end do
 !$omp end parallel do
+#endif
     call timer_end(LOG_TE_PERIODIC_CALC)
 
     call timer_begin(LOG_TE_PERIODIC_COMM_COLL)
@@ -240,12 +290,21 @@ CONTAINS
   ! ion-ion energy
       zps1 = 0
       zps2 = 0
+#ifdef USE_OPENACC
+!$acc kernels
+!$acc loop private(ia) reduction(+:zps1,zps2)
+#else
 !$omp parallel do default(none) private(ia) shared(system,pp,Kion) reduction(+:zps1,zps2)
+#endif
       do ia=1,system%nion
         zps1 = zps1 + pp%Zps(Kion(ia))
         zps2 = zps2 + pp%Zps(Kion(ia))**2
       end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end parallel do
+#endif
 
       E_sum(5) = E_sum(5) - Pi*zps1**2/(2*aEwald*sysvol) - sqrt(aEwald/Pi)*zps2
       energy%E_ion_ion = E_sum(5) + E_sum(4)

--- a/src/math/salmon_math.f90
+++ b/src/math/salmon_math.f90
@@ -32,6 +32,7 @@ contains
 !! Error function and its complement are implemented based on the reference
 !! W. J. Cody, Math. Comp. 23 631 (1969)
   function erf_salmon(x) result(y)
+    !$acc routine seq
     implicit none
     real(8),intent(in) :: x
     real(8) :: y
@@ -51,6 +52,7 @@ contains
   end function erf_salmon
 !--------------------------------------------------------------------------------
   function erfc_salmon(x) result(y)
+    !$acc routine seq
     implicit none
     real(8),intent(in) :: x
     real(8) :: y
@@ -70,6 +72,7 @@ contains
   end function erfc_salmon
 !--------------------------------------------------------------------------------
   function erf_salmon_short(x) result(y) ! 0d0 <=x<0.5d0
+    !$acc routine seq
     implicit none
     real(8),intent(in) :: x
     real(8) :: y
@@ -98,6 +101,7 @@ contains
   end function erf_salmon_short
 !--------------------------------------------------------------------------------
   function erfc_salmon_mid(x) result(y) ! 0.46875d0 <x< 4d0
+    !$acc routine seq
     implicit none
     real(8),intent(in) :: x
     real(8) :: y
@@ -136,6 +140,7 @@ contains
   end function erfc_salmon_mid
 !--------------------------------------------------------------------------------
   function erfc_salmon_long(x) result(y) ! 4d0 <x
+    !$acc routine seq
     use math_constants, only : pi
     implicit none
     real(8),intent(in) :: x

--- a/src/xc/salmon_xc.f90
+++ b/src/xc/salmon_xc.f90
@@ -83,7 +83,11 @@ contains
     nspin = system%nspin
 
     if(nspin==1)then
+#ifdef USE_OPENACC
+!$acc kernels loop collapse(2) private(iz,iy,ix)
+#else
 !$omp parallel do collapse(2) private(iz,iy,ix)
+#endif
       do iz=1,mg%num(3)
       do iy=1,mg%num(2)
       do ix=1,mg%num(1)
@@ -91,7 +95,11 @@ contains
       end do
       end do
       end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end parallel do
+#endif
     else if(nspin==2)then
 !$omp parallel private(is,iz,iy,ix)
       do is=1,2
@@ -161,7 +169,11 @@ contains
     end if
 
     if(nspin==1)then
+#ifdef USE_OPENACC
+!$acc kernels loop collapse(2) private(iz,iy,ix)
+#else
 !$omp parallel do collapse(2) private(iz,iy,ix)
+#endif
       do iz=1,mg%num(3)
       do iy=1,mg%num(2)
       do ix=1,mg%num(1)
@@ -169,7 +181,11 @@ contains
       end do
       end do
       end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end parallel do
+#endif
     else if(nspin==2)then
 !$omp parallel private(is,iz,iy,ix)
       do is=1,2
@@ -187,7 +203,11 @@ contains
     end if
 
     tot_exc=0.d0
+#ifdef USE_OPENACC
+!$acc kernels loop collapse(2) reduction(+:tot_exc) private(iz,iy,ix)
+#else
 !$omp parallel do collapse(2) reduction(+:tot_exc) private(iz,iy,ix)
+#endif
     do iz=1,mg%num(3)
     do iy=1,mg%num(2)
     do ix=1,mg%num(1)
@@ -195,7 +215,11 @@ contains
     end do
     end do
     end do
+#ifdef USE_OPENACC
+!$acc end kernels
+#else
 !$omp end parallel do
+#endif
     tot_exc = tot_exc*system%hvol
 
     call comm_summation(tot_exc,E_xc,info%icomm_r)


### PR DESCRIPTION
 - Add OpenACC pragma for Nvidia A100.
 - All OpenMP loop called by bulkSi step2 changed to OpenACC loop.

## Include content
Following subroutines are support OpenACC.
 - exchange_correlation
 - calc_eigen_energy
 - calc_Total_Energy_periodic
 - taylor
 - update_kvector_nonlocalpt
 - update_vlocal

## Performance
conditions:
 - input: bulkSi(https://github.com/SALMON-TDDFT/SALMON2-evaluation-scripts/tree/master/nvidia-gpu/bulkSi)
 - H/W: Nvidia A100(CPU 1core * 1threads) vs Xeon Gold 6242(4procs * 8threads)

result:
 - A100: total calculation time,11.73511505
 - Xeon: total calculation time,46.34086394

## How to build
Build:
```bash
module load hpc_sdk/20.9
mkdir build
cd build
python3 ../configure.py --enable-mpi --arch=pgi-openacc
make -j
```

## Validation
I run bulkSi(https://github.com/SALMON-TDDFT/SALMON2-evaluation-scripts/tree/master/nvidia-gpu/bulkSi) step2 with A100. I compared Intel CPU result with A100 result. The difference were less than 1e-08.