### PR TITLE
Support HPC SDK 21.5(OpenACC)

### DIFF
--- a/src/common/total_energy.f90
+++ b/src/common/total_energy.f90
@@ -217,6 +217,8 @@ CONTAINS
 
     etmp = 0d0
     E_wrk = 0d0
+    E_wrk_local_1 =0d0
+    E_wrk_local_2 =0d0
 #ifdef USE_OPENACC
 !$acc parallel copyin(yn_jm)
 !$acc loop collapse(2) reduction(+:E_wrk_local_1,E_wrk_local_2,etmp) private(ix,iy,iz,g,rho_i,rho_e,ia,r,Gd)

--- a/src/common/zstencil_core/gpu/seq.f90
+++ b/src/common/zstencil_core/gpu/seq.f90
@@ -73,8 +73,8 @@ subroutine zstencil_typical_gpu(io_s,io_e,Nspin,is_array,ie_array,is,ie,idx,idy,
   do ix=igs(1),ige(1)
     t_0 = tpsi(DX( 1), ispin, io)
     t_1 = tpsi(DX(-1), ispin, io)
-    v=lapt(1)*(t_0+t_1) + v
-    w=nabt(1)*(t_0-t_1) + w
+    v=lapt(1)*(t_0+t_1)
+    w=nabt(1)*(t_0-t_1)
 
     t_0 = tpsi(DX( 2), ispin, io)
     t_1 = tpsi(DX(-2), ispin, io)


### PR DESCRIPTION
Avoid "uninitialized variables" for HPC SDK 21.5.

In HPC SDK 21.5, uninitialized variables are treated as NaN.
In HPC SDK 20.9, uninitialized variables are treated as 0. So, uninitialized variables was not a problem.
