### PR TITLE
feat: r-space parallelization for nonorthogonal lattices (nproc_rgrid>1)

### DIFF
--- a/src/common/hamiltonian.f90
+++ b/src/common/hamiltonian.f90
@@ -311,6 +311,9 @@ SUBROUTINE hpsi(tpsi,htpsi,info,mg,V_local,system,stencil,srg,ppg,ttpsi)
       endif
 
 
+    else if(.not.stencil%if_orthogonal .and. info%if_divide_rspace) then
+    ! non-orthogonal lattice, r-space parallelized: pass1 -> halo(df/dx,df/dy) -> pass2
+      call hpsi_nonorth_rspace(tpsi,htpsi,info,mg,V_local,system,stencil,srg)
     else if(.not.stencil%if_orthogonal) then
     ! non-orthogonal lattice
     
@@ -830,6 +833,95 @@ contains
   end subroutine add_imaginary_potential_for_absorbing_boundary_z
 
 end subroutine hpsi
+
+!===================================================================================================================================
+
+subroutine hpsi_nonorth_rspace(tpsi,htpsi,info,mg,V_local,system,stencil,srg)
+! Nonorthogonal-lattice kinetic operator for the r-space-parallel case (nproc_rgrid>1).
+! Two-pass scheme: pass1 fills htpsi's diagonal-metric + Bk*nabla part and stores the
+! per-axis first derivatives df/dx, df/dy; their halos are then exchanged (update_overlap,
+! using the same srg as the wavefunction) so pass2 can form the off-diagonal-metric cross
+! derivatives whose stencils reach into the halo. For nproc_rgrid=1 this routine is not
+! reached (the serial path zstencil_nonorthogonal uses the periodic index wrap); the
+! orthogonal stencils are untouched. Math is identical to zstencil_nonorthogonal.
+  use structures
+  use stencil_sub, only: zstencil_nonorth_rspace_pass1, zstencil_nonorth_rspace_pass2
+  use sendrecv_grid, only: update_overlap_complex8
+  use salmon_global, only: yn_periodic
+  implicit none
+  type(s_dft_system)   ,intent(in)    :: system
+  type(s_parallel_info),intent(in)    :: info
+  type(s_rgrid)        ,intent(in)    :: mg
+  type(s_scalar)       ,intent(in)    :: V_local(system%Nspin)
+  type(s_stencil)      ,intent(in)    :: stencil
+  type(s_sendrecv_grid),intent(inout) :: srg
+  type(s_orbital)                     :: tpsi,htpsi
+  !
+  integer :: nspin,ispin,io,ik,im,im_s,im_e,ik_s,ik_e,io_s,io_e
+  real(8) :: k_lap0,kAc(3)
+  logical :: if_kAc
+  complex(8),allocatable :: wrk1(:,:,:,:,:,:,:),wrk2(:,:,:,:,:,:,:)
+
+  im_s=info%im_s; im_e=info%im_e
+  ik_s=info%ik_s; ik_e=info%ik_e
+  io_s=info%io_s; io_e=info%io_e
+  nspin=system%nspin
+  if_kAc = (yn_periodic=='y')
+
+  allocate(wrk1(mg%is_array(1):mg%ie_array(1),mg%is_array(2):mg%ie_array(2),mg%is_array(3):mg%ie_array(3) &
+               ,nspin,io_s:io_e,ik_s:ik_e,im_s:im_e))
+  allocate(wrk2(mg%is_array(1):mg%ie_array(1),mg%is_array(2):mg%ie_array(2),mg%is_array(3):mg%ie_array(3) &
+               ,nspin,io_s:io_e,ik_s:ik_e,im_s:im_e))
+
+  ! pass1: diagonal-metric Laplacian + Bk*nabla into htpsi; store df/dx, df/dy in wrk1, wrk2
+!$omp parallel do collapse(4) default(none) &
+!$omp private(im,ik,io,ispin,kAc,k_lap0) &
+!$omp shared(im_s,im_e,ik_s,ik_e,io_s,io_e,nspin,if_kAc,system,stencil,mg,tpsi,htpsi,V_local,wrk1,wrk2)
+  do im=im_s,im_e
+  do ik=ik_s,ik_e
+  do io=io_s,io_e
+  do ispin=1,nspin
+    kAc = 0d0
+    k_lap0 = 0d0
+    if(if_kAc) then
+      kAc(1:3) = system%vec_k(1:3,ik) + system%vec_Ac(1:3)
+      k_lap0 = stencil%coef_lap0 + 0.5d0* sum(kAc(1:3)**2)
+      kAc(1:3) = matmul(system%rmatrix_B,kAc)
+    end if
+    call zstencil_nonorth_rspace_pass1(mg%is_array,mg%ie_array,mg%is,mg%ie,mg%idx,mg%idy,mg%idz &
+        ,tpsi%zwf(:,:,:,ispin,io,ik,im),htpsi%zwf(:,:,:,ispin,io,ik,im) &
+        ,wrk1(:,:,:,ispin,io,ik,im),wrk2(:,:,:,ispin,io,ik,im) &
+        ,V_local(ispin)%f,k_lap0,stencil%coef_lap,stencil%coef_nab,kAc,stencil%coef_F)
+  end do
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+  ! exchange halos of df/dx, df/dy (same srg/layout as the wavefunction block)
+  call update_overlap_complex8(srg, mg, wrk1)
+  call update_overlap_complex8(srg, mg, wrk2)
+
+  ! pass2: add off-diagonal-metric cross derivatives from the halo-exchanged wrk1, wrk2
+!$omp parallel do collapse(4) default(none) &
+!$omp private(im,ik,io,ispin) &
+!$omp shared(im_s,im_e,ik_s,ik_e,io_s,io_e,nspin,stencil,mg,htpsi,wrk1,wrk2)
+  do im=im_s,im_e
+  do ik=ik_s,ik_e
+  do io=io_s,io_e
+  do ispin=1,nspin
+    call zstencil_nonorth_rspace_pass2(mg%is_array,mg%ie_array,mg%is,mg%ie,mg%idx,mg%idy,mg%idz &
+        ,wrk1(:,:,:,ispin,io,ik,im),wrk2(:,:,:,ispin,io,ik,im),htpsi%zwf(:,:,:,ispin,io,ik,im) &
+        ,stencil%coef_nab,stencil%coef_F)
+  end do
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+  deallocate(wrk1,wrk2)
+  return
+end subroutine hpsi_nonorth_rspace
 
 !===================================================================================================================================
 

