### PR TITLE
Make method_init_density='pp' work for psp8 and add a generic atomic-density fallback

### DIFF
--- a/src/atom/pp/input_pp.f90
+++ b/src/atom/pp/input_pp.f90
@@ -91,8 +91,17 @@ subroutine input_pp(pp,hx,hy,hz)
 
       if ( flag_beta_proj_is_given ) then
         flag_potential_is_given=.false.
-        if(method_init_density/='read_dns_cube' .and. method_init_density/='wf' .and. ps_format(ik)/='UPF') then
-          stop "radial density is not available (method_init_density=pp...)"
+        if(method_init_density/='read_dns_cube' .and. method_init_density/='wf') then
+          ! method_init_density='pp' needs a radial atomic density. It is read
+          ! from the file for UPF (<PP_RHOATOM>) and psp8 (valence density). If
+          ! the pseudopotential provides none (rho_pp_tbl is still all zero),
+          ! fall back to a generic atomic density built from the valence charge
+          ! so that 'pp' works for any pseudopotential instead of aborting.
+          if( maxval(abs(pp%rho_pp_tbl(:,ik))) < 1d-30 ) then
+            call set_generic_atomic_density(pp,ik)
+            write(*,'(a,i3,a)') " method_init_density=pp: pseudopotential of element ",ik, &
+              & " has no tabulated atomic density; using a generic atomic density."
+          end if
         end if
       end if
       if ( any(pp%vpp_so/=0.0d0) ) flag_so=.true.
@@ -284,6 +293,26 @@ subroutine input_pp(pp,hx,hy,hz)
 
   return
 end subroutine input_pp
+!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
+subroutine set_generic_atomic_density(pp,ik)
+  use structures,only : s_pp_info
+  implicit none
+  type(s_pp_info),intent(inout) :: pp
+  integer,intent(in) :: ik
+  integer :: i
+  real(8) :: rs, r
+  ! Generic spherical atomic valence density used as an initial-density guess
+  ! (method_init_density='pp') when the pseudopotential provides no tabulated
+  ! atomic density. Exponential model rho(r) = N*exp(-r/rs) normalized to the
+  ! number of valence electrons (pp%zps), stored as 4*pi*r^2*rho:
+  !   rho_pp_tbl(i) = (zps/(2*rs^3)) * r^2 * exp(-r/rs),  with  Int rho_pp_tbl dr = zps.
+  rs = 1.5d0  ! exponential scale length [a.u.]; this is only an initial guess
+  pp%rho_pp_tbl(:,ik) = 0.0d0
+  do i=1,pp%mr(ik)
+    r = pp%rad(i,ik)
+    pp%rho_pp_tbl(i,ik) = (dble(pp%zps(ik))/(2.0d0*rs**3)) * r**2 * exp(-r/rs)
+  end do
+end subroutine set_generic_atomic_density
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
 subroutine read_ps_ky(pp,rrc,ik,ps_file)
   use structures,only : s_pp_info
@@ -575,9 +604,13 @@ subroutine read_ps_abinitpsp8(pp,rrc,rhor_nlcc,flag_nlcc_element,ik,ps_file)
     write(*,*) "sum(rho_nlcc)=",sum_rho_nlcc*pi4*dr
   end if
 ! valence charge density
+! The psp8 file stores the valence density as 4*pi*rho (same convention as its
+! NLCC data). Store it as 4*pi*r^2*rho in rho_pp_tbl (the convention used by
+! calc_density_pp / method_init_density='pp'), i.e. r^2 * (4*pi*rho) = r^2*rho_tmp.
   sum_rho_pp=0.0d0
   do i=1,pp%mr(ik)+1
     read(4,*) dummy_text, r_tmp, rho_tmp
+    if (i <= pp%nrmax) pp%rho_pp_tbl(i,ik) = pp%rad(i,ik)**2 * rho_tmp
     sum_rho_pp=sum_rho_pp+rho_tmp*r_tmp**2
   end do
   write(*,*) "sum(rho_pp)=",sum_rho_pp*dr

