### PR TITLE
Added a new variable, dk_shift, to shift the Brillouin zone sampling.

### DIFF
--- a/src/common/lattice.f90
+++ b/src/common/lattice.f90
@@ -103,7 +103,7 @@ SUBROUTINE init_kvector(num_kgrid,system)
   use sym_kvector, only: init_sym_kvector
   use parallelization, only: nproc_id_global, nproc_group_global
   use communication, only: comm_bcast, comm_sync_all, comm_is_root
-  use salmon_global, only: file_kw
+  use salmon_global, only: file_kw, dk_shift
   implicit none
   integer            :: num_kgrid(3)
   type(s_dft_system) :: system
@@ -145,9 +145,9 @@ SUBROUTINE init_kvector(num_kgrid,system)
         ix=mod(ik-1,num_kgrid(1))+1
         iy=mod((ik-1)/num_kgrid(1),num_kgrid(2))+1
         iz=mod((ik-1)/(num_kgrid(1)*num_kgrid(2)),num_kgrid(3))+1
-        k(1,ik) = (dble(ix)-shift_k(1))/dble(num_kgrid(1))-0.5d0
-        k(2,ik) = (dble(iy)-shift_k(2))/dble(num_kgrid(2))-0.5d0
-        k(3,ik) = (dble(iz)-shift_k(3))/dble(num_kgrid(3))-0.5d0
+        k(1,ik) = (dble(ix)-shift_k(1)+dk_shift(1))/dble(num_kgrid(1))-0.5d0
+        k(2,ik) = (dble(iy)-shift_k(2)+dk_shift(2))/dble(num_kgrid(2))-0.5d0
+        k(3,ik) = (dble(iz)-shift_k(3)+dk_shift(3))/dble(num_kgrid(3))-0.5d0
      end do
      wtk(:)  = 1d0/dble(nk)
 

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -289,7 +289,8 @@ contains
 
     namelist/kgrid/ &
       & num_kgrid, &
-      & file_kw
+      & file_kw, &
+      & dk_shift
 
     namelist/tgrid/ &
       & nt, &
@@ -696,6 +697,7 @@ contains
 !! == default for &kgrid
     num_kgrid = 1
     file_kw   = 'none'
+    dk_shift = 0d0
 !! == default for &tgrid
     nt = 0
     dt = 0
@@ -1215,6 +1217,7 @@ contains
 !! == bcast for &kgrid
     call comm_bcast(num_kgrid,nproc_group_global)
     call comm_bcast(file_kw  ,nproc_group_global)
+    call comm_bcast(dk_shift ,nproc_group_global)
 !! == bcast for &tgrid
     call comm_bcast(nt,nproc_group_global)
     call comm_bcast(dt,nproc_group_global)
@@ -2087,6 +2090,9 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",I4)') 'num_kgrid(2)', num_kgrid(2)
       write(fh_variables_log, '("#",4X,A,"=",I4)') 'num_kgrid(3)', num_kgrid(3)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'file_kw', trim(file_kw)
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'dk_shift(1)', dk_shift(1)
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'dk_shift(2)', dk_shift(2)
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'dk_shift(3)', dk_shift(3)
 
       if(inml_tgrid >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'tgrid', inml_tgrid

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -130,6 +130,7 @@ module salmon_global
 !! &kgrid
   integer        :: num_kgrid(3)
   character(256) :: file_kw
+  real(8)        :: dk_shift(3)
 
 !! &tgrid
   integer        :: nt


### PR DESCRIPTION
Here, I added a new input variable, dk_shift(3), so as to control the shift of the Brillouin zone sampling. Currently, SALMON employs Monkhorst-Pack sampling for the Brillouin zone sampling. The intorduced parameters, dk_shift(3), add the shift to the Mohkhorst-pack sampling, and the amont of the shift is given by dk_shift(:)/num_kgrid(:) in the reduced coordinate of the first Brillouin zone.

The shift can be used to reduce a spurious excitation contribution (zero frequency contribution) to the optical spectra.