### PR TITLE
Fixed the condition for the shutdown

### DIFF
--- a/src/rt/main_tddft.f90
+++ b/src/rt/main_tddft.f90
@@ -22,8 +22,8 @@ subroutine main_tddft
 use math_constants, only: pi
 use salmon_global
 use structures
-use parallelization, only: adjust_elapse_time
-use communication, only: comm_is_root, comm_sync_all
+use parallelization, only: adjust_elapse_time, nproc_group_global
+use communication, only: comm_is_root, comm_sync_all, comm_bcast
 use salmon_xc, only: finalize_xc
 use timer
 use write_sub, only: write_response_0d,write_response_3d,write_pulse_0d,write_pulse_3d

--- a/src/rt/main_tddft.f90
+++ b/src/rt/main_tddft.f90
@@ -57,7 +57,7 @@ type(s_pp_nlcc) :: ppn
 type(s_singlescale) :: singlescale
 
 integer :: Mit, itt
-logical :: is_checkpoint_iter, is_shutdown_time
+logical :: is_checkpoint_iter, is_shutdown_time, is_checkpoint
 
 !check condition for using jellium model
 if(yn_jm=='y') call check_condition_jm
@@ -100,7 +100,11 @@ TE : do itt=Mit+1,nt
   is_checkpoint_iter = (checkpoint_interval >= 1) .and. (mod(itt,checkpoint_interval) == 0)
   is_shutdown_time   = (time_shutdown > 0d0) .and. (adjust_elapse_time(timer_now(LOG_TOTAL)) > time_shutdown)
 
-  if(is_checkpoint_iter .or. is_shutdown_time) then
+  is_checkpoint = is_checkpoint_iter .or. is_shutdown_time
+  call comm_bcast(is_checkpoint,nproc_group_global)
+
+
+  if(is_checkpoint) then
     if (is_shutdown_time .and. comm_is_root(info%id_rko)) then
       print *, 'shutdown the calculation, iter =', itt
     end if


### PR DESCRIPTION
Because the timers `adjust_elapse_time(timer_now(LOG_TOTAL)` may be different for each MPI process, the timing of the shutdown may not be synchronized, causing the failure of the shutdown. To solve this problem, the root process check the condition of the shutdown/restart_write and bloadcast the condition to all the other processes.