--- a/src/atom/pp/input_pp.f90
+++ b/src/atom/pp/input_pp.f90
@@ -607,10 +607,18 @@ subroutine read_ps_abinitpsp8(pp,rrc,rhor_nlcc,flag_nlcc_element,ik,ps_file)
 ! The psp8 file stores the valence density as 4*pi*rho (same convention as its
 ! NLCC data). Store it as 4*pi*r^2*rho in rho_pp_tbl (the convention used by
 ! calc_density_pp / method_init_density='pp'), i.e. r^2 * (4*pi*rho) = r^2*rho_tmp.
+  ! The radial grid must fit rho_pp_tbl; otherwise the valence density would be
+  ! silently truncated (and left inconsistent with sum_rho_pp below), corrupting
+  ! the method_init_density='pp' initial density. Fail explicitly instead.
+  if (pp%mr(ik)+1 > pp%nrmax) then
+    write(*,*) "Error: psp8 radial grid size",pp%mr(ik)+1,"exceeds pp%nrmax",pp%nrmax, &
+               "in read_ps_abinitpsp8 (element",ik,")"
+    stop "read_ps_abinitpsp8: radial grid larger than pp%nrmax"
+  end if
   sum_rho_pp=0.0d0
   do i=1,pp%mr(ik)+1
     read(4,*) dummy_text, r_tmp, rho_tmp
-    if (i <= pp%nrmax) pp%rho_pp_tbl(i,ik) = pp%rad(i,ik)**2 * rho_tmp
+    pp%rho_pp_tbl(i,ik) = pp%rad(i,ik)**2 * rho_tmp
     sum_rho_pp=sum_rho_pp+rho_tmp*r_tmp**2
   end do
   write(*,*) "sum(rho_pp)=",sum_rho_pp*dr


### PR DESCRIPTION
## Summary

`method_init_density='pp'` builds the initial electron density from the
pseudopotential's atomic valence density (`rho_pp_tbl`). That density is smooth
and positive everywhere, unlike the default `'wf'` guess that is built from the
gaussian initial orbitals — whose near-zero regions make meta-GGA functionals
(e.g. TBmBJ) diverge on the first iterations. So `'pp'` is the natural,
non-pathological initial density (cf. issue #1253).

Two gaps are fixed so that `'pp'` works for more pseudopotentials:

1. **psp8** stores the pseudo valence density in the file, but the reader read
   it only to print a diagnostic and then **discarded** it. It is now stored
   into `rho_pp_tbl` as `4*pi*r^2*rho` (`= r^2 * rho_tmp`, since psp8 stores
   `4*pi*rho`, the same convention as its NLCC data).
2. **Generic fallback**: if a pseudopotential still provides no tabulated atomic
   density, `'pp'` previously aborted with `"radial density is not available"`.
   It now builds a generic atomic density from the valence charge
   (`set_generic_atomic_density`: an exponential model normalised to `pp%zps`)
   instead of aborting.

`'wf'`/`'read_dns_cube'` and UPF (which already reads `<PP_RHOATOM>`) are
unaffected.

## Verification (Wisteria-O, A64FX)

**1. psp8 `'pp'` works and is correctly normalised.** bulk Si (8 atoms,
`Si.psp8` ONCVPSP, `zion=4`, so 32 valence electrons), `nproc_k=4`:

- `'pp'` no longer aborts; `calc_density_pp` reports `Int(rho) = 32.0000000` —
  i.e. the initial density integrates to exactly the number of valence
  electrons, confirming the normalisation.
- the GS converges (iter 60: total energy -951.4 eV, gap +0.03 eV). `'pp'` is in
  fact a better starting guess here than `'wf'` (which still had a negative gap
  at iter 60).

**2. `'pp'` cures the meta-GGA initial-density pathology (issue #1253).** bulk Si
(8 atoms, `Si_rps.dat`), `xc='TBmBJ'`:

| method_init_density | result |
|---------------------|--------|
| `'wf'` (gaussian)   | diverges — iter 4 total energy **+1580 eV**, gap overflows |
| **`'pp'`**          | **converges** — total energy **-862.8 eV**, gap **2.64 eV** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