--- a/src/common/initialization.f90
+++ b/src/common/initialization.f90
@@ -248,8 +248,9 @@ subroutine init_dft_system(lg,system,stencil)
   if(stencil%if_orthogonal) then
     stencil%coef_lap0 = -0.5d0*cNmat(0,Nd)*(1.d0/Hgs(1)**2+1.d0/Hgs(2)**2+1.d0/Hgs(3)**2)
   else
-    if(nproc_rgrid(1)*nproc_rgrid(2)*nproc_rgrid(3)/=1) &
-      stop "error: nonorthogonal lattice and r-space parallelization"
+    ! nonorthogonal + r-space parallelization (nproc_rgrid>1) is supported via the two-pass
+    ! kinetic path hpsi_nonorth_rspace (df/dx,df/dy halo exchange in hamiltonian.f90) and the
+    ! diagonal-metric CG preconditioner zstencil_nonorthogonal_preconditioning_diag.
     stencil%coef_lap0 = -0.5d0*cNmat(0,Nd)*  &
                       & ( stencil%coef_F(1)/Hgs(1)**2 + stencil%coef_F(2)/Hgs(2)**2 + stencil%coef_F(3)/Hgs(3)**2 )
   end if
@@ -263,8 +264,9 @@ subroutine init_dft_system(lg,system,stencil)
   if(stencil%if_orthogonal) then
     stencil%coef_lap0_nd1 = -0.5d0*cNmat(0,1)*(1.d0/Hgs(1)**2+1.d0/Hgs(2)**2+1.d0/Hgs(3)**2)
   else
-    if(nproc_rgrid(1)*nproc_rgrid(2)*nproc_rgrid(3)/=1) &
-      stop "error: nonorthogonal lattice and r-space parallelization"
+    ! nonorthogonal + r-space parallelization (nproc_rgrid>1) is supported via the two-pass
+    ! kinetic path hpsi_nonorth_rspace (df/dx,df/dy halo exchange in hamiltonian.f90) and the
+    ! diagonal-metric CG preconditioner zstencil_nonorthogonal_preconditioning_diag.
     stencil%coef_lap0_nd1 = -0.5d0*cNmat(0,1)*  &
                       & ( stencil%coef_F(1)/Hgs(1)**2 + stencil%coef_F(2)/Hgs(2)**2 + stencil%coef_F(3)/Hgs(3)**2 )
   end if

