### PR TITLE
Fixed atomic_create_directory routine by adding synchronization

### DIFF
--- a/src/io/filesystem.f90
+++ b/src/io/filesystem.f90
@@ -168,6 +168,10 @@ contains
       call create_directory(dirpath)
     end if
 
+    ! wait until the root process creates the directory
+    ! to avoid potential conflict between directory_exists() and posix_mkdir()...
+    call comm_sync_all(igroup)
+
     ! busy-wait until all process can read the directory...
     do while(.true.)
       if (directory_exists(dirpath)) then


### PR DESCRIPTION
In some conditions, `atomic_create_directory` routine is not properly executed, and the program is frozen since all the processes except the root process waits the directory creation by the root. This failure seems to be caused by the conflict between `create_directory()` and `directory_exists()`. Thus, I added the synchronization to avoid it. After the addition of the synchronization, the failure has not been observed.