### PR TITLE
Fixed a bug for c-interpretable kind in the IO routines.

### DIFF
--- a/src/io/filesystem.f90
+++ b/src/io/filesystem.f90
@@ -69,7 +69,7 @@ contains
     implicit none
     character(*), intent(in) :: filepath
     logical :: ret
-    integer :: retcode
+    integer(c_int) :: retcode
     call posix_file_exists(adjustl(trim(filepath))//c_null_char, retcode)
     ret = (retcode == 1) ! success
   end function
@@ -81,7 +81,7 @@ contains
     implicit none
     character(*), intent(in) :: dirpath
     logical :: ret
-    integer :: retcode
+    integer(c_int) :: retcode
     call posix_directory_exists(adjustl(trim(dirpath))//c_null_char, retcode)
     ret = (retcode == 1) ! success
   end function
@@ -91,7 +91,7 @@ contains
     implicit none
     character(*), intent(in) :: dirpath
     integer, intent(out), optional :: iret
-    integer :: retcode
+    integer(c_int) :: retcode
     if (.not. directory_exists(dirpath)) then
       call posix_mkdir(adjustl(trim(dirpath))//c_null_char, retcode)
       if (present(iret)) then
@@ -108,7 +108,7 @@ contains
   subroutine remove_file(filepath)
     implicit none
     character(*), intent(in) :: filepath
-    integer :: retcode
+    integer(c_int) :: retcode
     if (file_exists(filepath)) then
       call stdio_remove(adjustl(trim(filepath))//c_null_char, retcode)
       if (retcode /= 0) then
@@ -124,7 +124,7 @@ contains
   subroutine remove_directory(dirpath)
     implicit none
     character(*), intent(in) :: dirpath
-    integer :: retcode
+    integer(c_int) :: retcode
     if (directory_exists(dirpath)) then
       call stdio_remove(adjustl(trim(dirpath))//c_null_char, retcode)
       if (retcode /= 0) then
@@ -143,7 +143,7 @@ contains
   subroutine force_remove(entry_path)
     implicit none
     character(*), intent(in) :: entry_path
-    integer :: retcode
+    integer(c_int) :: retcode
     if (file_exists(entry_path)) then
       call remove_file(entry_path)
     else if (directory_exists(entry_path)) then


### PR DESCRIPTION
There were type mismatches for the c-interpretable arguments of the IO routines. If Fortran and C have different default kinds, the compilation fails due to the inconsistent variable declarations.
To solve this problem, now the corresponding variables are declared as c-interpretable variables.
