### PR TITLE
change of nscf in testsuite 184

### DIFF
--- a/testsuites/184_C2H2_gs_ffte_o1/inputfile
+++ b/testsuites/184_C2H2_gs_ffte_o1/inputfile
@@ -36,7 +36,7 @@
 /
 &scf
   ncg = 4
-  nscf = 50
+  nscf = 60
 /
 &functional
   xc = 'PZ'


### PR DESCRIPTION
Testsuite 184 doesn't pass in the GPU environment.  So I increase nscf a bit for the testsuite 184.