### PR TITLE
bugfix: multiscale with yn_out_rvf_rt

### DIFF
--- a/src/common/structures.f90
+++ b/src/common/structures.f90
@@ -414,6 +414,7 @@ module structures
     integer :: fh_current_decomposed, fh_intra_current
     integer :: fh_rt_spin
     integer :: fh_mag_decomposed_rt,fh_spin_current_decomposed
+    integer :: fh_trj
     character(100) :: file_eigen_data
     character(256) :: file_rt_data
     character(256) :: file_rt_energy_data

--- a/src/gs/main_dft.f90
+++ b/src/gs/main_dft.f90
@@ -115,7 +115,7 @@ call initialization2_dft( Miter, nspin, rion_update,  &
 
 Miopt = 0
 nopt_max = 1
-if(yn_opt=='y') call initialization_opt(Miopt,opt,system,flag_opt_conv,nopt_max)
+if(yn_opt=='y') call initialization_opt(Miopt,opt,system,flag_opt_conv,nopt_max,ofl)
 
 call timer_end(LOG_INIT_GS)
 
@@ -255,7 +255,7 @@ if(yn_opt=='y') then
    !!Rion(:,:) = system%Rion(:,:)
 
    write(comment_line,10) iopt
-   call write_xyz(comment_line,"add","r  ",system)
+   call write_xyz(comment_line,"add","r  ",system,ofl)
 10 format("#opt iteration step=",i5)
 
    if(comm_is_root(nproc_id_global))then

--- a/src/gs/main_dft_md.f90
+++ b/src/gs/main_dft_md.f90
@@ -122,7 +122,7 @@ call timer_end(LOG_INIT_GS)
 call write_dft_md_data(0,ofl,md)
 
 write(comment_line,10) 0
-call write_xyz(comment_line,"new","r  ",system)
+call write_xyz(comment_line,"new","r  ",system,ofl)
 10 format("#Adiabatic-MD time step=",i5)
 
 dt_h       = dt*0.5d0
@@ -212,7 +212,7 @@ MD_Loop : do it=1,nt
       if(ensemble=="NVT" .and. thermostat=="nose-hoover") &
            write(comment_line,112) trim(comment_line), md%xi_nh
 112   format(a,"  xi_nh=",e18.10)
-      call write_xyz(comment_line,"add","rvf",system)
+      call write_xyz(comment_line,"add","rvf",system,ofl)
    endif
 
    ! Export electronic density (cube or vtk)

--- a/src/gs/structure_opt.f90
+++ b/src/gs/structure_opt.f90
@@ -18,8 +18,8 @@ module structure_opt_sub
 contains
 
   !==============================================================initilize
-  subroutine  initialization_opt(Miopt,opt,system,flag_opt_conv,nopt_max)
-    use structures, only: s_opt,s_dft_system
+  subroutine  initialization_opt(Miopt,opt,system,flag_opt_conv,nopt_max,ofl)
+    use structures, only: s_opt,s_dft_system,s_ofile
     use parallelization, only: nproc_id_global
     use communication, only: comm_is_root
     use salmon_global, only: natom,nopt,yn_restart
@@ -30,6 +30,7 @@ contains
     type(s_dft_system) :: system
     integer :: nopt_max,Miopt,NA3
     logical :: flag_opt_conv
+    type(s_ofile) :: ofl
     character(100) :: comment_line
 
     flag_opt_conv = .false.
@@ -54,7 +55,7 @@ contains
     end if
 
     write(comment_line,10) 0
-    call write_xyz(comment_line,"new","r  ",system)
+    call write_xyz(comment_line,"new","r  ",system,ofl)
 10  format("#opt iteration step=",i5)
 
   end subroutine  initialization_opt

--- a/src/rt/initialization_rt.f90
+++ b/src/rt/initialization_rt.f90
@@ -368,7 +368,7 @@ subroutine initialization_rt( Mit, system, energy, ewald, rt, md, &
   end if
   
   if(yn_md=='y' .or. yn_out_rvf_rt=='y')then
-     call write_xyz(comment_line,"new","rvf",system)
+     call write_xyz(comment_line,"new","rvf",system,ofl)
   endif
   
   !---------------------------- time-evolution
@@ -479,7 +479,7 @@ subroutine initialization_rt( Mit, system, energy, ewald, rt, md, &
      write(comment_line,10) -1, 0.0d0
      if(ensemble=="NVT" .and. thermostat=="nose-hoover") &
           &  write(comment_line,12) trim(comment_line), md%xi_nh
-     call write_xyz(comment_line,"add","rvf",system)
+     call write_xyz(comment_line,"add","rvf",system,ofl)
   10 format("#rt   step=",i8,"   time",e16.6)
   12 format(a,"  xi_nh=",e18.10)
   end if

--- a/src/rt/time_evolution_step.f90
+++ b/src/rt/time_evolution_step.f90
@@ -292,7 +292,7 @@ SUBROUTINE time_evolution_step(Mit,itotNtime,itt,lg,mg,system,rt,info,stencil,xc
      if(yn_md=='y' .and. ensemble=="NVT" .and. thermostat=="nose-hoover") &
           &  write(comment_line,12) trim(comment_line), md%xi_nh
 12   format(a,"  xi_nh=",e18.10)
-     call write_xyz(comment_line,"add","rvf",system)
+     call write_xyz(comment_line,"add","rvf",system,ofl)
   endif
 
 


### PR DESCRIPTION
In the old version, the multiscale mode with yn_out_rvf_rt=y cannot SYSname_trj.xyz files for each macro grid point.