### PR TITLE
Add rmat_ms option for multiscale calculation

### DIFF
--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -383,7 +383,8 @@ contains
       & file_macropoint, &
       & set_ini_coor_vel,&
       & nmacro_write_group, &
-      & nmacro_chunk
+      & nmacro_chunk, &
+      & rmat_ms
 
     namelist/maxwell/             &
       & al_em,                    &
@@ -758,6 +759,9 @@ contains
     set_ini_coor_vel= 'n'
     nmacro_write_group= -1
     nmacro_chunk = 20
+    rmat_ms(1, 1:3) = (/ 1.0d0, 0.0d0, 0.0d0 /)
+    rmat_ms(2, 1:3) = (/ 0.0d0, 1.0d0, 0.0d0 /)
+    rmat_ms(3, 1:3) = (/ 0.0d0, 0.0d0, 1.0d0 /)
 
 !! == default for &maxwell
     al_em(:)                    = 0d0
@@ -1284,6 +1288,7 @@ contains
     call comm_bcast(set_ini_coor_vel,nproc_group_global)
     call comm_bcast(nmacro_write_group,nproc_group_global)
     call comm_bcast(nmacro_chunk,nproc_group_global)
+    call comm_bcast(rmat_ms,nproc_group_global)
 
 !! == bcast for &maxwell
     call comm_bcast(al_em                    ,nproc_group_global)
@@ -2100,6 +2105,9 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'set_ini_coor_vel', set_ini_coor_vel
       write(fh_variables_log, '("#",4X,A,"=",I5)') 'nmacro_write_group', nmacro_write_group
       write(fh_variables_log, '("#",4X,A,"=",I5)') 'nmacro_chunk', nmacro_chunk
+      write(fh_variables_log, '("#",4X,A,"=",3ES12.5)') 'rmat_ms(1:3,1)', rmat_ms(1:3,1)
+      write(fh_variables_log, '("#",4X,A,"=",3ES12.5)') 'rmat_ms(1:3,2)', rmat_ms(1:3,2)
+      write(fh_variables_log, '("#",4X,A,"=",3ES12.5)') 'rmat_ms(1:3,3)', rmat_ms(1:3,3)
 
       if(inml_maxwell >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'maxwell', inml_maxwell

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -227,6 +227,7 @@ module salmon_global
   character(1)   :: set_ini_coor_vel
   integer        :: nmacro_write_group
   integer        :: nmacro_chunk
+  real(8)        :: rmat_ms(3, 3)
 
 !! &maxwell
   real(8)        :: al_em(3)

--- a/src/ms/input_checker_ms.f90
+++ b/src/ms/input_checker_ms.f90
@@ -80,6 +80,9 @@ function check_input_variables_ms() result(flag)
     if (nmacro_chunk < 1) &
         call raise("ERROR! 'nmacro_chunk' must not larger than 1!")
 
+    if (.not. is_ortho(rmat_ms)) &
+        call raise("ERROR! 'rmat_ms' must be orthogonal matrix!")
+
     return
 
     contains
@@ -92,6 +95,19 @@ function check_input_variables_ms() result(flag)
         end if
         flag = .false.
     end subroutine raise
+
+    logical function is_ortho(rmat)
+        implicit none
+        real(8), intent(in) :: rmat(3, 3)
+        real(8) :: rtmp(3, 3)
+        rtmp = matmul(transpose(rmat), rmat)
+        rtmp(1, 1) = rtmp(1, 1) - 1.0d0
+        rtmp(2, 2) = rtmp(2, 2) - 1.0d0
+        rtmp(3, 3) = rtmp(3, 3) - 1.0d0
+        is_ortho = (maxval(abs(rtmp)) < 1d-2)
+        return
+    end function is_ortho
+        
 
 end function check_input_variables_ms
 end module input_checker_ms

--- a/src/ms/main_ms.f90
+++ b/src/ms/main_ms.f90
@@ -428,10 +428,10 @@ subroutine time_evolution_step_ms
         iix = ms%ixyz_tbl(1, iimacro)
         iiy = ms%ixyz_tbl(2, iimacro)
         iiz = ms%ixyz_tbl(3, iimacro)
-        rt%Ac_tot(1:3, itt-1) = fw%vec_Ac%v(1:3, iix, iiy, iiz)
-        rt%Ac_tot(1:3, itt)   = fw%vec_Ac_new%v(1:3, iix, iiy, iiz)
-        rt%Ac_ext(1:3, itt-1) = rt%Ac_tot(1:3, itt-1)
-        rt%Ac_ext(1:3, itt)   = rt%Ac_tot(1:3, itt)
+        rt%Ac_tot(1:3, itt-1) = matmul(rmat_ms, fw%vec_Ac%v(1:3, iix, iiy, iiz))
+        rt%Ac_tot(1:3, itt)   = matmul(rmat_ms, fw%vec_Ac_new%v(1:3, iix, iiy, iiz))
+        rt%Ac_ext(1:3, itt-1) = matmul(rmat_ms, rt%Ac_tot(1:3, itt-1))
+        rt%Ac_ext(1:3, itt)   = matmul(rmat_ms, rt%Ac_tot(1:3, itt))
 
         if(mod(itt,2)==1)then
             call time_evolution_step(Mit,nt,itt,lg,mg,system,rt,info,stencil,xc_func &
@@ -461,7 +461,8 @@ subroutine time_evolution_step_ms
         iix = ms%ixyz_tbl(1, iimacro)
         iiy = ms%ixyz_tbl(2, iimacro)
         iiz = ms%ixyz_tbl(3, iimacro)
-        fw%vec_j_em%v(1:3, iix, iiy, iiz) = -1.0d0 * curr(1:3, iimacro)
+        fw%vec_j_em%v(1:3, iix, iiy, iiz) &
+            & = matmul(transpose(rmat_ms), -1.0d0 * curr(1:3, iimacro))
     end do
 
     if (mod(itt, out_ms_step) == 0) call print_linelog()


### PR DESCRIPTION
This pull request experimentally implements a new option `rmat_ms`: a matrix that describes the rotational transform between the microscopic coordinates system and the macroscopic one.

Example:
```
  rmat_ms(1:3, 1) = +0.40824829, +0.40824829, -0.81649658
  rmat_ms(1:3, 2) = -0.70710678, +0.70710678, -0.00000000
  rmat_ms(1:3, 3) = +0.57735027, +0.57735027, +0.57735027
```
The above corresponds z-axis in the macroscopic (electromagnetic) system to the [111]-axis of the microscopic (electronic) system.