--- a/src/common/initialization.f90
+++ b/src/common/initialization.f90
@@ -1279,23 +1279,30 @@ subroutine init_nion_div(system,lg,mg,info)
 
   else !(flag_cuboid=.false.)
 
-     ! nonorthogonal lattice: replicate all atoms on every r-space rank (info%nion_mg = nion).
-     ! nonlocal/force integrals are reduced over icomm_r so each grid point is counted once.
-     ! The "dividing atom" sum-check below applies only to the cuboid (domain-split) path.
-     info%nion_mg = system%nion
-     allocate( info%ia_mg(info%nion_mg) )
+     ! nonorthogonal lattice: the cuboid Cartesian domain test does not apply (skewed grid),
+     ! so partition the atoms round-robin over the r-space ranks (each atom on exactly one
+     ! rank). info%ia_mg is used only by the Ewald ion-ion sums (energy/stress/force), which
+     ! loop over the local atoms and reduce over icomm_r; the round-robin split makes that
+     ! reduction give the full sum (replicating all atoms over-counts it by nproc_rgrid).
+     info%nion_mg = 0
      do ia=1,system%nion
-        info%ia_mg(ia) = ia
+        if( mod(ia-1, info%isize_r) == info%id_r ) info%nion_mg = info%nion_mg + 1
+     enddo
+     allocate( info%ia_mg(info%nion_mg) )
+     iia = 0
+     do ia=1,system%nion
+        if( mod(ia-1, info%isize_r) == info%id_r ) then
+           iia = iia + 1
+           info%ia_mg(iia) = ia
+        endif
      enddo
 
   endif
 
-  !check (cuboid only: each atom belongs to exactly one r-space domain. The nonorthogonal
-  ! path replicates all atoms on every rank, so this sum would be nproc_rgrid*nion.)
-  if (flag_cuboid) then
-    call comm_summation(info%nion_mg, nion_total, info%icomm_r)
-    if( nion_total .ne. system%nion ) stop "Error2 in dividing atom in mg domain"
-  end if
+  !check: each atom is assigned to exactly one r-space rank (cuboid: by domain; nonorthogonal:
+  ! round-robin), so the per-rank counts must sum to the total over icomm_r.
+  call comm_summation(info%nion_mg, nion_total, info%icomm_r)
+  if( nion_total .ne. system%nion ) stop "Error2 in dividing atom in mg domain"
 
   !write(*,*) "  #nion_mg=", system%nion_mg
   !write(*,*) "  #check nion_total=", nion_total

--- a/src/common/initialization.f90
+++ b/src/common/initialization.f90
@@ -1279,7 +1279,9 @@ subroutine init_nion_div(system,lg,mg,info)
 
   else !(flag_cuboid=.false.)
 
-     ! assuming r-space parallelization is not available in nonorthogonal lattice cell
+     ! nonorthogonal lattice: replicate all atoms on every r-space rank (info%nion_mg = nion).
+     ! nonlocal/force integrals are reduced over icomm_r so each grid point is counted once.
+     ! The "dividing atom" sum-check below applies only to the cuboid (domain-split) path.
      info%nion_mg = system%nion
      allocate( info%ia_mg(info%nion_mg) )
      do ia=1,system%nion
@@ -1288,9 +1290,12 @@ subroutine init_nion_div(system,lg,mg,info)
 
   endif
 
-  !check
-  call comm_summation(info%nion_mg, nion_total, info%icomm_r)
-  if( nion_total .ne. system%nion ) stop "Error2 in dividing atom in mg domain"
+  !check (cuboid only: each atom belongs to exactly one r-space domain. The nonorthogonal
+  ! path replicates all atoms on every rank, so this sum would be nproc_rgrid*nion.)
+  if (flag_cuboid) then
+    call comm_summation(info%nion_mg, nion_total, info%icomm_r)
+    if( nion_total .ne. system%nion ) stop "Error2 in dividing atom in mg domain"
+  end if
 
   !write(*,*) "  #nion_mg=", system%nion_mg
   !write(*,*) "  #check nion_total=", nion_total

