### PR TITLE
Added the simple mixing method for the potentials.

### DIFF
--- a/src/common/structures.f90
+++ b/src/common/structures.f90
@@ -443,6 +443,7 @@ module structures
     logical :: flag_mix_zero
     integer :: num_rho_stock
     type(s_scalar),allocatable :: rho_in(:), rho_out(:), rho_s_in(:,:), rho_s_out(:,:)
+    type(s_scalar),allocatable :: Vh_in(:), Vh_out(:), Vxc_in(:,:), Vxc_out(:,:)
     real(8) :: mixrate, alpha_mb, beta_p
     real(8) :: convergence_value_prev
   end type s_mixing

--- a/src/gs/mixing.f90
+++ b/src/gs/mixing.f90
@@ -117,7 +117,7 @@ subroutine simple_mixing_potential(mg,system,c1,c2,Vh,Vxc,mixing)
           c1*mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz) &
          +c2*mixing%Vxc_out(mixing%num_rho_stock,1)%f(ix,iy,iz)
 
-      mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
+      mixing%Vh_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
       mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vxc(1)%f(ix,iy,iz)
     end do
     end do
@@ -149,7 +149,7 @@ subroutine simple_mixing_potential(mg,system,c1,c2,Vh,Vxc,mixing)
           c1*mixing%Vxc_in(mixing%num_rho_stock,2)%f(ix,iy,iz) &
          +c2*mixing%Vxc_out(mixing%num_rho_stock,2)%f(ix,iy,iz)
 
-      mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
+      mixing%Vh_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
       mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vxc(1)%f(ix,iy,iz)
       mixing%Vxc_in(mixing%num_rho_stock,2)%f(ix,iy,iz)=Vxc(2)%f(ix,iy,iz)
     end do

--- a/src/gs/mixing.f90
+++ b/src/gs/mixing.f90
@@ -117,7 +117,7 @@ subroutine simple_mixing_potential(mg,system,c1,c2,Vh,Vxc,mixing)
           c1*mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz) &
          +c2*mixing%Vxc_out(mixing%num_rho_stock,1)%f(ix,iy,iz)
 
-      mixing%Vh_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
+      mixing%Vh_in(mixing%num_rho_stock)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
       mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vxc(1)%f(ix,iy,iz)
     end do
     end do
@@ -149,7 +149,7 @@ subroutine simple_mixing_potential(mg,system,c1,c2,Vh,Vxc,mixing)
           c1*mixing%Vxc_in(mixing%num_rho_stock,2)%f(ix,iy,iz) &
          +c2*mixing%Vxc_out(mixing%num_rho_stock,2)%f(ix,iy,iz)
 
-      mixing%Vh_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
+      mixing%Vh_in(mixing%num_rho_stock)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
       mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vxc(1)%f(ix,iy,iz)
       mixing%Vxc_in(mixing%num_rho_stock,2)%f(ix,iy,iz)=Vxc(2)%f(ix,iy,iz)
     end do

--- a/src/gs/mixing.f90
+++ b/src/gs/mixing.f90
@@ -116,6 +116,9 @@ subroutine simple_mixing_potential(mg,system,c1,c2,Vh,Vxc,mixing)
       Vxc(1)%f(ix,iy,iz)= &
           c1*mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz) &
          +c2*mixing%Vxc_out(mixing%num_rho_stock,1)%f(ix,iy,iz)
+
+      mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
+      mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vxc(1)%f(ix,iy,iz)
     end do
     end do
     end do
@@ -145,6 +148,10 @@ subroutine simple_mixing_potential(mg,system,c1,c2,Vh,Vxc,mixing)
       Vxc(2)%f(ix,iy,iz)= &
           c1*mixing%Vxc_in(mixing%num_rho_stock,2)%f(ix,iy,iz) &
          +c2*mixing%Vxc_out(mixing%num_rho_stock,2)%f(ix,iy,iz)
+
+      mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vh%f(ix,iy,iz)
+      mixing%Vxc_in(mixing%num_rho_stock,1)%f(ix,iy,iz)=Vxc(1)%f(ix,iy,iz)
+      mixing%Vxc_in(mixing%num_rho_stock,2)%f(ix,iy,iz)=Vxc(2)%f(ix,iy,iz)
     end do
     end do
     end do

--- a/src/gs/scf_iteration.f90
+++ b/src/gs/scf_iteration.f90
@@ -113,6 +113,8 @@ subroutine scf_iteration_step(lg,mg,system,info,stencil, &
       call wrapper_broyden(info%icomm_r,mg,system,rho_s,iter,mixing)
     case ('pulay')
       call pulay(mg,info,system,rho_s,iter,mixing)
+    case ('simple_potential')
+      ! Nothing is done here since Hartree and XC potentials are mixed instead of density
     case default
       stop 'Invalid method_mixing. Specify any one of "simple" or "broyden" or "pulay" for method_mixing.'
     end select
@@ -133,6 +135,10 @@ subroutine scf_iteration_step(lg,mg,system,info,stencil, &
     call exchange_correlation(system,xc_func,mg,srg_scalar,srg,rho_s,ppn,info,spsi,stencil,Vxc,energy%E_xc)
     call timer_end(LOG_CALC_EXC_COR)
 
+
+    if(method_mixing=='simple_potential')then
+      call simple_mixing_potential(mg,system,1.d0-mixing%mixrate,mixing%mixrate,Vh,Vxc,mixing)
+    end if
   end if
 
 end subroutine scf_iteration_step


### PR DESCRIPTION
I added a new mixing method, 'simple_potential'. By using this method, the potential is mixed instead of density, enabling a proper mixing for meta-GGA calculations.