### PR TITLE
Debug calc_current(OpenACC)

### DIFF
--- a/src/common/density_matrix.f90
+++ b/src/common/density_matrix.f90
@@ -120,9 +120,10 @@ contains
         tid = 0
 #ifdef USE_OPENACC
         wrk(:,:,:,tid) = 0.d0
+        tid_offset = size(wrk,4)/2
 
 !$acc kernels copyin(is,ie)
-!$acc loop collapse(2) private(wrk2,ik,io,iz,iy,ix)
+!$acc loop collapse(2) gang worker(256) private(wrk2,ik,io,iz,iy,ix)
         do ik=info%ik_s,info%ik_e
         do io=info%io_s,info%io_e
         do iz=is(3),ie(3)
@@ -135,11 +136,10 @@ contains
         end do
         end do
         end do
-!$acc loop collapse(3) private(tid_offset,ik,io,iz,iy,ix)
+!$acc loop collapse(3) private(tid_offset,iz,iy,ix)
         do iz=is(3),ie(3)
         do iy=is(2),ie(2)
         do ix=is(1),ie(1)
-        tid_offset = size(wrk,4)/2
         do while(tid_offset > 0)
           if(tid < tid_offset .and. tid + tid_offset < nthreads) then
             wrk(ix,iy,iz,tid) = wrk(ix,iy,iz,tid) + wrk(ix,iy,iz,tid + tid_offset)

--- a/src/common/density_matrix.f90
+++ b/src/common/density_matrix.f90
@@ -132,16 +132,21 @@ contains
         end do
         end do
         end do
-!$acc end kernels
-
-!!$acc end kernels
+!$acc loop collapse(3) private(ix)
+        do iz=is(3),ie(3)
+        do iy=is(2),ie(2)
+        do ix=is(1),ie(1)
         ix = size(wrk,4)/2
         do while(ix > 0)
           if(tid < ix .and. tid + ix < nthreads) then
-            wrk(:,:,:,tid) = wrk(:,:,:,tid) + wrk(:,:,:,tid + ix)
+            wrk(ix,iy,iz,tid) = wrk(ix,iy,iz,tid) + wrk(ix,iy,iz,tid + ix)
           end if
           ix = ix/2
         end do
+        end do
+        end do
+        end do
+!$acc end kernels
 
 #else
 !$omp parallel private(ik,io,iz,iy,ix,wrk2) firstprivate(tid)


### PR DESCRIPTION
- Debug calc_current subroutine with OpenACC.
- As a result, the performance of bulkSi deteriorated.
   - Modify separately if necessary.