### PR TITLE
fix: malformed internal writes break the restart directory name

### DIFF
--- a/src/io/checkpoint_restart.f90
+++ b/src/io/checkpoint_restart.f90
@@ -78,11 +78,22 @@ subroutine generate_restart_directory_name(basedir,gdir,pdir)
   character(*),  intent(in)  :: basedir
   character(256),intent(out) :: gdir
   character(256),intent(out) :: pdir
+  character(6) :: crank
 
-  ! global directory
-  write(gdir,'(A,I6.6,A)')   trim(basedir)
+  ! Build the directory names with plain string operations. The previous code,
+  !   write(gdir,'(A,I6.6,A)') trim(basedir)
+  !   write(pdir,'(A,A,I6.6,A)') trim(gdir),'rank_',nproc_id_global,'/'
+  ! used internal-file list-directed writes whose formats did not match the
+  ! output list (the gdir write has an I6.6 with no integer argument), which
+  ! aborts with jwe0131i ("end of the character variable in an internal file
+  ! I/O statement") on strict compilers and broke the (RT) restart checkpoint.
+
+  ! global directory (the restart directory itself; no iteration index, unlike
+  ! generate_checkpoint_directory_name)
+  gdir = trim(basedir)
   ! process private directory
-  write(pdir,'(A,A,I6.6,A)') trim(gdir),'rank_',nproc_id_global,'/'
+  write(crank,'(i6.6)') nproc_id_global
+  pdir = trim(gdir)//'rank_'//crank//'/'
 end subroutine generate_restart_directory_name
 
 


### PR DESCRIPTION
## Summary

`generate_restart_directory_name` built the restart directory strings with
internal-file list-directed writes whose formats did not match the output list:

```fortran
write(gdir,'(A,I6.6,A)')   trim(basedir)                       ! I6.6 has no integer argument
write(pdir,'(A,A,I6.6,A)') trim(gdir),'rank_',nproc_id_global,'/'
```

On strict compilers (Fujitsu A64FX) this aborts with `jwe0131i` ("the end of the
character variable in an internal file I/O statement was detected"), leaving the
directory name malformed and the checkpoint incomplete — so **RT-to-RT restart
could not write or read its checkpoint**.

## Fix

Build the names with plain string operations. The restart directory carries no
iteration index (unlike `generate_checkpoint_directory_name`), so `gdir` is just
`trim(basedir)`, and the per-rank directory is assembled by concatenation with a
small, well-formed integer write.

## Verification (Wisteria-O, A64FX)

bulk Si, GS → RT (20 steps, `checkpoint_interval=20`) → RT restart from
`checkpoint_rt_000020/`:

- **With the fix:** the checkpoint directory is written completely
  (`info.bin`, `occupation.bin`, `wfn.bin`, `Vh_stock.bin`, `atomic_*.txt`) and
  the restart run reads it and continues successfully.
- **Without the fix:** the checkpoint write aborts with `jwe0131i` and the
  restart fails (the directory ends up empty / unreadable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