--- a/src/common/stencil.f90
+++ b/src/common/stencil.f90
@@ -215,6 +215,126 @@ end subroutine zstencil_nonorthogonal
 
 !===================================================================================================================================
 
+subroutine zstencil_nonorth_rspace_pass1(is_array,ie_array,is,ie,idx,idy,idz &
+                                        ,tpsi,htpsi,wrk1,wrk2,V_local,lap0,lapt,nabt,Bk,F)
+! Nonorthogonal lattice, r-space-parallel path (pass 1 of 2).
+! Identical math to zstencil_nonorthogonal's first loop, but stores the per-axis
+! first derivatives df/dx, df/dy into wrk1, wrk2 instead of consuming them in-place.
+! The cross-derivative term is added by zstencil_nonorth_rspace_pass2 AFTER wrk1/wrk2
+! halos are exchanged (update_overlap). Serial nonorthogonal runs keep using
+! zstencil_nonorthogonal (index-wrap supplies the neighbors); orthogonal stencils are
+! untouched. This routine is reached only for nonorthogonal lattice with nproc_rgrid>1.
+  implicit none
+  integer   ,intent(in)  :: is_array(3),ie_array(3),is(3),ie(3) &
+                           ,idx(is(1)-4:ie(1)+4),idy(is(2)-4:ie(2)+4),idz(is(3)-4:ie(3)+4)
+  complex(8),intent(in)  :: tpsi(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  real(8)   ,intent(in)  :: V_local(is(1):ie(1),is(2):ie(2),is(3):ie(3)),lap0,lapt(4,3),nabt(4,3)
+  real(8)   ,intent(in)  :: Bk(3),F(6)
+  complex(8),intent(out) :: htpsi(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  complex(8),intent(out) :: wrk1(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  complex(8),intent(out) :: wrk2(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  !
+  integer :: ix,iy,iz
+  complex(8) :: w(3),v(3)
+
+  do iz=is(3),ie(3)
+  do iy=is(2),ie(2)
+  do ix=is(1),ie(1)
+
+    v(1) =  lapt(1,1)*(tpsi(DX(1)) + tpsi(DX(-1))) &
+         & +lapt(2,1)*(tpsi(DX(2)) + tpsi(DX(-2))) &
+         & +lapt(3,1)*(tpsi(DX(3)) + tpsi(DX(-3))) &
+         & +lapt(4,1)*(tpsi(DX(4)) + tpsi(DX(-4)))
+
+    v(2) =  lapt(1,2)*(tpsi(DY(1)) + tpsi(DY(-1))) &
+         & +lapt(2,2)*(tpsi(DY(2)) + tpsi(DY(-2))) &
+         & +lapt(3,2)*(tpsi(DY(3)) + tpsi(DY(-3))) &
+         & +lapt(4,2)*(tpsi(DY(4)) + tpsi(DY(-4)))
+
+    v(3) =  lapt(1,3)*(tpsi(DZ(1)) + tpsi(DZ(-1))) &
+         & +lapt(2,3)*(tpsi(DZ(2)) + tpsi(DZ(-2))) &
+         & +lapt(3,3)*(tpsi(DZ(3)) + tpsi(DZ(-3))) &
+         & +lapt(4,3)*(tpsi(DZ(4)) + tpsi(DZ(-4)))
+
+    w(1) =  nabt(1,1)*(tpsi(DX(1)) - tpsi(DX(-1))) &
+         & +nabt(2,1)*(tpsi(DX(2)) - tpsi(DX(-2))) &
+         & +nabt(3,1)*(tpsi(DX(3)) - tpsi(DX(-3))) &
+         & +nabt(4,1)*(tpsi(DX(4)) - tpsi(DX(-4)))
+
+    w(2) =  nabt(1,2)*(tpsi(DY(1)) - tpsi(DY(-1))) &
+         & +nabt(2,2)*(tpsi(DY(2)) - tpsi(DY(-2))) &
+         & +nabt(3,2)*(tpsi(DY(3)) - tpsi(DY(-3))) &
+         & +nabt(4,2)*(tpsi(DY(4)) - tpsi(DY(-4)))
+
+    w(3) =  nabt(1,3)*(tpsi(DZ(1)) - tpsi(DZ(-1))) &
+         & +nabt(2,3)*(tpsi(DZ(2)) - tpsi(DZ(-2))) &
+         & +nabt(3,3)*(tpsi(DZ(3)) - tpsi(DZ(-3))) &
+         & +nabt(4,3)*(tpsi(DZ(4)) - tpsi(DZ(-4)))
+
+    htpsi(ix,iy,iz) = ( V_local(ix,iy,iz) + lap0 )* tpsi(ix,iy,iz) &
+                    - 0.5d0* ( F(1)*v(1) + F(2)*v(2) + F(3)*v(3) ) - zI* ( Bk(1)*w(1) + Bk(2)*w(2) + Bk(3)*w(3) )
+    wrk1(ix,iy,iz) = w(1) ! df/dx
+    wrk2(ix,iy,iz) = w(2) ! df/dy
+  end do
+  end do
+  end do
+
+  return
+end subroutine zstencil_nonorth_rspace_pass1
+
+!===================================================================================================================================
+
+subroutine zstencil_nonorth_rspace_pass2(is_array,ie_array,is,ie,idx,idy,idz &
+                                        ,wrk1,wrk2,htpsi,nabt,F)
+! Nonorthogonal lattice, r-space-parallel path (pass 2 of 2).
+! Identical math to zstencil_nonorthogonal's second loop. Adds the off-diagonal-metric
+! cross-derivative contribution from the (already halo-exchanged) wrk1=df/dx, wrk2=df/dy.
+! Access is face-direction only (DZ, DY), so the existing face halo (update_overlap)
+! supplies the required neighbors; no edge/corner ghosts are needed.
+  implicit none
+  integer   ,intent(in)    :: is_array(3),ie_array(3),is(3),ie(3) &
+                             ,idx(is(1)-4:ie(1)+4),idy(is(2)-4:ie(2)+4),idz(is(3)-4:ie(3)+4)
+  complex(8),intent(in)    :: wrk1(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  complex(8),intent(in)    :: wrk2(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  real(8)   ,intent(in)    :: nabt(4,3),F(6)
+  complex(8),intent(inout) :: htpsi(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  !
+  integer :: ix,iy,iz
+  complex(8) :: w(3)
+
+  do iz=is(3),ie(3)
+  do iy=is(2),ie(2)
+  do ix=is(1),ie(1)
+
+  ! yz: (d/dz) * (df/dy)
+    w(1) =  nabt(1,3)*(wrk2(DZ(1)) - wrk2(DZ(-1))) &
+         & +nabt(2,3)*(wrk2(DZ(2)) - wrk2(DZ(-2))) &
+         & +nabt(3,3)*(wrk2(DZ(3)) - wrk2(DZ(-3))) &
+         & +nabt(4,3)*(wrk2(DZ(4)) - wrk2(DZ(-4)))
+
+  ! zx: (d/dz) * (df/dx)
+    w(2) =  nabt(1,3)*(wrk1(DZ(1)) - wrk1(DZ(-1))) &
+         & +nabt(2,3)*(wrk1(DZ(2)) - wrk1(DZ(-2))) &
+         & +nabt(3,3)*(wrk1(DZ(3)) - wrk1(DZ(-3))) &
+         & +nabt(4,3)*(wrk1(DZ(4)) - wrk1(DZ(-4)))
+
+  ! xy: (d/dy) * (df/dx)
+    w(3) =  nabt(1,2)*(wrk1(DY(1)) - wrk1(DY(-1))) &
+         & +nabt(2,2)*(wrk1(DY(2)) - wrk1(DY(-2))) &
+         & +nabt(3,2)*(wrk1(DY(3)) - wrk1(DY(-3))) &
+         & +nabt(4,2)*(wrk1(DY(4)) - wrk1(DY(-4)))
+
+    htpsi(ix,iy,iz) = htpsi(ix,iy,iz) - 0.5d0* ( F(4)*w(1) + F(5)*w(2) + F(6)*w(3) )
+
+  end do
+  end do
+  end do
+
+  return
+end subroutine zstencil_nonorth_rspace_pass2
+
+!===================================================================================================================================
+
 # define DR(dt) idx(ix+(sx)*(dt)),idy(iy+(sy)*(dt)),idz(iz+(sz)*(dt))
 
 ! (future works)

--- a/src/gs/conjugate_gradient.f90
+++ b/src/gs/conjugate_gradient.f90
@@ -739,7 +739,8 @@ end subroutine inner_product
 
 subroutine preconditioning_zgk(mg,system,info,gk,pre_gk)
   !$ use omp_lib
-  use preconditioning_sub, only: zstencil_preconditioning,zstencil_nonorthogonal_preconditioning
+  use preconditioning_sub, only: zstencil_preconditioning,zstencil_nonorthogonal_preconditioning &
+                                ,zstencil_nonorthogonal_preconditioning_diag
   use structures
   use sendrecv_grid, only: update_overlap_complex8
   use salmon_global, only: yn_want_communication_overlapping,alpha_pre
@@ -781,6 +782,16 @@ subroutine preconditioning_zgk(mg,system,info,gk,pre_gk)
     do ik=info%ik_s,info%ik_e
     do io=info%io_s,info%io_e
     do ispin=1,nspin
+      if (info%if_divide_rspace) then
+      ! r-space parallel: diagonal-metric preconditioner (cross term dropped; preconditioner-only)
+      call zstencil_nonorthogonal_preconditioning_diag(mg%is_array,mg%ie_array,mg%is,  &
+                                    mg%ie,mg%idx,mg%idy,mg%idz, &
+                                    gk%zwf(:,:,:,ispin,io,ik,1), &
+                                    pre_gk%zwf(:,:,:,ispin,io,ik,1), &
+                                    stencil%coef_lap0_nd1, &
+                                    stencil%coef_lap_nd1,stencil%coef_nab_nd1, &
+                                    stencil%coef_F,alpha)
+      else
       call zstencil_nonorthogonal_preconditioning(mg%is_array,mg%ie_array,mg%is,  &
                                     mg%ie,mg%idx,mg%idy,mg%idz, &
                                     gk%zwf(:,:,:,ispin,io,ik,1), &
@@ -788,6 +799,7 @@ subroutine preconditioning_zgk(mg,system,info,gk,pre_gk)
                                     stencil%coef_lap0_nd1, &
                                     stencil%coef_lap_nd1,stencil%coef_nab_nd1, &
                                     stencil%coef_F,alpha)
+      end if
     end do
     end do
     end do

--- a/src/gs/preconditioning.f90
+++ b/src/gs/preconditioning.f90
@@ -226,4 +226,61 @@ subroutine zstencil_nonorthogonal_preconditioning(is_array,ie_array,is,ie,idx,id
 #endif
 end subroutine zstencil_nonorthogonal_preconditioning
 
+!===================================================================================================================================
+
+subroutine zstencil_nonorthogonal_preconditioning_diag(is_array,ie_array,is,ie,idx,idy,idz &
+                                   ,tpsi,htpsi,lap0,lapt,nabt,F,alpha)
+! Diagonal-metric variant of zstencil_nonorthogonal_preconditioning for the r-space-parallel
+! case (nproc_rgrid>1). The off-diagonal-metric cross-derivative term (which would require
+! halo-exchanging the df/dx, df/dy intermediates) is omitted. This only changes the
+! preconditioner, not the converged Kohn-Sham state, so the SCF result is unaffected (CG may
+! take slightly more iterations). The diagonal part reads tpsi at face neighbors, whose halo
+! is exchanged by the caller. Serial nonorthogonal CG keeps the full routine; signature is
+! identical for a drop-in swap. nabt is unused here (kept for signature compatibility).
+  use structures
+  implicit none
+
+  integer   ,intent(in)    :: is_array(3),ie_array(3),is(3),ie(3) &
+                             ,idx(is(1)-4:ie(1)+4),idy(is(2)-4:ie(2)+4),idz(is(3)-4:ie(3)+4)
+  complex(8),intent(in)    :: tpsi(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  complex(8),intent(inout) :: htpsi(is_array(1):ie_array(1),is_array(2):ie_array(2),is_array(3):ie_array(3))
+  real(8)   ,intent(in)    :: lap0,lapt(1,3),nabt(1,3)
+  real(8)   ,intent(in)    :: F(6)
+  real(8)   ,intent(in)    :: alpha
+  !
+  integer :: ix,iy,iz
+  real(8) :: omega
+  real(8) :: d
+  complex(8) :: v(3)
+
+  omega=2.d0*(1.d0-alpha)
+  d = lap0
+#ifdef USE_OPENACC
+!$acc parallel
+!$acc loop collapse(2) private(iz,iy,ix,v)
+#else
+!$OMP parallel
+!$OMP do collapse(2) private(iz,iy,ix,v)
+#endif
+  do iz=is(3),ie(3)
+  do iy=is(2),ie(2)
+  do ix=is(1),ie(1)
+    v(1) =  lapt(1,1)*(tpsi(DX(1)) + tpsi(DX(-1)))
+    v(2) =  lapt(1,2)*(tpsi(DY(1)) + tpsi(DY(-1)))
+    v(3) =  lapt(1,3)*(tpsi(DZ(1)) + tpsi(DZ(-1)))
+
+    htpsi(ix,iy,iz) = lap0 * tpsi(ix,iy,iz) &
+                    - 0.5d0* ( F(1)*v(1) + F(2)*v(2) + F(3)*v(3) )
+    htpsi(ix,iy,iz) = omega/d*(2.d0*tpsi(ix,iy,iz)-omega/d*htpsi(ix,iy,iz))
+  end do
+  end do
+  end do
+#ifdef USE_OPENACC
+!$acc end parallel
+#else
+!$OMP end do
+!$OMP end parallel
+#endif
+end subroutine zstencil_nonorthogonal_preconditioning_diag
+
 end module preconditioning_sub


### PR DESCRIPTION
## Summary

Enables real-space domain decomposition (`nproc_rgrid > 1`) for nonorthogonal lattices, which was previously disabled by a guard in `initialization.f90`. The changes are additive and limited to the nonorthogonal r-space-parallel path; orthogonal stencils and serial (`nproc_rgrid = 1`) nonorthogonal runs take the existing code path unchanged.

## Background

The nonorthogonal kinetic operator (`zstencil_nonorthogonal`) forms the off-diagonal-metric cross derivatives by differentiating intermediate per-axis first-derivative fields (`df/dx`, `df/dy`) held in a work array. The serial path obtains the neighbors of that work array through the periodic index wrap; under r-space decomposition the work array's halo is not exchanged, which is why the case was guarded off. Access is in the face directions only, so the existing face halo is sufficient.

## Changes

- `stencil.f90` — `zstencil_nonorth_rspace_pass1/2`: a two-pass split of `zstencil_nonorthogonal` (algebraically equivalent) that exposes `df/dx`, `df/dy` for a halo exchange between the passes.
- `hamiltonian.f90` — `hpsi_nonorth_rspace`: pass1 → `update_overlap_complex8`(df/dx, df/dy) → pass2, selected when `.not. stencil%if_orthogonal .and. info%if_divide_rspace`. Reuses the wavefunction `srg`.
- `preconditioning.f90` + `conjugate_gradient.f90` — `zstencil_nonorthogonal_preconditioning_diag`: a diagonal-metric CG preconditioner for the r-space-parallel case (the cross term would require the same halo). This changes only the preconditioner, not the converged state; for strongly nonorthogonal cells a larger `ncg` may be needed for convergence.
- `initialization.f90` — round-robin atom partition over the r-space ranks. The Ewald ion-ion sums loop over `info%ia_mg` and reduce over `icomm_r`; with all atoms replicated on each rank the real-space Ewald was counted `nproc_rgrid` times. The partition assigns each atom to a single rank so the reduction yields the full sum. The guards are removed.

## Validation

Primitive Si (nonorthogonal FCC, `nr=16`, Γ), `nproc_rgrid=(1,1,1)` vs `(1,1,2)`, `ncg=16`:

| quantity | difference (r-space-parallel vs serial) |
|---|---|
| total energy | 1.8e-8 eV |
| stress (P_total) | 2e-7 GPa |
| Ewald terms (E_ewa_R, P_ewa, P_ewa_R) | none |
| eigenvalues (8 states), forces | none |

Built with the Fujitsu compiler (A64FX).

## Notes

The branch is based on `feature/stress-tensor`; the changes are independent of the stress / meta-GGA work and can be rebased onto `develop-2.0.0`. The new routines are CPU/OpenMP only (no GPU/OpenACC path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
