### PR TITLE
Three-temperature (electron/hole/lattice) carrier model coupled to Maxwell-FDTD (ttm3)

### DIFF
--- a/src/common/structures.f90
+++ b/src/common/structures.f90
@@ -398,6 +398,7 @@ module structures
     real(8) :: origin(3)                  ! Coordinate of Origin Point (TBA)
     character(8)  :: a_bc(3,2)            ! Boundary Condition for 1:x, 2:y, 3:z and 1:bottom and 2:top
     integer, allocatable :: imedia(:,:,:) ! Material information
+    integer :: icomm_x = 0, id_x = 0, isize_x = 1   ! x-axis sub-comm (ttm3 space-charge x-decomp)
   end type s_fdtd_system
 
   type s_opt

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -51,6 +51,7 @@ module inputoutput
   integer :: inml_singlescale
   integer :: inml_multiscale
   integer :: inml_maxwell
+  integer :: inml_ttm
   integer :: inml_analysis
   integer :: inml_poisson
   integer :: inml_ewald
@@ -467,6 +468,12 @@ contains
       & ori_s,                    &
       & rot_s
 
+    namelist/ttm/ &
+      & ttm_egap, ttm_mu_e, ttm_mu_h, ttm_auger_e, ttm_auger_h, &
+      & ttm_tau, ttm_cl, ttm_tini, ttm_eps_bg, ttm_n0, ttm_beta2, &
+      & ttm_ddiff, ttm_kappa_e, ttm_kappa_l, ttm_dgap, &
+      & ttm_mob_e, ttm_mob_h, ttm_sig_cold, ttm_coupling
+
     namelist/analysis/ &
       & projection_option, &
       & out_projection_step, &
@@ -642,6 +649,26 @@ contains
 
 !! == default for &calculation
     theory              = 'tddft'
+    ttm_egap     = 1.16d0
+    ttm_mu_e     = 0.36d0
+    ttm_mu_h     = 0.81d0
+    ttm_auger_e  = 2.3d-31
+    ttm_auger_h  = 7.8d-32
+    ttm_tau      = 240.0d0
+    ttm_cl       = 1.66d6
+    ttm_tini     = 300.0d0
+    ttm_eps_bg   = 13.55d0
+    ttm_n0       = 2.0d23
+    ttm_beta2    = 0.0d0
+    ttm_ddiff    = 0.0d0
+    ttm_kappa_e  = 0.0d0
+    ttm_kappa_l  = 0.0d0
+    ttm_dgap     = 0.055d0
+    ttm_mob_e    = 0.0d0
+    ttm_mob_h    = 0.0d0
+    ttm_sig_cold = 0.0d0
+    ttm_coupling = 1
+    yn_use_ttm3  = .false.
     yn_md               = 'n'
     yn_opt              = 'n'
     yn_dc               = 'n'
@@ -1079,6 +1106,9 @@ contains
       read(fh_namelist, nml=maxwell, iostat=inml_maxwell)
       rewind(fh_namelist)
 
+      read(fh_namelist, nml=ttm, iostat=inml_ttm)
+      rewind(fh_namelist)
+
       read(fh_namelist, nml=analysis, iostat=inml_analysis)
       rewind(fh_namelist)
 
@@ -1433,6 +1463,25 @@ contains
     call comm_bcast(gamma_ld                 ,nproc_group_global)
     gamma_ld = gamma_ld * uenergy_to_au
     call comm_bcast(omega_ld                 ,nproc_group_global)
+    call comm_bcast(ttm_egap                 ,nproc_group_global)
+    call comm_bcast(ttm_mu_e                 ,nproc_group_global)
+    call comm_bcast(ttm_mu_h                 ,nproc_group_global)
+    call comm_bcast(ttm_auger_e              ,nproc_group_global)
+    call comm_bcast(ttm_auger_h              ,nproc_group_global)
+    call comm_bcast(ttm_tau                  ,nproc_group_global)
+    call comm_bcast(ttm_cl                   ,nproc_group_global)
+    call comm_bcast(ttm_tini                 ,nproc_group_global)
+    call comm_bcast(ttm_eps_bg               ,nproc_group_global)
+    call comm_bcast(ttm_n0                   ,nproc_group_global)
+    call comm_bcast(ttm_beta2                ,nproc_group_global)
+    call comm_bcast(ttm_ddiff                ,nproc_group_global)
+    call comm_bcast(ttm_kappa_e              ,nproc_group_global)
+    call comm_bcast(ttm_kappa_l              ,nproc_group_global)
+    call comm_bcast(ttm_dgap                 ,nproc_group_global)
+    call comm_bcast(ttm_mob_e                ,nproc_group_global)
+    call comm_bcast(ttm_mob_h                ,nproc_group_global)
+    call comm_bcast(ttm_sig_cold             ,nproc_group_global)
+    call comm_bcast(ttm_coupling             ,nproc_group_global)
     omega_ld = omega_ld * uenergy_to_au
     call comm_bcast(wave_input,nproc_group_global)
     call comm_bcast(ek_dir1                  ,nproc_group_global)

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -663,11 +663,11 @@ contains
     ttm_ddiff    = 0.0d0
     ttm_kappa_e  = 0.0d0
     ttm_kappa_l  = 0.0d0
-    ttm_dgap     = 0.055d0
+    ttm_dgap     = 0.10417d0  ! BGN 1.5 eV*A*Ne^(1/3) in a.u.: 1.5/(0.529177*27.2114)
     ttm_mob_e    = 0.0d0
     ttm_mob_h    = 0.0d0
     ttm_sig_cold = 0.0d0
-    ttm_coupling = 1
+    ttm_coupling = 3          ! exact-exponential JE: unconditionally stable incl. metallization
     yn_use_ttm3  = .false.
     yn_md               = 'n'
     yn_opt              = 'n'
@@ -2672,7 +2672,29 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",I6)') "nstate_frag",nstate_frag
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'energy_cut', energy_cut
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'lambda_cut', lambda_cut
-      
+
+      if(inml_ttm >0)ierr_nml = ierr_nml +1
+      write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'ttm', inml_ttm
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_egap', ttm_egap
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_mu_e', ttm_mu_e
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_mu_h', ttm_mu_h
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_auger_e', ttm_auger_e
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_auger_h', ttm_auger_h
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_tau', ttm_tau
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_cl', ttm_cl
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_tini', ttm_tini
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_eps_bg', ttm_eps_bg
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_n0', ttm_n0
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_beta2', ttm_beta2
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_ddiff', ttm_ddiff
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_kappa_e', ttm_kappa_e
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_kappa_l', ttm_kappa_l
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_dgap', ttm_dgap
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_mob_e', ttm_mob_e
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_mob_h', ttm_mob_h
+      write(fh_variables_log, '("#",4X,A,"=",ES14.5)') 'ttm_sig_cold', ttm_sig_cold
+      write(fh_variables_log, '("#",4X,A,"=",I6)') 'ttm_coupling', ttm_coupling
+
       close(fh_variables_log)
     end if
 

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -431,6 +431,7 @@ contains
       & yn_obs_plane_em,          &
       & yn_obs_plane_integral_em, &
       & yn_wf_em,                 &
+      & yn_em_envelope,           &
       & film_thickness,           &
       & media_id_pml,             &
       & media_id_source1,         &
@@ -858,6 +859,7 @@ contains
     yn_obs_plane_em(:)          = 'n'
     yn_obs_plane_integral_em(:) = 'n'
     yn_wf_em                    = 'y'
+    yn_em_envelope              = 'n'
     film_thickness              = 0d0
     media_id_pml(:,:)           = 0
     media_id_source1            = 0
@@ -1144,6 +1146,7 @@ contains
     call string_lowercase(bloch_real_imag_em(1))
     call string_lowercase(bloch_real_imag_em(2))
     call string_lowercase(bloch_real_imag_em(3))
+    call string_lowercase(yn_em_envelope)
     if(n_s>0) then
       do ii = 1,n_s
         call string_lowercase(typ_s(ii))
@@ -1455,6 +1458,7 @@ contains
     call comm_bcast(yn_obs_plane_em          ,nproc_group_global)
     call comm_bcast(yn_obs_plane_integral_em ,nproc_group_global)
     call comm_bcast(yn_wf_em                 ,nproc_group_global)
+    call comm_bcast(yn_em_envelope           ,nproc_group_global)
     call comm_bcast(film_thickness           ,nproc_group_global)
     film_thickness = film_thickness * ulength_to_au
     call comm_bcast(media_id_pml             ,nproc_group_global)
@@ -2365,6 +2369,7 @@ contains
         end do
       end if
       write(fh_variables_log, '("#",4X,A,"=",A)')      'yn_wf_em', yn_wf_em
+      write(fh_variables_log, '("#",4X,A,"=",A)')      'yn_em_envelope', yn_em_envelope
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'film_thickness', film_thickness
       write(fh_variables_log, '("#",4X,A,"=",I6)')     'media_id_pml(1,1)', media_id_pml(1,1)
       write(fh_variables_log, '("#",4X,A,"=",I6)')     'media_id_pml(1,2)', media_id_pml(1,2)
@@ -2704,6 +2709,7 @@ contains
       end do
     end if
     call yn_argument_check(yn_wf_em)
+    call yn_argument_check(yn_em_envelope)
     call yn_argument_check(yn_make_shape)
     call yn_argument_check(yn_output_shape)
     call yn_argument_check(yn_copy_x)
@@ -2933,6 +2939,11 @@ contains
       if(yn_jm=='y') stop "DC method (yn_dc=y): yn_jm=y is not supported."
       if(base_directory /= './') stop "DC method (yn_dc=y): base_directory must be default."
       if(nproc_k/=1) stop "DC method (yn_dc=y): nproc_k must be 1 for both the total system and fragments."
+    end if
+
+    if(yn_em_envelope=='y')then
+      if(omega1<=0d0) stop "yn_em_envelope=y requires a single carrier omega1>0"
+      if(omega2/=0d0) stop "yn_em_envelope=y supports a single carrier only (unset omega2)"
     end if
 
 #ifdef USE_FFTW

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -234,6 +234,28 @@ module salmon_global
   integer        :: nmacro_chunk
   real(8)        :: rmat_ms(3, 3)
 
+!! &ttm  (temperature model; theory = maxwell-3tm)
+  real(8)        :: ttm_egap
+  real(8)        :: ttm_mu_e
+  real(8)        :: ttm_mu_h
+  real(8)        :: ttm_auger_e
+  real(8)        :: ttm_auger_h
+  real(8)        :: ttm_tau
+  real(8)        :: ttm_cl
+  real(8)        :: ttm_tini
+  real(8)        :: ttm_eps_bg
+  real(8)        :: ttm_n0
+  real(8)        :: ttm_beta2
+  real(8)        :: ttm_ddiff
+  real(8)        :: ttm_kappa_e
+  real(8)        :: ttm_kappa_l
+  real(8)        :: ttm_dgap
+  real(8)        :: ttm_mob_e
+  real(8)        :: ttm_mob_h
+  real(8)        :: ttm_sig_cold
+  integer        :: ttm_coupling
+  logical        :: yn_use_ttm3
+
 !! &maxwell
   real(8)        :: al_em(3)
   real(8)        :: dl_em(3)

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -269,6 +269,7 @@ module salmon_global
   character(1)   :: yn_obs_plane_em(200)
   character(1)   :: yn_obs_plane_integral_em(200)
   character(1)   :: yn_wf_em
+  character(1)   :: yn_em_envelope
   real(8)        :: film_thickness
   integer        :: media_id_pml(3,2)
   integer        :: media_id_source1

--- a/src/main.f90
+++ b/src/main.f90
@@ -17,6 +17,10 @@
   endif
 
   call read_input
+  if( theory == 'maxwell-3tm' )then
+    yn_use_ttm3 = .true.
+    theory      = 'maxwell'
+  end if
   call set_basic_flag(theory)
 
   call read_Hubbard_parameters  !should move into read_input subroutine!
@@ -35,7 +39,7 @@
   case('dft_k_expand')                ; call main_dft_k_expand !convert DFT/k-points data to supercell/gammma DFT
   case('single_scale_maxwell_tddft'  ); call main_tddft
   case('multi_scale_maxwell_tddft'   ); call main_ms
-  case('maxwell')                     ; call main_maxwell
+  case('maxwell','maxwell-3tm')       ; call main_maxwell
   case('sbe', 'maxwell_sbe')          ; call main_ssbe(nproc_group_global)
  !case('maxwell_sbe')                 ; call main_maxwell_sbe
  !case('ttm')                         ; call main_ttm

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3311,7 +3311,7 @@ contains
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
     use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_get_front,ttm3_eps_sig,&
                                ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_front_ijk,ttm3_write_profile,&
-                               ttm3_drude_coef_cell,ttm3_coupling_mode
+                               ttm3_drude_coef_cell,ttm3_coupling_mode,ttm3_drude_osc_cell
     use phys_constants,  only: cspeed_au
     use math_constants,  only: pi
     implicit none
@@ -3334,6 +3334,7 @@ contains
     real(8) :: t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
     real(8) :: t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf
     real(8) :: t3_eps,t3_sig,t3_de,t3_c1,t3_cx,t3_cy,t3_cz,t3_cj,t3_gtpa
+    real(8) :: t3_ge,t3_wp2,t3_a,t3_b,t3_d2,t3_p,t3_dd,t3_cc,t3_ss,t3_m11,t3_m12,t3_m21,t3_m22,t3_estar,t3_enew,t3_dfld
     integer :: t3_im
     real(8),allocatable :: u_energy(:,:,:), u_energy_p(:,:,:)
     real(8),allocatable :: work(:,:,:), work1(:,:,:), work2(:,:,:)
@@ -3375,7 +3376,7 @@ contains
                                                  fe%gbeam_width_x2 ,fe%gbeam_width_y2 ,fe%gbeam_width_z2 )
       end if
       if(fe%flag_ld) call eh_add_curr(fe%rjx_fdtd_ld(:,:,:),fe%rjy_fdtd_ld(:,:,:),fe%rjz_fdtd_ld(:,:,:))
-      if(use_ttm3 .and. allocated(t3_rjfx) .and. ttm3_coupling_mode()==0) &
+      if(use_ttm3 .and. allocated(t3_rjfx) .and. ( ttm3_coupling_mode()==0 .or. ttm3_coupling_mode()==2 )) &
         call eh_add_curr(t3_rjfx,t3_rjfy,t3_rjfz)  ! carrier Drude current (J-update only)
       call eh_sendrecv(fs,fe,'e')
       
@@ -3450,7 +3451,7 @@ contains
         end if
         !ghost LD current
         if(fe%flag_ld) call eh_add_curr_g(fe%rjx_fdtd_ld_g,fe%rjy_fdtd_ld_g,fe%rjz_fdtd_ld_g)
-        if(use_ttm3 .and. allocated(t3_rjfx_g) .and. ttm3_coupling_mode()==0) &
+        if(use_ttm3 .and. allocated(t3_rjfx_g) .and. ( ttm3_coupling_mode()==0 .or. ttm3_coupling_mode()==2 )) &
           call eh_add_curr_g(t3_rjfx_g,t3_rjfy_g,t3_rjfz_g)  ! ghost carrier Drude (J-update only)
         call eh_sendrecv(fs,fe,'e_g')
 
@@ -3607,7 +3608,7 @@ contains
         !    optics (eps_bg + sig_cold) from init.  This replaces the old eps/sigma coefficient
         !    back-action, which is numerically unstable in the real-field FDTD when sigma grows
         !    fast (abrupt coefficient change -> front/antinode runaway).
-        if( ttm3_coupling_mode()==0 )then
+        if( ( ttm3_coupling_mode()==0 .or. ttm3_coupling_mode()==2 ) )then
         do t3_im=1,ttm3_ninterior()
           call ttm3_interior_cell( t3_im, ix,iy,iz )
             call ttm3_drude_coef_cell( ix,iy,iz, omega1, dt_em, t3_c1, t3_cj )   ! c1, c2 (ADE)
@@ -3626,6 +3627,62 @@ contains
               t3_rjfz_g(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jz_g(ix,iy,iz)
             end if
         end do
+        else if( ttm3_coupling_mode()==3 )then
+          !--- mode 3: exact local Drude-oscillator exponential sub-step (semi-implicit JE).
+          !    After the lossless E-update, advance each interior cell (E_a,J_a) under the local
+          !    Drude oscillator d/dt[E;J]=[[0,-4pi/eps],[wp2/4pi,-gamma]][E;J] by the exact 2x2
+          !    matrix exponential, then redistribute dE equally to the split-Yee components.
+          !    Unconditionally stable, energy-conserving, broadband.  No eh_add_curr injection.
+          do t3_im=1,ttm3_ninterior()
+            call ttm3_interior_cell( t3_im, ix,iy,iz )
+            call ttm3_drude_osc_cell( ix,iy,iz, t3_eps, t3_ge, t3_wp2 )
+            t3_b  = 4.0d0*pi/t3_eps ; t3_a = t3_wp2/(4.0d0*pi)
+            t3_d2 = (0.5d0*t3_ge)**2 - t3_a*t3_b
+            t3_p  = exp( -0.5d0*t3_ge*dt_em )
+            if( t3_d2 > 1.0d-30 )then
+              t3_dd = sqrt(t3_d2) ; t3_cc = cosh(t3_dd*dt_em) ; t3_ss = sinh(t3_dd*dt_em)/t3_dd
+            else if( t3_d2 < -1.0d-30 )then
+              t3_dd = sqrt(-t3_d2) ; t3_cc = cos(t3_dd*dt_em) ; t3_ss = sin(t3_dd*dt_em)/t3_dd
+            else
+              t3_cc = 1.0d0 ; t3_ss = dt_em
+            end if
+            t3_m11 = t3_p*( t3_cc + 0.5d0*t3_ge*t3_ss )
+            t3_m12 = t3_p*( -t3_b*t3_ss )
+            t3_m21 = t3_p*(  t3_a*t3_ss )
+            t3_m22 = t3_p*( t3_cc - 0.5d0*t3_ge*t3_ss )
+            t3_estar = fe%ex_y(ix,iy,iz)+fe%ex_z(ix,iy,iz)
+            t3_enew  = t3_m11*t3_estar + t3_m12*t3_jx(ix,iy,iz)
+            t3_jx(ix,iy,iz) = t3_m21*t3_estar + t3_m22*t3_jx(ix,iy,iz)
+            t3_dfld = 0.5d0*( t3_enew - t3_estar )
+            fe%ex_y(ix,iy,iz)=fe%ex_y(ix,iy,iz)+t3_dfld ; fe%ex_z(ix,iy,iz)=fe%ex_z(ix,iy,iz)+t3_dfld
+            t3_estar = fe%ey_z(ix,iy,iz)+fe%ey_x(ix,iy,iz)
+            t3_enew  = t3_m11*t3_estar + t3_m12*t3_jy(ix,iy,iz)
+            t3_jy(ix,iy,iz) = t3_m21*t3_estar + t3_m22*t3_jy(ix,iy,iz)
+            t3_dfld = 0.5d0*( t3_enew - t3_estar )
+            fe%ey_z(ix,iy,iz)=fe%ey_z(ix,iy,iz)+t3_dfld ; fe%ey_x(ix,iy,iz)=fe%ey_x(ix,iy,iz)+t3_dfld
+            t3_estar = fe%ez_x(ix,iy,iz)+fe%ez_y(ix,iy,iz)
+            t3_enew  = t3_m11*t3_estar + t3_m12*t3_jz(ix,iy,iz)
+            t3_jz(ix,iy,iz) = t3_m21*t3_estar + t3_m22*t3_jz(ix,iy,iz)
+            t3_dfld = 0.5d0*( t3_enew - t3_estar )
+            fe%ez_x(ix,iy,iz)=fe%ez_x(ix,iy,iz)+t3_dfld ; fe%ez_y(ix,iy,iz)=fe%ez_y(ix,iy,iz)+t3_dfld
+            if(yn_em_envelope=="y")then
+              t3_estar = fe%ex_y_g(ix,iy,iz)+fe%ex_z_g(ix,iy,iz)
+              t3_enew  = t3_m11*t3_estar + t3_m12*t3_jx_g(ix,iy,iz)
+              t3_jx_g(ix,iy,iz) = t3_m21*t3_estar + t3_m22*t3_jx_g(ix,iy,iz)
+              t3_dfld = 0.5d0*( t3_enew - t3_estar )
+              fe%ex_y_g(ix,iy,iz)=fe%ex_y_g(ix,iy,iz)+t3_dfld ; fe%ex_z_g(ix,iy,iz)=fe%ex_z_g(ix,iy,iz)+t3_dfld
+              t3_estar = fe%ey_z_g(ix,iy,iz)+fe%ey_x_g(ix,iy,iz)
+              t3_enew  = t3_m11*t3_estar + t3_m12*t3_jy_g(ix,iy,iz)
+              t3_jy_g(ix,iy,iz) = t3_m21*t3_estar + t3_m22*t3_jy_g(ix,iy,iz)
+              t3_dfld = 0.5d0*( t3_enew - t3_estar )
+              fe%ey_z_g(ix,iy,iz)=fe%ey_z_g(ix,iy,iz)+t3_dfld ; fe%ey_x_g(ix,iy,iz)=fe%ey_x_g(ix,iy,iz)+t3_dfld
+              t3_estar = fe%ez_x_g(ix,iy,iz)+fe%ez_y_g(ix,iy,iz)
+              t3_enew  = t3_m11*t3_estar + t3_m12*t3_jz_g(ix,iy,iz)
+              t3_jz_g(ix,iy,iz) = t3_m21*t3_estar + t3_m22*t3_jz_g(ix,iy,iz)
+              t3_dfld = 0.5d0*( t3_enew - t3_estar )
+              fe%ez_x_g(ix,iy,iz)=fe%ez_x_g(ix,iy,iz)+t3_dfld ; fe%ez_y_g(ix,iy,iz)=fe%ez_y_g(ix,iy,iz)+t3_dfld
+            end if
+          end do
         else
           !--- eps-update coupling (reference 3D3TM style): fold the carrier eps/sigma into the
           !    FDTD media coefficients each step (same dielectric formula as init), instead of a

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -245,7 +245,7 @@ contains
                                input_i3d_em,output_i3d_em,stop_em,input_r_txt_em,output_r_txt_em,input_r_bin_em, &
                                txtfile_copy_em
     use ttm,             only: use_ttm, init_ttm_parameters, init_ttm_grid, init_ttm_alloc
-    use ttm3,            only: use_ttm3, init_ttm3_parameters, init_ttm3_grid, init_ttm3_alloc
+    use ttm3,            only: use_ttm3, init_ttm3_parameters, ttm3_set_dt, init_ttm3_grid, init_ttm3_alloc
     implicit none
     type(s_fdtd_system),intent(inout) :: fs
     type(ls_fdtd_eh),   intent(inout) :: fe
@@ -867,6 +867,7 @@ contains
 
     !--- three-temperature + carrier model (ttm3) grid/allocation (parameters read earlier) ------!
     if( use_ttm3 )then
+       call ttm3_set_dt( dt_em )   ! dt_em is finalised (CFL) by here; the early init captured 0
        call init_ttm3_grid( fs%hgs, fs%mg%is_array, fs%mg%is, fs%mg%ie, fs%imedia )
        call init_ttm3_alloc( fs%srg_ng, fs%mg )
        if( comm_is_root(nproc_id_global) )then

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3638,9 +3638,13 @@ contains
             open(unit2,file='3tm_rt.data',status='old',position='append')
             ! col 12 = front-cell field-intensity envelope |E|^2+|E_g|^2 [a.u.]; compare to the
             ! reference surface intensity out_all(6)=3.509e16*|E|^2*n to localize the ~2x field factor.
+            ! col 13 = front-cell heating source -divS [a.u. power/vol]; col 14 = front-cell
+            ! generation rate [a.u.].  With Te/Ne/Tl these reconstruct the full dTe balance
+            ! externally (Ce, e-phonon, dilution, Col, gap cost) -> localize what sets Te.
             write(unit2,"(F16.8,99(1X,E23.15E3))") &
                  dble(iter)*dt_em*utime_from_au, &
-                 t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh, t3_env(ix,iy,iz)
+                 t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh, t3_env(ix,iy,iz), &
+                 t3_power(ix,iy,iz), t3_gen(ix,iy,iz)
             close(unit2)
             ! depth profile (time, ix, Te[K], Ne[cm-3], Tl[K], |E|^2[a.u.]) for spatial diagnostics
             call ttm3_write_profile( '3tm_prof.data', dble(iter)*dt_em*utime_from_au, unit2, t3_env )

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3197,13 +3197,13 @@ contains
       
       !check ae_shape
       select case(ae_shape)
-      case('Ecos2','Acos2','Agauss')
+      case('Ecos2','Acos2','Agauss','Adgauss')
         continue
       case default
         if     (ipulse==1) then
-          call stop_em('set ae_shape1 to "Ecos2", "Acos2" or "Agauss".')
+          call stop_em('set ae_shape1 to "Ecos2", "Acos2", "Agauss" or "Adgauss".')
         elseif (ipulse==2) then
-          call stop_em('set ae_shape2 to "Ecos2", "Acos2" or "Agauss".')
+          call stop_em('set ae_shape2 to "Ecos2", "Acos2", "Agauss" or "Adgauss".')
         end if
       end select
       
@@ -6661,6 +6661,20 @@ contains
       theta2_i = omega*gamma + cep*2d0*pi + 1.5d0*pi
       e_inc_r  = amp*alpha*( sin(theta2_r) + beta/omega*cos(theta2_r) )
       e_inc_i  = amp*alpha*( sin(theta2_i) + beta/omega*cos(theta2_i) )
+    elseif(aes=='Adgauss') then
+      ! Gaussian-DERIVATIVE field envelope (peak at the rising/falling inflection
+      ! t=4tw-+tw/sqrt2, zero at the centre 4tw).  This reproduces the standalone 3D3TM
+      ! reference's effective surface drive (its complex-envelope solver yields a field
+      ! intensity following |d(Gaussian)/dt|^2 rather than the Gaussian itself).  The
+      ! envelope is odd about the centre, so the carrier oscillation already gives
+      ! \int E dt = 0.  Used for faithful numerical comparison against the reference;
+      ! the physically standard envelope is 'Agauss'.
+      gamma    = t - 4.0d0*tw                                 ! time from the Gaussian centre
+      alpha    = 2.3315d0*gamma/tw*exp( -gamma*gamma/(tw*tw) ) ! Gaussian-derivative envelope, peak ~amp
+      theta2_r = omega*gamma + cep*2d0*pi
+      theta2_i = omega*gamma + cep*2d0*pi + 1.5d0*pi
+      e_inc_r  = amp*alpha*sin(theta2_r)
+      e_inc_i  = amp*alpha*sin(theta2_i)
     else
       e_inc_r=0.0d0; e_inc_i=0.0d0;
     end if

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3263,7 +3263,7 @@ contains
                                base_directory,nt_em,yn_periodic,ek_dir1,t1_t2,t1_start,              &
                                E_amplitude1,tw1,omega1,phi_cep1,epdir_re1,epdir_im1,ae_shape1,       &
                                E_amplitude2,tw2,omega2,phi_cep2,epdir_re2,epdir_im2,ae_shape2,       &
-                               checkpoint_interval,ase_num_em,art_num_em
+                               checkpoint_interval,ase_num_em,art_num_em,yn_em_envelope
     use inputoutput,     only: utime_from_au,uenergy_from_au
     use parallelization, only: nproc_id_global,nproc_size_global,nproc_group_global
     use communication,   only: comm_is_root,comm_summation
@@ -3360,7 +3360,62 @@ contains
       call eh_fd(fe%ihz_y_is,fe%ihz_y_ie,      fs%mg%is,fs%mg%ie,fe%Nd,&
                  fe%c1_hz_y,fe%c2_hz_y,fe%hz_y,fe%ex_y,fe%ex_z,'h','y',cb_y = fe%c_ebloch_y) !hz_y
       call eh_sendrecv(fs,fe,'h')
-      
+
+      !--- ghost (quadrature) field propagation — lockstep with real field -------------------!
+      if(yn_em_envelope=='y') then
+        !store ghost LD old values
+        if(fe%flag_ld) call eh_store_old_g
+
+        !update ghost E
+        call eh_fd(fe%iex_y_is,fe%iex_y_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_ex_y,fe%c2_ex_y,fe%ex_y_g,fe%hz_x_g,fe%hz_y_g,'e','y',cb_y=fe%c_hbloch_y) !ex_y_g
+        call eh_fd(fe%iex_z_is,fe%iex_z_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_ex_z,fe%c2_ex_z,fe%ex_z_g,fe%hy_z_g,fe%hy_x_g,'e','z',cb_z=fe%c_hbloch_z) !ex_z_g
+        call eh_fd(fe%iey_z_is,fe%iey_z_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_ey_z,fe%c2_ey_z,fe%ey_z_g,fe%hx_y_g,fe%hx_z_g,'e','z',cb_z=fe%c_hbloch_z) !ey_z_g
+        call eh_fd(fe%iey_x_is,fe%iey_x_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_ey_x,fe%c2_ey_x,fe%ey_x_g,fe%hz_x_g,fe%hz_y_g,'e','x',cb_x=fe%c_hbloch_x) !ey_x_g
+        call eh_fd(fe%iez_x_is,fe%iez_x_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_ez_x,fe%c2_ez_x,fe%ez_x_g,fe%hy_z_g,fe%hy_x_g,'e','x',cb_x=fe%c_hbloch_x) !ez_x_g
+        call eh_fd(fe%iez_y_is,fe%iez_y_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_ez_y,fe%c2_ez_y,fe%ez_y_g,fe%hx_y_g,fe%hx_z_g,'e','y',cb_y=fe%c_hbloch_y) !ez_y_g
+        !ghost incident source: same parameters but carrier phase shifted -pi/2 (cep -= 0.25)
+        if(fe%inc_num>0) then
+          if(fe%inc_dist1/='none' .and. ae_shape1/='impulse') &
+            call eh_add_inc_g(1,E_amplitude1,tw1,omega1,phi_cep1-0.25d0,               &
+                              epdir_re1,epdir_im1,fe%c2_inc1_xyz,ae_shape1,fe%inc_dist1,&
+                              fe%gbeam_width_xy1,fe%gbeam_width_yz1,fe%gbeam_width_xz1, &
+                              fe%gbeam_width_x1 ,fe%gbeam_width_y1 ,fe%gbeam_width_z1 )
+          if(fe%inc_dist2/='none' .and. ae_shape2/='impulse') &
+            call eh_add_inc_g(2,E_amplitude2,tw2,omega2,phi_cep2-0.25d0,               &
+                              epdir_re2,epdir_im2,fe%c2_inc2_xyz,ae_shape2,fe%inc_dist2,&
+                              fe%gbeam_width_xy2,fe%gbeam_width_yz2,fe%gbeam_width_xz2, &
+                              fe%gbeam_width_x2 ,fe%gbeam_width_y2 ,fe%gbeam_width_z2 )
+        end if
+        !ghost LD current
+        if(fe%flag_ld) call eh_add_curr_g(fe%rjx_fdtd_ld_g,fe%rjy_fdtd_ld_g,fe%rjz_fdtd_ld_g)
+        call eh_sendrecv(fs,fe,'e_g')
+
+        !update ghost LD
+        if(fe%flag_ld) call eh_update_ld_g
+
+        !update ghost H
+        call eh_fd(fe%ihx_y_is,fe%ihx_y_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_hx_y,fe%c2_hx_y,fe%hx_y_g,fe%ez_x_g,fe%ez_y_g,'h','y',cb_y=fe%c_ebloch_y) !hx_y_g
+        call eh_fd(fe%ihx_z_is,fe%ihx_z_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_hx_z,fe%c2_hx_z,fe%hx_z_g,fe%ey_z_g,fe%ey_x_g,'h','z',cb_z=fe%c_ebloch_z) !hx_z_g
+        call eh_fd(fe%ihy_z_is,fe%ihy_z_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_hy_z,fe%c2_hy_z,fe%hy_z_g,fe%ex_y_g,fe%ex_z_g,'h','z',cb_z=fe%c_ebloch_z) !hy_z_g
+        call eh_fd(fe%ihy_x_is,fe%ihy_x_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_hy_x,fe%c2_hy_x,fe%hy_x_g,fe%ez_x_g,fe%ez_y_g,'h','x',cb_x=fe%c_ebloch_x) !hy_x_g
+        call eh_fd(fe%ihz_x_is,fe%ihz_x_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_hz_x,fe%c2_hz_x,fe%hz_x_g,fe%ey_z_g,fe%ey_x_g,'h','x',cb_x=fe%c_ebloch_x) !hz_x_g
+        call eh_fd(fe%ihz_y_is,fe%ihz_y_ie, fs%mg%is,fs%mg%ie,fe%Nd,&
+                   fe%c1_hz_y,fe%c2_hz_y,fe%hz_y_g,fe%ex_y_g,fe%ex_z_g,'h','y',cb_y=fe%c_ebloch_y) !hz_y_g
+        call eh_sendrecv(fs,fe,'h_g')
+      end if !yn_em_envelope
+      !--- end ghost field propagation -------------------------------------------------------!
+
       !ttm
       if( use_ttm )then
         !Poynting vector
@@ -3455,6 +3510,21 @@ contains
                     fe%hy_s(fe%iobs_po_id(ii,1),fe%iobs_po_id(ii,2),fe%iobs_po_id(ii,3))*fe%uAperm_from_au, &
                     fe%hz_s(fe%iobs_po_id(ii,1),fe%iobs_po_id(ii,2),fe%iobs_po_id(ii,3))*fe%uAperm_from_au
               close(fe%ifn)
+              !ghost (quadrature) field diagnostic output
+              if(yn_em_envelope=='y') then
+                write(save_name,*) ii
+                save_name=trim(adjustl(base_directory))//'/obs'//trim(adjustl(save_name))//'_at_point_ghost_rt.data'
+                open(fe%ifn,file=save_name,status='unknown',position='append')
+                write(fe%ifn,"(F16.8,3(1X,E23.15E3))",advance='no')                                                    &
+                      dble(iter)*dt_em*utime_from_au,                                                                  &
+                      (fe%ex_y_g(fe%iobs_po_id(ii,1),fe%iobs_po_id(ii,2),fe%iobs_po_id(ii,3))                         &
+                      +fe%ex_z_g(fe%iobs_po_id(ii,1),fe%iobs_po_id(ii,2),fe%iobs_po_id(ii,3)))*fe%uVperm_from_au,     &
+                      (fe%ey_z_g(fe%iobs_po_id(ii,1),fe%iobs_po_id(ii,2),fe%iobs_po_id(ii,3))                         &
+                      +fe%ey_x_g(fe%iobs_po_id(ii,1),fe%iobs_po_id(ii,2),fe%iobs_po_id(ii,3)))*fe%uVperm_from_au,     &
+                      (fe%ez_x_g(fe%iobs_po_id(ii,1),fe%iobs_po_id(ii,2),fe%iobs_po_id(ii,3))                         &
+                      +fe%ez_y_g(fe%iobs_po_id(ii,1),fe%iobs_po_id(ii,2),fe%iobs_po_id(ii,3)))*fe%uVperm_from_au
+                close(fe%ifn)
+              end if !yn_em_envelope
             end if
             
             !plane
@@ -4689,7 +4759,376 @@ contains
       
       return
     end subroutine eh_update_max
-    
+
+    !+ CONTAINED IN eh_calc ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    !+ store ghost LD old values +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    subroutine eh_store_old_g
+      implicit none
+
+!$omp parallel
+!$omp do private(ii,ix,iy,iz) collapse(3)
+      do ii=1,fe%max_pole_num_ld
+      do iz=fs%mg%is(3),fs%mg%ie(3)
+      do iy=fs%mg%is(2),fs%mg%ie(2)
+      do ix=fs%mg%is(1),fs%mg%ie(1)
+        fe%rjx_old_ld_g(ix,iy,iz,ii) = fe%rjx_ld_g(ix,iy,iz,ii)
+        fe%rjy_old_ld_g(ix,iy,iz,ii) = fe%rjy_ld_g(ix,iy,iz,ii)
+        fe%rjz_old_ld_g(ix,iy,iz,ii) = fe%rjz_ld_g(ix,iy,iz,ii)
+      end do
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fs%mg%is(3),fs%mg%ie(3)
+      do iy=fs%mg%is(2),fs%mg%ie(2)
+      do ix=fs%mg%is(1),fs%mg%ie(1)
+        fe%ex_old_ld_g(ix,iy,iz) = fe%ex_y_g(ix,iy,iz) + fe%ex_z_g(ix,iy,iz)
+        fe%ey_old_ld_g(ix,iy,iz) = fe%ey_z_g(ix,iy,iz) + fe%ey_x_g(ix,iy,iz)
+        fe%ez_old_ld_g(ix,iy,iz) = fe%ez_x_g(ix,iy,iz) + fe%ez_y_g(ix,iy,iz)
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+
+      return
+    end subroutine eh_store_old_g
+
+    !+ CONTAINED IN eh_calc ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    !+ update ghost Lorentz-Drude ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    subroutine eh_update_ld_g
+      implicit none
+
+      !initialize
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fs%mg%is(3),fs%mg%ie(3)
+      do iy=fs%mg%is(2),fs%mg%ie(2)
+      do ix=fs%mg%is(1),fs%mg%ie(1)
+        fe%rjx_fdtd_ld_g(ix,iy,iz)=0.0d0
+        fe%rjy_fdtd_ld_g(ix,iy,iz)=0.0d0
+        fe%rjz_fdtd_ld_g(ix,iy,iz)=0.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+
+      !update ghost LD polarization current & vector and FDTD current
+      do ii=1,fe%max_pole_num_ld
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+        do iz=fs%mg%is(3),fs%mg%ie(3)
+        do iy=fs%mg%is(2),fs%mg%ie(2)
+        do ix=fs%mg%is(1),fs%mg%ie(1)
+          fe%rjx_ld_g(ix,iy,iz,ii) = fe%c1_jx_ld(ix,iy,iz,ii)*fe%rjx_old_ld_g(ix,iy,iz,ii)              &
+                                    +fe%c2_jx_ld(ix,iy,iz,ii)*( fe%ex_y_g(ix,iy,iz)+fe%ex_z_g(ix,iy,iz)  &
+                                                               +fe%ex_old_ld_g(ix,iy,iz) )                &
+                                    -fe%c3_jx_ld(ix,iy,iz,ii)*fe%px_ld_g(ix,iy,iz,ii)
+          fe%rjy_ld_g(ix,iy,iz,ii) = fe%c1_jy_ld(ix,iy,iz,ii)*fe%rjy_old_ld_g(ix,iy,iz,ii)              &
+                                    +fe%c2_jy_ld(ix,iy,iz,ii)*( fe%ey_z_g(ix,iy,iz)+fe%ey_x_g(ix,iy,iz)  &
+                                                               +fe%ey_old_ld_g(ix,iy,iz) )                &
+                                    -fe%c3_jy_ld(ix,iy,iz,ii)*fe%py_ld_g(ix,iy,iz,ii)
+          fe%rjz_ld_g(ix,iy,iz,ii) = fe%c1_jz_ld(ix,iy,iz,ii)*fe%rjz_old_ld_g(ix,iy,iz,ii)              &
+                                    +fe%c2_jz_ld(ix,iy,iz,ii)*( fe%ez_x_g(ix,iy,iz)+fe%ez_y_g(ix,iy,iz)  &
+                                                               +fe%ez_old_ld_g(ix,iy,iz) )                &
+                                    -fe%c3_jz_ld(ix,iy,iz,ii)*fe%pz_ld_g(ix,iy,iz,ii)
+          fe%px_ld_g(ix,iy,iz,ii)  = fe%px_ld_g(ix,iy,iz,ii) &
+                                    +0.5d0*dt_em*( fe%rjx_ld_g(ix,iy,iz,ii) + fe%rjx_old_ld_g(ix,iy,iz,ii) )
+          fe%py_ld_g(ix,iy,iz,ii)  = fe%py_ld_g(ix,iy,iz,ii) &
+                                    +0.5d0*dt_em*( fe%rjy_ld_g(ix,iy,iz,ii) + fe%rjy_old_ld_g(ix,iy,iz,ii) )
+          fe%pz_ld_g(ix,iy,iz,ii)  = fe%pz_ld_g(ix,iy,iz,ii) &
+                                    +0.5d0*dt_em*( fe%rjz_ld_g(ix,iy,iz,ii) + fe%rjz_old_ld_g(ix,iy,iz,ii) )
+          fe%rjx_fdtd_ld_g(ix,iy,iz)  = fe%rjx_fdtd_ld_g(ix,iy,iz)                                           &
+                                       +0.5d0*( (1.0d0+fe%c1_jx_ld(ix,iy,iz,ii)) * fe%rjx_ld_g(ix,iy,iz,ii)  &
+                                                      -fe%c3_jx_ld(ix,iy,iz,ii)  * fe%px_ld_g(ix,iy,iz,ii) )
+          fe%rjy_fdtd_ld_g(ix,iy,iz)  = fe%rjy_fdtd_ld_g(ix,iy,iz)                                           &
+                                       +0.5d0*( (1.0d0+fe%c1_jy_ld(ix,iy,iz,ii)) * fe%rjy_ld_g(ix,iy,iz,ii)  &
+                                                      -fe%c3_jy_ld(ix,iy,iz,ii)  * fe%py_ld_g(ix,iy,iz,ii) )
+          fe%rjz_fdtd_ld_g(ix,iy,iz)  = fe%rjz_fdtd_ld_g(ix,iy,iz)                                           &
+                                       +0.5d0*( (1.0d0+fe%c1_jz_ld(ix,iy,iz,ii)) * fe%rjz_ld_g(ix,iy,iz,ii)  &
+                                                      -fe%c3_jz_ld(ix,iy,iz,ii)  * fe%pz_ld_g(ix,iy,iz,ii) )
+        end do
+        end do
+        end do
+!$omp end do
+!$omp end parallel
+      end do
+
+      return
+    end subroutine eh_update_ld_g
+
+    !+ CONTAINED IN eh_calc ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    !+ add ghost incident current source (quadrature: carrier phase shifted -pi/2) ++++++++++++
+    subroutine eh_add_inc_g(iord,amp,tw,omega,cep,ep_r,ep_i,c2_inc_xyz,aes,typ,&
+                            g_xy,g_yz,g_xz,g_x,g_y,g_z)
+      implicit none
+      integer,      intent(in) :: iord
+      real(8),      intent(in) :: amp,tw,omega,cep
+      real(8),      intent(in) :: ep_r(3),ep_i(3),c2_inc_xyz(3)
+      character(16),intent(in) :: aes,typ
+      real(8),      intent(in) :: g_xy(fs%mg%is_array(1):fs%mg%ie_array(1),fs%mg%is_array(2):fs%mg%ie_array(2)),&
+                                  g_yz(fs%mg%is_array(2):fs%mg%ie_array(2),fs%mg%is_array(3):fs%mg%ie_array(3)),&
+                                  g_xz(fs%mg%is_array(1):fs%mg%ie_array(1),fs%mg%is_array(3):fs%mg%ie_array(3))
+      real(8),      intent(in) :: g_x( fs%mg%is_array(1):fs%mg%ie_array(1) ),&
+                                  g_y( fs%mg%is_array(2):fs%mg%ie_array(2) ),&
+                                  g_z( fs%mg%is_array(3):fs%mg%ie_array(3) )
+      real(8)                  :: t_sta,t,e_inc_r,e_inc_i
+      real(8)                  :: add_inc(3)
+
+      !calculate incident pulse (with carrier phase already shifted by caller)
+      if(iord==1) then
+        t_sta = t1_start
+      elseif(iord==2) then
+        t_sta = t1_start + t1_t2
+      end if
+      t = (dble(iter)-0.5d0)*dt_em - t_sta
+      call eh_calc_e_inc(amp,t,tw,omega,cep,aes,e_inc_r,e_inc_i)
+      add_inc(:) = e_inc_r*ep_r(:) + e_inc_i*ep_i(:)
+
+      if(typ=='point_hs') then
+        if(fe%inc_po_pe(iord)==1) then
+          ix=fe%inc_po_id(iord,1); iy=fe%inc_po_id(iord,2); iz=fe%inc_po_id(iord,3)
+          fe%ex_y_g(ix,iy,iz)=add_inc(1)/2.0d0
+          fe%ex_z_g(ix,iy,iz)=add_inc(1)/2.0d0
+          fe%ey_z_g(ix,iy,iz)=add_inc(2)/2.0d0
+          fe%ey_x_g(ix,iy,iz)=add_inc(2)/2.0d0
+          fe%ez_x_g(ix,iy,iz)=add_inc(3)/2.0d0
+          fe%ez_y_g(ix,iy,iz)=add_inc(3)/2.0d0
+        end if
+      elseif(typ=='point_ss') then
+        if(fe%inc_po_pe(iord)==1) then
+          ix=fe%inc_po_id(iord,1); iy=fe%inc_po_id(iord,2); iz=fe%inc_po_id(iord,3)
+          fe%ex_y_g(ix,iy,iz)=fe%ex_y_g(ix,iy,iz)+add_inc(1)/2.0d0
+          fe%ex_z_g(ix,iy,iz)=fe%ex_z_g(ix,iy,iz)+add_inc(1)/2.0d0
+          fe%ey_z_g(ix,iy,iz)=fe%ey_z_g(ix,iy,iz)+add_inc(2)/2.0d0
+          fe%ey_x_g(ix,iy,iz)=fe%ey_x_g(ix,iy,iz)+add_inc(2)/2.0d0
+          fe%ez_x_g(ix,iy,iz)=fe%ez_x_g(ix,iy,iz)+add_inc(3)/2.0d0
+          fe%ez_y_g(ix,iy,iz)=fe%ez_y_g(ix,iy,iz)+add_inc(3)/2.0d0
+        end if
+      elseif(typ=='x-line_hs') then
+        if(fe%inc_li_pe(iord,1)==1) then
+          iy=fe%inc_po_id(iord,2); iz=fe%inc_po_id(iord,3)
+          fe%ex_y_g(fe%iex_y_is(1):fe%iex_y_ie(1),iy,iz)=add_inc(1)/2.0d0
+          fe%ex_z_g(fe%iex_z_is(1):fe%iex_z_ie(1),iy,iz)=add_inc(1)/2.0d0
+          fe%ey_z_g(fe%iey_z_is(1):fe%iey_z_ie(1),iy,iz)=add_inc(2)/2.0d0
+          fe%ey_x_g(fe%iey_x_is(1):fe%iey_x_ie(1),iy,iz)=add_inc(2)/2.0d0
+          fe%ez_x_g(fe%iez_x_is(1):fe%iez_x_ie(1),iy,iz)=add_inc(3)/2.0d0
+          fe%ez_y_g(fe%iez_y_is(1):fe%iez_y_ie(1),iy,iz)=add_inc(3)/2.0d0
+        end if
+      elseif(typ=='x-line_ss') then
+        if(fe%inc_li_pe(iord,1)==1) then
+          iy=fe%inc_po_id(iord,2); iz=fe%inc_po_id(iord,3)
+          fe%ex_y_g(fe%iex_y_is(1):fe%iex_y_ie(1),iy,iz)=fe%ex_y_g(fe%iex_y_is(1):fe%iex_y_ie(1),iy,iz)+add_inc(1)/2.0d0
+          fe%ex_z_g(fe%iex_z_is(1):fe%iex_z_ie(1),iy,iz)=fe%ex_z_g(fe%iex_z_is(1):fe%iex_z_ie(1),iy,iz)+add_inc(1)/2.0d0
+          fe%ey_z_g(fe%iey_z_is(1):fe%iey_z_ie(1),iy,iz)=fe%ey_z_g(fe%iey_z_is(1):fe%iey_z_ie(1),iy,iz)+add_inc(2)/2.0d0
+          fe%ey_x_g(fe%iey_x_is(1):fe%iey_x_ie(1),iy,iz)=fe%ey_x_g(fe%iey_x_is(1):fe%iey_x_ie(1),iy,iz)+add_inc(2)/2.0d0
+          fe%ez_x_g(fe%iez_x_is(1):fe%iez_x_ie(1),iy,iz)=fe%ez_x_g(fe%iez_x_is(1):fe%iez_x_ie(1),iy,iz)+add_inc(3)/2.0d0
+          fe%ez_y_g(fe%iez_y_is(1):fe%iez_y_ie(1),iy,iz)=fe%ez_y_g(fe%iez_y_is(1):fe%iez_y_ie(1),iy,iz)+add_inc(3)/2.0d0
+        end if
+      elseif(typ=='y-line_hs') then
+        if(fe%inc_li_pe(iord,2)==1) then
+          ix=fe%inc_po_id(iord,1); iz=fe%inc_po_id(iord,3)
+          fe%ex_y_g(ix,fe%iex_y_is(2):fe%iex_y_ie(2),iz)=add_inc(1)/2.0d0
+          fe%ex_z_g(ix,fe%iex_z_is(2):fe%iex_z_ie(2),iz)=add_inc(1)/2.0d0
+          fe%ey_z_g(ix,fe%iey_z_is(2):fe%iey_z_ie(2),iz)=add_inc(2)/2.0d0
+          fe%ey_x_g(ix,fe%iey_x_is(2):fe%iey_x_ie(2),iz)=add_inc(2)/2.0d0
+          fe%ez_x_g(ix,fe%iez_x_is(2):fe%iez_x_ie(2),iz)=add_inc(3)/2.0d0
+          fe%ez_y_g(ix,fe%iez_y_is(2):fe%iez_y_ie(2),iz)=add_inc(3)/2.0d0
+        end if
+      elseif(typ=='y-line_ss') then
+        if(fe%inc_li_pe(iord,2)==1) then
+          ix=fe%inc_po_id(iord,1); iz=fe%inc_po_id(iord,3)
+          fe%ex_y_g(ix,fe%iex_y_is(2):fe%iex_y_ie(2),iz)=fe%ex_y_g(ix,fe%iex_y_is(2):fe%iex_y_ie(2),iz)+add_inc(1)/2.0d0
+          fe%ex_z_g(ix,fe%iex_z_is(2):fe%iex_z_ie(2),iz)=fe%ex_z_g(ix,fe%iex_z_is(2):fe%iex_z_ie(2),iz)+add_inc(1)/2.0d0
+          fe%ey_z_g(ix,fe%iey_z_is(2):fe%iey_z_ie(2),iz)=fe%ey_z_g(ix,fe%iey_z_is(2):fe%iey_z_ie(2),iz)+add_inc(2)/2.0d0
+          fe%ey_x_g(ix,fe%iey_x_is(2):fe%iey_x_ie(2),iz)=fe%ey_x_g(ix,fe%iey_x_is(2):fe%iey_x_ie(2),iz)+add_inc(2)/2.0d0
+          fe%ez_x_g(ix,fe%iez_x_is(2):fe%iez_x_ie(2),iz)=fe%ez_x_g(ix,fe%iez_x_is(2):fe%iez_x_ie(2),iz)+add_inc(3)/2.0d0
+          fe%ez_y_g(ix,fe%iez_y_is(2):fe%iez_y_ie(2),iz)=fe%ez_y_g(ix,fe%iez_y_is(2):fe%iez_y_ie(2),iz)+add_inc(3)/2.0d0
+        end if
+      elseif(typ=='z-line_hs') then
+        if(fe%inc_li_pe(iord,3)==1) then
+          ix=fe%inc_po_id(iord,1); iy=fe%inc_po_id(iord,2)
+          fe%ex_y_g(ix,iy,fe%iex_y_is(3):fe%iex_y_ie(3))=add_inc(1)/2.0d0
+          fe%ex_z_g(ix,iy,fe%iex_z_is(3):fe%iex_z_ie(3))=add_inc(1)/2.0d0
+          fe%ey_z_g(ix,iy,fe%iey_z_is(3):fe%iey_z_ie(3))=add_inc(2)/2.0d0
+          fe%ey_x_g(ix,iy,fe%iey_x_is(3):fe%iey_x_ie(3))=add_inc(2)/2.0d0
+          fe%ez_x_g(ix,iy,fe%iez_x_is(3):fe%iez_x_ie(3))=add_inc(3)/2.0d0
+          fe%ez_y_g(ix,iy,fe%iez_y_is(3):fe%iez_y_ie(3))=add_inc(3)/2.0d0
+        end if
+      elseif(typ=='z-line_ss') then
+        if(fe%inc_li_pe(iord,3)==1) then
+          ix=fe%inc_po_id(iord,1); iy=fe%inc_po_id(iord,2)
+          fe%ex_y_g(ix,iy,fe%iex_y_is(3):fe%iex_y_ie(3))=fe%ex_y_g(ix,iy,fe%iex_y_is(3):fe%iex_y_ie(3))+add_inc(1)/2.0d0
+          fe%ex_z_g(ix,iy,fe%iex_z_is(3):fe%iex_z_ie(3))=fe%ex_z_g(ix,iy,fe%iex_z_is(3):fe%iex_z_ie(3))+add_inc(1)/2.0d0
+          fe%ey_z_g(ix,iy,fe%iey_z_is(3):fe%iey_z_ie(3))=fe%ey_z_g(ix,iy,fe%iey_z_is(3):fe%iey_z_ie(3))+add_inc(2)/2.0d0
+          fe%ey_x_g(ix,iy,fe%iey_x_is(3):fe%iey_x_ie(3))=fe%ey_x_g(ix,iy,fe%iey_x_is(3):fe%iey_x_ie(3))+add_inc(2)/2.0d0
+          fe%ez_x_g(ix,iy,fe%iez_x_is(3):fe%iez_x_ie(3))=fe%ez_x_g(ix,iy,fe%iez_x_is(3):fe%iez_x_ie(3))+add_inc(3)/2.0d0
+          fe%ez_y_g(ix,iy,fe%iez_y_is(3):fe%iez_y_ie(3))=fe%ez_y_g(ix,iy,fe%iez_y_is(3):fe%iez_y_ie(3))+add_inc(3)/2.0d0
+        end if
+      elseif(typ=='xy-plane') then
+        if(fe%inc_pl_pe(iord,1)==1) then
+          iz=fe%inc_po_id(iord,3)
+!$omp parallel
+!$omp do private(ix,iy)
+          do iy=fe%iex_z_is(2),fe%iex_z_ie(2)
+          do ix=fe%iex_z_is(1),fe%iex_z_ie(1)
+            fe%ex_z_g(ix,iy,iz)=fe%ex_z_g(ix,iy,iz)+c2_inc_xyz(3)*add_inc(1)*g_xy(ix,iy)*g_x(ix)*g_y(iy)
+          end do
+          end do
+!$omp end do
+!$omp end parallel
+!$omp parallel
+!$omp do private(ix,iy)
+          do iy=fe%iey_z_is(2),fe%iey_z_ie(2)
+          do ix=fe%iey_z_is(1),fe%iey_z_ie(1)
+            fe%ey_z_g(ix,iy,iz)=fe%ey_z_g(ix,iy,iz)+c2_inc_xyz(3)*add_inc(2)*g_xy(ix,iy)*g_x(ix)*g_y(iy)
+          end do
+          end do
+!$omp end do
+!$omp end parallel
+        end if
+      elseif(typ=='yz-plane') then
+        if(fe%inc_pl_pe(iord,2)==1) then
+          ix=fe%inc_po_id(iord,1)
+!$omp parallel
+!$omp do private(iy,iz)
+          do iz=fe%iey_x_is(3),fe%iey_x_ie(3)
+          do iy=fe%iey_x_is(2),fe%iey_x_ie(2)
+            fe%ey_x_g(ix,iy,iz)=fe%ey_x_g(ix,iy,iz)+c2_inc_xyz(1)*add_inc(2)*g_yz(iy,iz)*g_y(iy)*g_z(iz)
+          end do
+          end do
+!$omp end do
+!$omp end parallel
+!$omp parallel
+!$omp do private(iy,iz)
+          do iz=fe%iez_x_is(3),fe%iez_x_ie(3)
+          do iy=fe%iez_x_is(2),fe%iez_x_ie(2)
+            fe%ez_x_g(ix,iy,iz)=fe%ez_x_g(ix,iy,iz)+c2_inc_xyz(1)*add_inc(3)*g_yz(iy,iz)*g_y(iy)*g_z(iz)
+          end do
+          end do
+!$omp end do
+!$omp end parallel
+        end if
+      elseif(typ=='xz-plane') then
+        if(fe%inc_pl_pe(iord,3)==1) then
+          iy=fe%inc_po_id(iord,2)
+!$omp parallel
+!$omp do private(ix,iz)
+          do iz=fe%iex_y_is(3),fe%iex_y_ie(3)
+          do ix=fe%iex_y_is(1),fe%iex_y_ie(1)
+            fe%ex_y_g(ix,iy,iz)=fe%ex_y_g(ix,iy,iz)+c2_inc_xyz(2)*add_inc(1)*g_xz(ix,iz)*g_x(ix)*g_z(iz)
+          end do
+          end do
+!$omp end do
+!$omp end parallel
+!$omp parallel
+!$omp do private(ix,iz)
+          do iz=fe%iez_y_is(3),fe%iez_y_ie(3)
+          do ix=fe%iez_y_is(1),fe%iez_y_ie(1)
+            fe%ez_y_g(ix,iy,iz)=fe%ez_y_g(ix,iy,iz)+c2_inc_xyz(2)*add_inc(3)*g_xz(ix,iz)*g_x(ix)*g_z(iz)
+          end do
+          end do
+!$omp end do
+!$omp end parallel
+        end if
+      end if
+
+      return
+    end subroutine eh_add_inc_g
+
+    !+ CONTAINED IN eh_calc ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    !+ add ghost LD current to ghost E field ++++++++++++++++++++++++++++++++++++++++++++++++
+    subroutine eh_add_curr_g(rjx,rjy,rjz)
+      implicit none
+      real(8),intent(in) :: rjx(fs%mg%is_array(1):fs%mg%ie_array(1),&
+                                fs%mg%is_array(2):fs%mg%ie_array(2),&
+                                fs%mg%is_array(3):fs%mg%ie_array(3)),&
+                            rjy(fs%mg%is_array(1):fs%mg%ie_array(1),&
+                                fs%mg%is_array(2):fs%mg%ie_array(2),&
+                                fs%mg%is_array(3):fs%mg%ie_array(3)),&
+                            rjz(fs%mg%is_array(1):fs%mg%ie_array(1),&
+                                fs%mg%is_array(2):fs%mg%ie_array(2),&
+                                fs%mg%is_array(3):fs%mg%ie_array(3))
+
+      !ex_g
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fe%iex_y_is(3),fe%iex_y_ie(3)
+      do iy=fe%iex_y_is(2),fe%iex_y_ie(2)
+      do ix=fe%iex_y_is(1),fe%iex_y_ie(1)
+        fe%ex_y_g(ix,iy,iz)=fe%ex_y_g(ix,iy,iz)+fe%c2_jx(ix,iy,iz)*rjx(ix,iy,iz)/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fe%iex_z_is(3),fe%iex_z_ie(3)
+      do iy=fe%iex_z_is(2),fe%iex_z_ie(2)
+      do ix=fe%iex_z_is(1),fe%iex_z_ie(1)
+        fe%ex_z_g(ix,iy,iz)=fe%ex_z_g(ix,iy,iz)+fe%c2_jx(ix,iy,iz)*rjx(ix,iy,iz)/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+
+      !ey_g
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fe%iey_z_is(3),fe%iey_z_ie(3)
+      do iy=fe%iey_z_is(2),fe%iey_z_ie(2)
+      do ix=fe%iey_z_is(1),fe%iey_z_ie(1)
+        fe%ey_z_g(ix,iy,iz)=fe%ey_z_g(ix,iy,iz)+fe%c2_jy(ix,iy,iz)*rjy(ix,iy,iz)/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fe%iey_x_is(3),fe%iey_x_ie(3)
+      do iy=fe%iey_x_is(2),fe%iey_x_ie(2)
+      do ix=fe%iey_x_is(1),fe%iey_x_ie(1)
+        fe%ey_x_g(ix,iy,iz)=fe%ey_x_g(ix,iy,iz)+fe%c2_jy(ix,iy,iz)*rjy(ix,iy,iz)/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+
+      !ez_g
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fe%iez_x_is(3),fe%iez_x_ie(3)
+      do iy=fe%iez_x_is(2),fe%iez_x_ie(2)
+      do ix=fe%iez_x_is(1),fe%iez_x_ie(1)
+        fe%ez_x_g(ix,iy,iz)=fe%ez_x_g(ix,iy,iz)+fe%c2_jz(ix,iy,iz)*rjz(ix,iy,iz)/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fe%iez_y_is(3),fe%iez_y_ie(3)
+      do iy=fe%iez_y_is(2),fe%iez_y_ie(2)
+      do ix=fe%iez_y_is(1),fe%iez_y_ie(1)
+        fe%ez_y_g(ix,iy,iz)=fe%ez_y_g(ix,iy,iz)+fe%c2_jz(ix,iy,iz)*rjz(ix,iy,iz)/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+
+      return
+    end subroutine eh_add_curr_g
+
   end subroutine eh_calc
   
   !===========================================================================================
@@ -5726,11 +6165,11 @@ contains
     implicit none
     type(s_fdtd_system),intent(inout) :: fs
     type(ls_fdtd_eh), intent(inout)   :: fe
-    character(1),intent(in)           :: var
+    character(*),intent(in)            :: var
     integer                           :: ix,iy,iz
     real(8),allocatable               :: f1(:,:,:),f2(:,:,:),f3(:,:,:)
-    
-    if(var=='e') then
+
+    if(trim(var)=='e') then
       call update_overlap_real8(fs%srg_ng,fs%mg,fe%ex_y)
       call update_overlap_real8(fs%srg_ng,fs%mg,fe%ex_z)
       call update_overlap_real8(fs%srg_ng,fs%mg,fe%ey_z)
@@ -5744,6 +6183,20 @@ contains
       call update_overlap_real8(fs%srg_ng,fs%mg,fe%hy_x)
       call update_overlap_real8(fs%srg_ng,fs%mg,fe%hz_x)
       call update_overlap_real8(fs%srg_ng,fs%mg,fe%hz_y)
+    elseif(var=='e_g') then
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%ex_y_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%ex_z_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%ey_z_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%ey_x_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%ez_x_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%ez_y_g)
+    elseif(var=='h_g') then
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hx_y_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hx_z_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hy_z_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hy_x_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hz_x_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hz_y_g)
     elseif(var=='r') then
       call update_overlap_real8(fs%srg_ng,fs%mg,fe%rmedia)
     elseif(var=='s') then

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -245,6 +245,7 @@ contains
                                input_i3d_em,output_i3d_em,stop_em,input_r_txt_em,output_r_txt_em,input_r_bin_em, &
                                txtfile_copy_em
     use ttm,             only: use_ttm, init_ttm_parameters, init_ttm_grid, init_ttm_alloc
+    use ttm3,            only: use_ttm3, init_ttm3_parameters, init_ttm3_grid, init_ttm3_alloc
     implicit none
     type(s_fdtd_system),intent(inout) :: fs
     type(ls_fdtd_eh),   intent(inout) :: fe
@@ -315,8 +316,12 @@ contains
       fe%flag_art = .false.
     end if
     
+    !three-temperature model parameters (read early so its need for the cell-centred
+    ! fields can be folded into flag_save below)
+    call init_ttm3_parameters( dt_em )
+
     !save option: calculate variables used for save(typically, ex-z_s and hx-z_s)
-    if(fe%flag_obs .or. fe%flag_ase .or. fe%flag_art) then
+    if(fe%flag_obs .or. fe%flag_ase .or. fe%flag_art .or. use_ttm3) then
       fe%flag_save = .true.
     else
       fe%flag_save = .false.
@@ -859,6 +864,19 @@ contains
           close(unit2)
        end if
     end if !use_ttm
+
+    !--- three-temperature + carrier model (ttm3) grid/allocation (parameters read earlier) ------!
+    if( use_ttm3 )then
+       call init_ttm3_grid( fs%hgs, fs%mg%is_array, fs%mg%is, fs%mg%ie, fs%imedia )
+       call init_ttm3_alloc( fs%srg_ng, fs%mg )
+       if( comm_is_root(nproc_id_global) )then
+          open(unit2,file='3tm_rt.data')
+          write(unit2,'("#",99(1X,I0,":",A))') &
+               1, "Time[fs]", 2, "T_ele[K]", 3, "T_hole[K]", 4, "T_lat[K]", &
+               5, "N_ele[cm-3]", 6, "N_hole[cm-3]"
+          close(unit2)
+       end if
+    end if !use_ttm3
 
     !*** write media information ******************************************************************************!
     if(comm_is_root(nproc_id_global)) then
@@ -3280,6 +3298,7 @@ contains
     use misc_routines,   only: get_wtime
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
+    use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_state
     implicit none
     type(s_fdtd_system),intent(inout) :: fs
     type(ls_fdtd_eh),   intent(inout) :: fe
@@ -3291,6 +3310,9 @@ contains
     integer             :: jx,jy,jz,unit1=4000
     real(8),allocatable :: Spoynting(:,:,:,:), divS(:,:,:)
     real(8),allocatable :: Spoynting_g(:,:,:,:), divS_g(:,:,:)
+    real(8),allocatable :: t3_S(:,:,:,:), t3_divS(:,:,:), t3_S_g(:,:,:,:), t3_divS_g(:,:,:)
+    real(8),allocatable :: t3_power(:,:,:), t3_gen(:,:,:), t3_env(:,:,:)
+    real(8) :: t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
     real(8),allocatable :: u_energy(:,:,:), u_energy_p(:,:,:)
     real(8),allocatable :: work(:,:,:), work1(:,:,:), work2(:,:,:)
     real(8)             :: dV, tmp(4)
@@ -3491,6 +3513,54 @@ contains
           deallocate( work )
         end if
       end if !use_ttm
+
+      !--- three-temperature + carrier model (ttm3): laser -> carrier generation + heating -----!
+      !  forward coupling (field -> carriers): absorbed-power heating + intensity-envelope-driven
+      !  carrier generation drive the ttm3 state.  (Single-domain, like the two-temperature path;
+      !  the carrier -> permittivity back-action via ttm3_permittivity is the next integration.)
+      if( use_ttm3 )then
+        if( .not.allocated(t3_power) )then
+          call allocate_poynting(fs, t3_S, t3_divS)
+          call allocate_poynting(fs, u=t3_power)
+          call allocate_poynting(fs, u=t3_gen)
+          allocate( t3_env(fs%mg%is_array(1):fs%mg%ie_array(1), &
+                           fs%mg%is_array(2):fs%mg%ie_array(2), &
+                           fs%mg%is_array(3):fs%mg%ie_array(3)) ); t3_env=0.0d0
+          if(yn_em_envelope=='y') call allocate_poynting(fs, t3_S_g, t3_divS_g)
+        end if
+        call calc_es_and_hs(fs, fe)
+        call calc_poynting_vector(fs, fe, t3_S)
+        call calc_poynting_vector_div(fs, t3_S, t3_divS)
+        if(yn_em_envelope=='y')then
+          call calc_es_and_hs_g(fs, fe)
+          call calc_poynting_vector_g(fs, fe, t3_S_g)
+          call calc_poynting_vector_div(fs, t3_S_g, t3_divS_g)
+          t3_power(:,:,:) = -0.5d0*( t3_divS(:,:,:) + t3_divS_g(:,:,:) )
+          call eh_get_field_envelope(fs, fe, t3_env)
+        else
+          t3_power(:,:,:) = -t3_divS(:,:,:)
+        end if
+        do iz=fs%mg%is(3),fs%mg%ie(3)
+        do iy=fs%mg%is(2),fs%mg%ie(2)
+        do ix=fs%mg%is(1),fs%mg%ie(1)
+          t3_gen(ix,iy,iz) = ttm3_generation( t3_env(ix,iy,iz) )
+        end do
+        end do
+        end do
+        call ttm3_main( fs%srg_ng, fs%mg, t3_power, t3_gen )
+        if( mod(iter,obs_samp_em)==0 )then
+          call ttm3_get_state( (/ (fs%mg%is(1)+fs%mg%ie(1))/2, &
+                                  (fs%mg%is(2)+fs%mg%ie(2))/2, &
+                                  (fs%mg%is(3)+fs%mg%ie(3))/2 /), &
+                               t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh )
+          if( comm_is_root(nproc_id_global) )then
+            open(unit2,file='3tm_rt.data',status='old',position='append')
+            write(unit2,"(F16.8,99(1X,E23.15E3))") &
+                 dble(iter)*dt_em*utime_from_au, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
+            close(unit2)
+          end if
+        end if
+      end if !use_ttm3
 
       !output
       if( fe%flag_save .and. mod(iter,obs_samp_em)==0 )then

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3310,7 +3310,8 @@ contains
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
     use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_get_front,ttm3_eps_sig,&
-                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_front_ijk,ttm3_write_profile
+                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_front_ijk,ttm3_write_profile,&
+                               ttm3_drude_coef_cell
     use phys_constants,  only: cspeed_au
     use math_constants,  only: pi
     implicit none
@@ -3326,6 +3327,8 @@ contains
     real(8),allocatable :: Spoynting_g(:,:,:,:), divS_g(:,:,:)
     real(8),allocatable :: t3_S(:,:,:,:), t3_divS(:,:,:), t3_S_g(:,:,:,:), t3_divS_g(:,:,:)
     real(8),allocatable :: t3_power(:,:,:), t3_gen(:,:,:), t3_env(:,:,:)
+    real(8),allocatable :: t3_jx(:,:,:),t3_jy(:,:,:),t3_jz(:,:,:)        ! carrier Drude ADE current J
+    real(8),allocatable :: t3_rjfx(:,:,:),t3_rjfy(:,:,:),t3_rjfz(:,:,:) ! J injected via eh_add_curr
     real(8) :: t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
     real(8) :: t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf
     real(8) :: t3_eps,t3_sig,t3_de,t3_c1,t3_cx,t3_cy,t3_cz,t3_cj,t3_gtpa
@@ -3370,6 +3373,7 @@ contains
                                                  fe%gbeam_width_x2 ,fe%gbeam_width_y2 ,fe%gbeam_width_z2 )
       end if
       if(fe%flag_ld) call eh_add_curr(fe%rjx_fdtd_ld(:,:,:),fe%rjy_fdtd_ld(:,:,:),fe%rjz_fdtd_ld(:,:,:))
+      if(use_ttm3 .and. allocated(t3_rjfx)) call eh_add_curr(t3_rjfx,t3_rjfy,t3_rjfz)  ! carrier Drude current
       call eh_sendrecv(fs,fe,'e')
       
       !update lorentz-drude
@@ -3543,6 +3547,9 @@ contains
           allocate( t3_env(fs%mg%is_array(1):fs%mg%ie_array(1), &
                            fs%mg%is_array(2):fs%mg%ie_array(2), &
                            fs%mg%is_array(3):fs%mg%ie_array(3)) ); t3_env=0.0d0
+          call allocate_poynting(fs, u=t3_jx  ); call allocate_poynting(fs, u=t3_jy  ); call allocate_poynting(fs, u=t3_jz  )
+          call allocate_poynting(fs, u=t3_rjfx); call allocate_poynting(fs, u=t3_rjfy); call allocate_poynting(fs, u=t3_rjfz)
+          t3_jx=0d0; t3_jy=0d0; t3_jz=0d0; t3_rjfx=0d0; t3_rjfy=0d0; t3_rjfz=0d0
           if(yn_em_envelope=='y') call allocate_poynting(fs, t3_S_g, t3_divS_g)
         end if
         call calc_es_and_hs(fs, fe)
@@ -3578,30 +3585,24 @@ contains
         end do
         call ttm3_main( fs%srg_ng, fs%mg, t3_power, t3_gen )
 
-        !--- Stage 2 back-action: carrier-dependent permittivity drives the FDTD media
-        !    coefficients.  Only TRUE-INTERIOR medium cells (all 6 neighbours the same
-        !    medium) are updated, so the surface cells keep their interface-consistent
-        !    init coefficients.  The interior-cell list is built by ttm3 at init time;
-        !    fs%imedia must NOT be used here (the FDTD setup deallocates it).
-        !    Single-frequency static eps at omega1 (the reference's approximation);
-        !    SALMON's dt is vacuum-CFL-sized, so eps>=1 stays CFL-stable.
+        !--- carrier-Drude back-action via the STABLE current-source coupling (SALMON-native):
+        !    each medium cell carries an auxiliary Drude polarization current J evolved by the
+        !    ADE  J_new = c1*J + c2*E  (c1,c2 from the carrier plasma frequency/collision rate),
+        !    and injected into the FDTD E-update next step through the existing eh_add_curr
+        !    interface (same scheme as the validated Lorentz-Drude media).  The media
+        !    coefficients (c1_ex_*, c2_jx) are NOT touched -- they keep the fixed cold-bound
+        !    optics (eps_bg + sig_cold) from init.  This replaces the old eps/sigma coefficient
+        !    back-action, which is numerically unstable in the real-field FDTD when sigma grows
+        !    fast (abrupt coefficient change -> front/antinode runaway).
         do t3_im=1,ttm3_ninterior()
           call ttm3_interior_cell( t3_im, ix,iy,iz )
-            call ttm3_eps_sig( ix,iy,iz, omega1, t3_eps, t3_sig )
-            t3_eps = max( t3_eps, 1.0d0 )
-            t3_de  = 1.0d0/( 1.0d0 + 2.0d0*pi*t3_sig/t3_eps*dt_em )
-            t3_c1  = ( 1.0d0 - 2.0d0*pi*t3_sig/t3_eps*dt_em )*t3_de
-            t3_cx  = ( cspeed_au/t3_eps*dt_em )*t3_de/fs%hgs(1)
-            t3_cy  = ( cspeed_au/t3_eps*dt_em )*t3_de/fs%hgs(2)
-            t3_cz  = ( cspeed_au/t3_eps*dt_em )*t3_de/fs%hgs(3)
-            t3_cj  = ( 4.0d0*pi/t3_eps*dt_em )*t3_de
-            fe%c1_ex_y(ix,iy,iz)=t3_c1; fe%c2_ex_y(ix,iy,iz)= t3_cy
-            fe%c1_ex_z(ix,iy,iz)=t3_c1; fe%c2_ex_z(ix,iy,iz)=-t3_cz
-            fe%c1_ey_z(ix,iy,iz)=t3_c1; fe%c2_ey_z(ix,iy,iz)= t3_cz
-            fe%c1_ey_x(ix,iy,iz)=t3_c1; fe%c2_ey_x(ix,iy,iz)=-t3_cx
-            fe%c1_ez_x(ix,iy,iz)=t3_c1; fe%c2_ez_x(ix,iy,iz)= t3_cx
-            fe%c1_ez_y(ix,iy,iz)=t3_c1; fe%c2_ez_y(ix,iy,iz)=-t3_cy
-            fe%c2_jx(ix,iy,iz)=-t3_cj; fe%c2_jy(ix,iy,iz)=-t3_cj; fe%c2_jz(ix,iy,iz)=-t3_cj
+            call ttm3_drude_coef_cell( ix,iy,iz, omega1, dt_em, t3_c1, t3_cj )   ! c1, c2 (ADE)
+            t3_jx(ix,iy,iz) = t3_c1*t3_jx(ix,iy,iz) + t3_cj*( fe%ex_y(ix,iy,iz)+fe%ex_z(ix,iy,iz) )
+            t3_jy(ix,iy,iz) = t3_c1*t3_jy(ix,iy,iz) + t3_cj*( fe%ey_z(ix,iy,iz)+fe%ey_x(ix,iy,iz) )
+            t3_jz(ix,iy,iz) = t3_c1*t3_jz(ix,iy,iz) + t3_cj*( fe%ez_x(ix,iy,iz)+fe%ez_y(ix,iy,iz) )
+            t3_rjfx(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jx(ix,iy,iz)
+            t3_rjfy(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jy(ix,iy,iz)
+            t3_rjfz(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jz(ix,iy,iz)
         end do
 
         if( mod(iter,i_3tm_out)==0 )then

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3298,7 +3298,7 @@ contains
     use misc_routines,   only: get_wtime
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
-    use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_state
+    use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max
     implicit none
     type(s_fdtd_system),intent(inout) :: fs
     type(ls_fdtd_eh),   intent(inout) :: fe
@@ -3549,10 +3549,9 @@ contains
         end do
         call ttm3_main( fs%srg_ng, fs%mg, t3_power, t3_gen )
         if( mod(iter,obs_samp_em)==0 )then
-          call ttm3_get_state( (/ (fs%mg%is(1)+fs%mg%ie(1))/2, &
-                                  (fs%mg%is(2)+fs%mg%ie(2))/2, &
-                                  (fs%mg%is(3)+fs%mg%ie(3))/2 /), &
-                               t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh )
+          !report the peak over medium cells (the absorbing front, not the screened core).
+          !single-domain diagnostic: local peak equals the global peak for nproc_rgrid=1.
+          call ttm3_get_max( t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh )
           if( comm_is_root(nproc_id_global) )then
             open(unit2,file='3tm_rt.data',status='old',position='append')
             write(unit2,"(F16.8,99(1X,E23.15E3))") &

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -210,6 +210,13 @@ module fdtd_eh
   private :: calc_poynting_vector_div
   integer,      private, parameter :: unit2=3000
   character(11),private, parameter :: file_unit2='ttm_rt.data'
+  ! three-temperature time-series output cadence (steps).  Set in eh_init so the
+  ! single 3tm_rt.data file stays bounded: at least every obs_samp_em steps, but
+  ! coarsened so the total row count never exceeds n_3tm_out_max (a long run with a
+  ! small obs_samp_em therefore cannot blow the file up).  open/append/close each
+  ! write keeps it to one descriptor (no per-cell unit, unlike the legacy TTM path).
+  integer,      private            :: i_3tm_out=1
+  integer,      private, parameter :: n_3tm_out_max=20000
 
 contains
   
@@ -870,6 +877,8 @@ contains
        call ttm3_set_dt( dt_em )   ! dt_em is finalised (CFL) by here; the early init captured 0
        call init_ttm3_grid( fs%hgs, fs%mg%is_array, fs%mg%is, fs%mg%ie, fs%imedia )
        call init_ttm3_alloc( fs%srg_ng, fs%mg )
+       ! bound the time-series file: emit at most n_3tm_out_max rows, never finer than obs_samp_em
+       i_3tm_out = max( obs_samp_em, (nt_em + n_3tm_out_max - 1)/n_3tm_out_max )
        if( comm_is_root(nproc_id_global) )then
           open(unit2,file='3tm_rt.data')
           write(unit2,'("#",99(1X,I0,":",A))') &
@@ -3588,9 +3597,10 @@ contains
             fe%c2_jx(ix,iy,iz)=-t3_cj; fe%c2_jy(ix,iy,iz)=-t3_cj; fe%c2_jz(ix,iy,iz)=-t3_cj
         end do
 
-        if( mod(iter,obs_samp_em)==0 )then
+        if( mod(iter,i_3tm_out)==0 )then
           !report the peak over medium cells (the absorbing front, not the screened core).
           !single-domain diagnostic: local peak equals the global peak for nproc_rgrid=1.
+          !i_3tm_out (>= obs_samp_em) bounds 3tm_rt.data to <= n_3tm_out_max rows.
           call ttm3_get_max( t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh )
           if( comm_is_root(nproc_id_global) )then
             open(unit2,file='3tm_rt.data',status='old',position='append')

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3310,7 +3310,7 @@ contains
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
     use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_get_front,ttm3_eps_sig,&
-                               ttm3_ninterior,ttm3_interior_cell
+                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen
     use phys_constants,  only: cspeed_au
     use math_constants,  only: pi
     implicit none
@@ -3569,7 +3569,9 @@ contains
         do iy=fs%mg%is(2),fs%mg%ie(2)
         do ix=fs%mg%is(1),fs%mg%ie(1)
           t3_gtpa = ttm3_generation( t3_env(ix,iy,iz) )                       ! beta2 * I_env^2
-          t3_gen(ix,iy,iz)   = max( t3_power(ix,iy,iz), 0.0d0 )/omega1 + t3_gtpa
+          ! linear generation = BOUND-absorption fraction of the absorbed power (Layer C-a);
+          ! reduces to max(power,0)/omega1 when sig_cold<=0 (split disabled).
+          t3_gen(ix,iy,iz)   = ttm3_linear_gen( ix,iy,iz, omega1, t3_power(ix,iy,iz) ) + t3_gtpa
           t3_power(ix,iy,iz) = t3_power(ix,iy,iz) + 2.0d0*omega1*t3_gtpa      ! TPA: 2 hbar w per pair
         end do
         end do

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -327,6 +327,19 @@ contains
     ! fields can be folded into flag_save below)
     call init_ttm3_parameters( dt_em )
 
+    !ttm3 state (Te/Th/Tl/Ne/Nh + carrier Drude currents) is NOT in the checkpoint set:
+    !a restart would silently resume with a cold, carrier-free slab mid-pulse -> refuse
+    !up front (before any restart data is touched).  Checkpoints may still be written,
+    !but they cannot seed a maxwell-3tm restart -- warn.
+    if( use_ttm3 )then
+      if(yn_restart=='y') &
+        call stop_em('theory=maxwell-3tm does not support yn_restart=y (ttm3 state is not checkpointed).')
+      if(checkpoint_interval>0 .and. comm_is_root(nproc_id_global)) then
+        write(*,'(A)') " WARNING: checkpoint data will NOT include the ttm3 state;"
+        write(*,'(A)') "          it cannot be used to restart a maxwell-3tm run."
+      end if
+    end if
+
     !save option: calculate variables used for save(typically, ex-z_s and hx-z_s)
     if(fe%flag_obs .or. fe%flag_ase .or. fe%flag_art .or. use_ttm3) then
       fe%flag_save = .true.
@@ -885,7 +898,8 @@ contains
           write(unit2,'("#",99(1X,I0,":",A))') &
                1, "Time[fs]", &
                2, "Te_front[K]", 3, "Th_front[K]", 4, "Tl_front[K]", 5, "Ne_front[cm-3]", 6, "Nh_front[cm-3]", &
-               7, "Te_max[K]",   8, "Th_max[K]",   9, "Tl_max[K]",  10, "Ne_max[cm-3]",  11, "Nh_max[cm-3]"
+               7, "Te_max[K]",   8, "Th_max[K]",   9, "Tl_max[K]",  10, "Ne_max[cm-3]",  11, "Nh_max[cm-3]", &
+              12, "env_front[au]", 13, "power_front[au]", 14, "gen_front[au]"
           close(unit2)
        end if
     end if !use_ttm3
@@ -3311,7 +3325,7 @@ contains
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
     use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_get_front,ttm3_eps_sig,&
-                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_front_ijk,ttm3_write_profile,&
+                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_write_profile,&
                                ttm3_drude_coef_cell,ttm3_coupling_mode,ttm3_drude_osc_cell
     use phys_constants,  only: cspeed_au
     use math_constants,  only: pi
@@ -3334,6 +3348,8 @@ contains
     real(8),allocatable :: t3_rjfx_g(:,:,:),t3_rjfy_g(:,:,:),t3_rjfz_g(:,:,:) ! ghost J injected via eh_add_curr_g
     real(8) :: t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
     real(8) :: t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf
+    real(8) :: t3_envf,t3_powf,t3_genf
+    integer :: t3_gjx,t3_gjy,t3_gjz
     real(8) :: t3_eps,t3_sig,t3_de,t3_c1,t3_cx,t3_cy,t3_cz,t3_cj,t3_gtpa
     real(8) :: t3_ge,t3_wp2,t3_a,t3_b,t3_d2,t3_p,t3_dd,t3_cc,t3_ss,t3_m11,t3_m12,t3_m21,t3_m22,t3_estar,t3_enew,t3_dfld
     integer :: t3_im
@@ -3554,16 +3570,23 @@ contains
           allocate( t3_env(fs%mg%is_array(1):fs%mg%ie_array(1), &
                            fs%mg%is_array(2):fs%mg%ie_array(2), &
                            fs%mg%is_array(3):fs%mg%ie_array(3)) ); t3_env=0.0d0
-          call allocate_poynting(fs, u=t3_jx  ); call allocate_poynting(fs, u=t3_jy  ); call allocate_poynting(fs, u=t3_jz  )
-          call allocate_poynting(fs, u=t3_rjfx); call allocate_poynting(fs, u=t3_rjfy); call allocate_poynting(fs, u=t3_rjfz)
+          !carrier-current arrays: eh_add_curr/_g declare their dummies explicit-shape with
+          !HALO bounds (is_array:ie_array), so these must be allocated with the same bounds
+          !(allocate_poynting's u= is halo-less is:ie and would sequence-associate with an
+          !index skew = scrambled injection + out-of-bounds reads; found 2026-07-05 review).
+          ix=fs%mg%is_array(1); jx=fs%mg%ie_array(1)
+          iy=fs%mg%is_array(2); jy=fs%mg%ie_array(2)
+          iz=fs%mg%is_array(3); jz=fs%mg%ie_array(3)
+          allocate( t3_jx  (ix:jx,iy:jy,iz:jz), t3_jy  (ix:jx,iy:jy,iz:jz), t3_jz  (ix:jx,iy:jy,iz:jz), &
+                    t3_rjfx(ix:jx,iy:jy,iz:jz), t3_rjfy(ix:jx,iy:jy,iz:jz), t3_rjfz(ix:jx,iy:jy,iz:jz) )
           t3_jx=0d0; t3_jy=0d0; t3_jz=0d0; t3_rjfx=0d0; t3_rjfy=0d0; t3_rjfz=0d0
           if(yn_em_envelope=='y')then
             call allocate_poynting(fs, t3_S_g, t3_divS_g)
             !ghost (quadrature) carrier current: the envelope generation/heating use
             !env = |E|^2 + |E_g|^2 and -0.5*(divS+divS_g), so the ghost field must be damped
             !by the same carrier Drude as the real field, else |E_g|^2 stays undamped -> runaway.
-            call allocate_poynting(fs, u=t3_jx_g  ); call allocate_poynting(fs, u=t3_jy_g  ); call allocate_poynting(fs, u=t3_jz_g  )
-            call allocate_poynting(fs, u=t3_rjfx_g); call allocate_poynting(fs, u=t3_rjfy_g); call allocate_poynting(fs, u=t3_rjfz_g)
+            allocate( t3_jx_g  (ix:jx,iy:jy,iz:jz), t3_jy_g  (ix:jx,iy:jy,iz:jz), t3_jz_g  (ix:jx,iy:jy,iz:jz), &
+                      t3_rjfx_g(ix:jx,iy:jy,iz:jz), t3_rjfy_g(ix:jx,iy:jy,iz:jz), t3_rjfz_g(ix:jx,iy:jy,iz:jz) )
             t3_jx_g=0d0; t3_jy_g=0d0; t3_jz_g=0d0; t3_rjfx_g=0d0; t3_rjfy_g=0d0; t3_rjfz_g=0d0
           end if
         end if
@@ -3705,30 +3728,33 @@ contains
         end if
 
         if( mod(iter,i_3tm_out)==0 )then
-          !report the peak over medium cells (the absorbing front, not the screened core).
-          !single-domain diagnostic: local peak equals the global peak for nproc_rgrid=1.
+          !report the front cell (illuminated face, the reference's x=0 surface analogue) and
+          !the global peak over medium cells (sits at internal Fabry-Perot antinodes, reads
+          !high in a finite slab).  Both written so the two can be compared.
           !i_3tm_out (>= obs_samp_em) bounds 3tm_rt.data to <= n_3tm_out_max rows.
-          ! front = illuminated face cell (matches the reference's x=0 surface cell);
-          ! max = global peak over medium cells (sits at internal Fabry-Perot antinodes,
-          ! reads high in a finite slab).  Both written so the two can be compared.
-          call ttm3_get_front( t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf )
+          !ttm3_get_front/ttm3_write_profile are COLLECTIVE (called by every rank): the front
+          !cell is selected globally, so cols 2-6 and 12-14 all come from the same cell for
+          !any MPI decomposition (rank 0 no longer reads its possibly-vacuum local cell).
+          call ttm3_get_front( t3_env, t3_power, t3_gen, &
+                               t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, &
+                               t3_envf,t3_powf,t3_genf, t3_gjx,t3_gjy,t3_gjz )
           call ttm3_get_max  ( t3_Te ,t3_Th ,t3_Tl ,t3_Ne ,t3_Nh  )
-          call ttm3_front_ijk( ix, iy, iz )                  ! front cell, for the field-envelope diagnostic (col 12)
           if( comm_is_root(nproc_id_global) )then
             open(unit2,file='3tm_rt.data',status='old',position='append')
-            ! col 12 = front-cell field-intensity envelope |E|^2+|E_g|^2 [a.u.]; compare to the
-            ! reference surface intensity out_all(6)=3.509e16*|E|^2*n to localize the ~2x field factor.
+            ! col 12 = front-cell field-intensity envelope |E|^2+|E_g|^2 [a.u.];
             ! col 13 = front-cell heating source -divS [a.u. power/vol]; col 14 = front-cell
             ! generation rate [a.u.].  With Te/Ne/Tl these reconstruct the full dTe balance
             ! externally (Ce, e-phonon, dilution, Col, gap cost) -> localize what sets Te.
             write(unit2,"(F16.8,99(1X,E23.15E3))") &
                  dble(iter)*dt_em*utime_from_au, &
-                 t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh, t3_env(ix,iy,iz), &
-                 t3_power(ix,iy,iz), t3_gen(ix,iy,iz)
+                 t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh, &
+                 t3_envf, t3_powf, t3_genf
             close(unit2)
-            ! depth profile (time, ix, Te[K], Ne[cm-3], Tl[K], |E|^2[a.u.]) for spatial diagnostics
-            call ttm3_write_profile( '3tm_prof.data', dble(iter)*dt_em*utime_from_au, unit2, t3_env )
           end if
+          ! depth profile (time, ix, Te[K], Ne[cm-3], Tl[K], |E|^2[a.u.]) along the global
+          ! front-cell line; collective (gathers x-slices), root does the writing inside
+          call ttm3_write_profile( '3tm_prof.data', dble(iter)*dt_em*utime_from_au, unit2, t3_env, &
+                                   t3_gjy, t3_gjz )
         end if
       end if !use_ttm3
 

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3311,7 +3311,7 @@ contains
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
     use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_get_front,ttm3_eps_sig,&
                                ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_front_ijk,ttm3_write_profile,&
-                               ttm3_drude_coef_cell
+                               ttm3_drude_coef_cell,ttm3_coupling_mode
     use phys_constants,  only: cspeed_au
     use math_constants,  only: pi
     implicit none
@@ -3375,7 +3375,8 @@ contains
                                                  fe%gbeam_width_x2 ,fe%gbeam_width_y2 ,fe%gbeam_width_z2 )
       end if
       if(fe%flag_ld) call eh_add_curr(fe%rjx_fdtd_ld(:,:,:),fe%rjy_fdtd_ld(:,:,:),fe%rjz_fdtd_ld(:,:,:))
-      if(use_ttm3 .and. allocated(t3_rjfx)) call eh_add_curr(t3_rjfx,t3_rjfy,t3_rjfz)  ! carrier Drude current
+      if(use_ttm3 .and. allocated(t3_rjfx) .and. ttm3_coupling_mode()==0) &
+        call eh_add_curr(t3_rjfx,t3_rjfy,t3_rjfz)  ! carrier Drude current (J-update only)
       call eh_sendrecv(fs,fe,'e')
       
       !update lorentz-drude
@@ -3449,7 +3450,8 @@ contains
         end if
         !ghost LD current
         if(fe%flag_ld) call eh_add_curr_g(fe%rjx_fdtd_ld_g,fe%rjy_fdtd_ld_g,fe%rjz_fdtd_ld_g)
-        if(use_ttm3 .and. allocated(t3_rjfx_g)) call eh_add_curr_g(t3_rjfx_g,t3_rjfy_g,t3_rjfz_g)  ! ghost carrier Drude
+        if(use_ttm3 .and. allocated(t3_rjfx_g) .and. ttm3_coupling_mode()==0) &
+          call eh_add_curr_g(t3_rjfx_g,t3_rjfy_g,t3_rjfz_g)  ! ghost carrier Drude (J-update only)
         call eh_sendrecv(fs,fe,'e_g')
 
         !update ghost LD
@@ -3605,6 +3607,7 @@ contains
         !    optics (eps_bg + sig_cold) from init.  This replaces the old eps/sigma coefficient
         !    back-action, which is numerically unstable in the real-field FDTD when sigma grows
         !    fast (abrupt coefficient change -> front/antinode runaway).
+        if( ttm3_coupling_mode()==0 )then
         do t3_im=1,ttm3_ninterior()
           call ttm3_interior_cell( t3_im, ix,iy,iz )
             call ttm3_drude_coef_cell( ix,iy,iz, omega1, dt_em, t3_c1, t3_cj )   ! c1, c2 (ADE)
@@ -3623,6 +3626,25 @@ contains
               t3_rjfz_g(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jz_g(ix,iy,iz)
             end if
         end do
+        else
+          !--- eps-update coupling (reference 3D3TM style): fold the carrier eps/sigma into the
+          !    FDTD media coefficients each step (same dielectric formula as init), instead of a
+          !    current source.  Isolates the Maxwell-coupling METHOD on an identical run.
+          do t3_im=1,ttm3_ninterior()
+            call ttm3_interior_cell( t3_im, ix,iy,iz )
+            call ttm3_eps_sig( ix,iy,iz, omega1, t3_eps, t3_sig )
+            t3_de = 1.0d0 + 2.0d0*pi*t3_sig/t3_eps*dt_em
+            t3_c1 = ( 1.0d0 - 2.0d0*pi*t3_sig/t3_eps*dt_em )/t3_de
+            t3_cx = cspeed_au/t3_eps*dt_em/t3_de/fs%hgs(1)
+            t3_cy = cspeed_au/t3_eps*dt_em/t3_de/fs%hgs(2)
+            t3_cz = cspeed_au/t3_eps*dt_em/t3_de/fs%hgs(3)
+            t3_cj = ( 4.0d0*pi/t3_eps*dt_em )/t3_de
+            fe%c1_ex_y(ix,iy,iz)= t3_c1; fe%c2_ex_y(ix,iy,iz)= t3_cy; fe%c1_ex_z(ix,iy,iz)= t3_c1; fe%c2_ex_z(ix,iy,iz)=-t3_cz
+            fe%c1_ey_z(ix,iy,iz)= t3_c1; fe%c2_ey_z(ix,iy,iz)= t3_cz; fe%c1_ey_x(ix,iy,iz)= t3_c1; fe%c2_ey_x(ix,iy,iz)=-t3_cx
+            fe%c1_ez_x(ix,iy,iz)= t3_c1; fe%c2_ez_x(ix,iy,iz)= t3_cx; fe%c1_ez_y(ix,iy,iz)= t3_c1; fe%c2_ez_y(ix,iy,iz)=-t3_cy
+            fe%c2_jx(ix,iy,iz)  =-t3_cj; fe%c2_jy(ix,iy,iz)  =-t3_cj; fe%c2_jz(ix,iy,iz)  =-t3_cj
+          end do
+        end if
 
         if( mod(iter,i_3tm_out)==0 )then
           !report the peak over medium cells (the absorbing front, not the screened core).

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3622,8 +3622,8 @@ contains
                  dble(iter)*dt_em*utime_from_au, &
                  t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh, t3_env(ix,iy,iz)
             close(unit2)
-            ! depth profile (time, ix, Te[K], Ne[cm-3], Tl[K]) for spatial-distribution diagnostics
-            call ttm3_write_profile( '3tm_prof.data', dble(iter)*dt_em*utime_from_au, unit2 )
+            ! depth profile (time, ix, Te[K], Ne[cm-3], Tl[K], |E|^2[a.u.]) for spatial diagnostics
+            call ttm3_write_profile( '3tm_prof.data', dble(iter)*dt_em*utime_from_au, unit2, t3_env )
           end if
         end if
       end if !use_ttm3

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -6631,17 +6631,21 @@ contains
       e_inc_i = -amp*(-alpha*sin(2.d0*theta1)*cos(theta2_i) &
                       -beta*cos(theta1)**2*sin(theta2_i))/beta*gamma
     elseif(aes=='Agauss') then
-      ! Gaussian-envelope pulse centred at 4*tw (so the field is ~0 at t=0 and rises
-      ! smoothly), envelope width tw.  Reproduces the standalone 3D3TM reference pulse
-      ! exp(-(t-4*tpulse)^2/tpulse^2) used for the carrier-generation study, where the
-      ! simulation window catches only the rising edge.  e_inc_i is the pi/2 quadrature
-      ! partner for the envelope feature.  No 0<=t<=tw window: the Gaussian decays itself.
-      gamma    = t - 4.0d0*tw                       ! time from the Gaussian centre
-      alpha    = exp( -gamma*gamma/(tw*tw) )        ! Gaussian envelope
+      ! Gaussian-envelope pulse centred at 4*tw (field ~0 at t=0, rises smoothly), width
+      ! tw, matching the standalone 3D3TM reference Ac ~ exp(-(t-4*tpulse)^2/tpulse^2).
+      ! The Gaussian is applied to the VECTOR POTENTIAL A and the field is E = -dA/dt
+      ! (normalised by omega so amp is the peak E amplitude).  Putting the envelope on A,
+      ! not on E, guarantees \int E dt = -[A] = 0 (A->0 at both ends), so the pulse leaves
+      ! no residual vector potential -- no spurious DC field / net momentum kick.  The
+      ! cos(theta) term is the envelope-derivative correction that enforces this.
+      ! e_inc_i is the pi/2 quadrature partner.  Gaussian decays itself (no 0<=t<=tw cut).
+      gamma    = t - 4.0d0*tw                        ! time from the Gaussian centre
+      alpha    = exp( -gamma*gamma/(tw*tw) )         ! Gaussian envelope of A
+      beta     = 2.0d0*gamma/(tw*tw)                 ! -d(ln env)/dt: envelope-derivative term
       theta2_r = omega*gamma + cep*2d0*pi
       theta2_i = omega*gamma + cep*2d0*pi + 1.5d0*pi
-      e_inc_r  = amp*alpha*cos(theta2_r)
-      e_inc_i  = amp*alpha*cos(theta2_i)
+      e_inc_r  = amp*alpha*( sin(theta2_r) + beta/omega*cos(theta2_r) )
+      e_inc_i  = amp*alpha*( sin(theta2_i) + beta/omega*cos(theta2_i) )
     else
       e_inc_r=0.0d0; e_inc_i=0.0d0;
     end if

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3299,7 +3299,10 @@ contains
     use misc_routines,   only: get_wtime
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
-    use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max
+    use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_eps_sig,&
+                               ttm3_ninterior,ttm3_interior_cell
+    use phys_constants,  only: cspeed_au
+    use math_constants,  only: pi
     implicit none
     type(s_fdtd_system),intent(inout) :: fs
     type(ls_fdtd_eh),   intent(inout) :: fe
@@ -3314,6 +3317,8 @@ contains
     real(8),allocatable :: t3_S(:,:,:,:), t3_divS(:,:,:), t3_S_g(:,:,:,:), t3_divS_g(:,:,:)
     real(8),allocatable :: t3_power(:,:,:), t3_gen(:,:,:), t3_env(:,:,:)
     real(8) :: t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
+    real(8) :: t3_eps,t3_sig,t3_de,t3_c1,t3_cx,t3_cy,t3_cz,t3_cj
+    integer :: t3_im
     real(8),allocatable :: u_energy(:,:,:), u_energy_p(:,:,:)
     real(8),allocatable :: work(:,:,:), work1(:,:,:), work2(:,:,:)
     real(8)             :: dV, tmp(4)
@@ -3549,6 +3554,33 @@ contains
         end do
         end do
         call ttm3_main( fs%srg_ng, fs%mg, t3_power, t3_gen )
+
+        !--- Stage 2 back-action: carrier-dependent permittivity drives the FDTD media
+        !    coefficients.  Only TRUE-INTERIOR medium cells (all 6 neighbours the same
+        !    medium) are updated, so the surface cells keep their interface-consistent
+        !    init coefficients.  The interior-cell list is built by ttm3 at init time;
+        !    fs%imedia must NOT be used here (the FDTD setup deallocates it).
+        !    Single-frequency static eps at omega1 (the reference's approximation);
+        !    SALMON's dt is vacuum-CFL-sized, so eps>=1 stays CFL-stable.
+        do t3_im=1,ttm3_ninterior()
+          call ttm3_interior_cell( t3_im, ix,iy,iz )
+            call ttm3_eps_sig( ix,iy,iz, omega1, t3_eps, t3_sig )
+            t3_eps = max( t3_eps, 1.0d0 )
+            t3_de  = 1.0d0/( 1.0d0 + 2.0d0*pi*t3_sig/t3_eps*dt_em )
+            t3_c1  = ( 1.0d0 - 2.0d0*pi*t3_sig/t3_eps*dt_em )*t3_de
+            t3_cx  = ( cspeed_au/t3_eps*dt_em )*t3_de/fs%hgs(1)
+            t3_cy  = ( cspeed_au/t3_eps*dt_em )*t3_de/fs%hgs(2)
+            t3_cz  = ( cspeed_au/t3_eps*dt_em )*t3_de/fs%hgs(3)
+            t3_cj  = ( 4.0d0*pi/t3_eps*dt_em )*t3_de
+            fe%c1_ex_y(ix,iy,iz)=t3_c1; fe%c2_ex_y(ix,iy,iz)= t3_cy
+            fe%c1_ex_z(ix,iy,iz)=t3_c1; fe%c2_ex_z(ix,iy,iz)=-t3_cz
+            fe%c1_ey_z(ix,iy,iz)=t3_c1; fe%c2_ey_z(ix,iy,iz)= t3_cz
+            fe%c1_ey_x(ix,iy,iz)=t3_c1; fe%c2_ey_x(ix,iy,iz)=-t3_cx
+            fe%c1_ez_x(ix,iy,iz)=t3_c1; fe%c2_ez_x(ix,iy,iz)= t3_cx
+            fe%c1_ez_y(ix,iy,iz)=t3_c1; fe%c2_ez_y(ix,iy,iz)=-t3_cy
+            fe%c2_jx(ix,iy,iz)=-t3_cj; fe%c2_jy(ix,iy,iz)=-t3_cj; fe%c2_jz(ix,iy,iz)=-t3_cj
+        end do
+
         if( mod(iter,obs_samp_em)==0 )then
           !report the peak over medium cells (the absorbing front, not the screened core).
           !single-domain diagnostic: local peak equals the global peak for nproc_rgrid=1.

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -882,8 +882,9 @@ contains
        if( comm_is_root(nproc_id_global) )then
           open(unit2,file='3tm_rt.data')
           write(unit2,'("#",99(1X,I0,":",A))') &
-               1, "Time[fs]", 2, "T_ele[K]", 3, "T_hole[K]", 4, "T_lat[K]", &
-               5, "N_ele[cm-3]", 6, "N_hole[cm-3]"
+               1, "Time[fs]", &
+               2, "Te_front[K]", 3, "Th_front[K]", 4, "Tl_front[K]", 5, "Ne_front[cm-3]", 6, "Nh_front[cm-3]", &
+               7, "Te_max[K]",   8, "Th_max[K]",   9, "Tl_max[K]",  10, "Ne_max[cm-3]",  11, "Nh_max[cm-3]"
           close(unit2)
        end if
     end if !use_ttm3
@@ -3308,7 +3309,7 @@ contains
     use misc_routines,   only: get_wtime
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
-    use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_eps_sig,&
+    use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_get_front,ttm3_eps_sig,&
                                ttm3_ninterior,ttm3_interior_cell
     use phys_constants,  only: cspeed_au
     use math_constants,  only: pi
@@ -3326,6 +3327,7 @@ contains
     real(8),allocatable :: t3_S(:,:,:,:), t3_divS(:,:,:), t3_S_g(:,:,:,:), t3_divS_g(:,:,:)
     real(8),allocatable :: t3_power(:,:,:), t3_gen(:,:,:), t3_env(:,:,:)
     real(8) :: t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
+    real(8) :: t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf
     real(8) :: t3_eps,t3_sig,t3_de,t3_c1,t3_cx,t3_cy,t3_cz,t3_cj
     integer :: t3_im
     real(8),allocatable :: u_energy(:,:,:), u_energy_p(:,:,:)
@@ -3601,11 +3603,16 @@ contains
           !report the peak over medium cells (the absorbing front, not the screened core).
           !single-domain diagnostic: local peak equals the global peak for nproc_rgrid=1.
           !i_3tm_out (>= obs_samp_em) bounds 3tm_rt.data to <= n_3tm_out_max rows.
-          call ttm3_get_max( t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh )
+          ! front = illuminated face cell (matches the reference's x=0 surface cell);
+          ! max = global peak over medium cells (sits at internal Fabry-Perot antinodes,
+          ! reads high in a finite slab).  Both written so the two can be compared.
+          call ttm3_get_front( t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf )
+          call ttm3_get_max  ( t3_Te ,t3_Th ,t3_Tl ,t3_Ne ,t3_Nh  )
           if( comm_is_root(nproc_id_global) )then
             open(unit2,file='3tm_rt.data',status='old',position='append')
             write(unit2,"(F16.8,99(1X,E23.15E3))") &
-                 dble(iter)*dt_em*utime_from_au, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
+                 dble(iter)*dt_em*utime_from_au, &
+                 t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
             close(unit2)
           end if
         end if

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3329,6 +3329,8 @@ contains
     real(8),allocatable :: t3_power(:,:,:), t3_gen(:,:,:), t3_env(:,:,:)
     real(8),allocatable :: t3_jx(:,:,:),t3_jy(:,:,:),t3_jz(:,:,:)        ! carrier Drude ADE current J
     real(8),allocatable :: t3_rjfx(:,:,:),t3_rjfy(:,:,:),t3_rjfz(:,:,:) ! J injected via eh_add_curr
+    real(8),allocatable :: t3_jx_g(:,:,:),t3_jy_g(:,:,:),t3_jz_g(:,:,:)        ! ghost (quadrature) carrier current
+    real(8),allocatable :: t3_rjfx_g(:,:,:),t3_rjfy_g(:,:,:),t3_rjfz_g(:,:,:) ! ghost J injected via eh_add_curr_g
     real(8) :: t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
     real(8) :: t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf
     real(8) :: t3_eps,t3_sig,t3_de,t3_c1,t3_cx,t3_cy,t3_cz,t3_cj,t3_gtpa
@@ -3447,6 +3449,7 @@ contains
         end if
         !ghost LD current
         if(fe%flag_ld) call eh_add_curr_g(fe%rjx_fdtd_ld_g,fe%rjy_fdtd_ld_g,fe%rjz_fdtd_ld_g)
+        if(use_ttm3 .and. allocated(t3_rjfx_g)) call eh_add_curr_g(t3_rjfx_g,t3_rjfy_g,t3_rjfz_g)  ! ghost carrier Drude
         call eh_sendrecv(fs,fe,'e_g')
 
         !update ghost LD
@@ -3550,7 +3553,15 @@ contains
           call allocate_poynting(fs, u=t3_jx  ); call allocate_poynting(fs, u=t3_jy  ); call allocate_poynting(fs, u=t3_jz  )
           call allocate_poynting(fs, u=t3_rjfx); call allocate_poynting(fs, u=t3_rjfy); call allocate_poynting(fs, u=t3_rjfz)
           t3_jx=0d0; t3_jy=0d0; t3_jz=0d0; t3_rjfx=0d0; t3_rjfy=0d0; t3_rjfz=0d0
-          if(yn_em_envelope=='y') call allocate_poynting(fs, t3_S_g, t3_divS_g)
+          if(yn_em_envelope=='y')then
+            call allocate_poynting(fs, t3_S_g, t3_divS_g)
+            !ghost (quadrature) carrier current: the envelope generation/heating use
+            !env = |E|^2 + |E_g|^2 and -0.5*(divS+divS_g), so the ghost field must be damped
+            !by the same carrier Drude as the real field, else |E_g|^2 stays undamped -> runaway.
+            call allocate_poynting(fs, u=t3_jx_g  ); call allocate_poynting(fs, u=t3_jy_g  ); call allocate_poynting(fs, u=t3_jz_g  )
+            call allocate_poynting(fs, u=t3_rjfx_g); call allocate_poynting(fs, u=t3_rjfy_g); call allocate_poynting(fs, u=t3_rjfz_g)
+            t3_jx_g=0d0; t3_jy_g=0d0; t3_jz_g=0d0; t3_rjfx_g=0d0; t3_rjfy_g=0d0; t3_rjfz_g=0d0
+          end if
         end if
         call calc_es_and_hs(fs, fe)
         call calc_poynting_vector(fs, fe, t3_S)
@@ -3603,6 +3614,14 @@ contains
             t3_rjfx(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jx(ix,iy,iz)
             t3_rjfy(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jy(ix,iy,iz)
             t3_rjfz(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jz(ix,iy,iz)
+            if(yn_em_envelope=='y')then   ! same carrier Drude on the ghost (quadrature) field
+              t3_jx_g(ix,iy,iz) = t3_c1*t3_jx_g(ix,iy,iz) + t3_cj*( fe%ex_y_g(ix,iy,iz)+fe%ex_z_g(ix,iy,iz) )
+              t3_jy_g(ix,iy,iz) = t3_c1*t3_jy_g(ix,iy,iz) + t3_cj*( fe%ey_z_g(ix,iy,iz)+fe%ey_x_g(ix,iy,iz) )
+              t3_jz_g(ix,iy,iz) = t3_c1*t3_jz_g(ix,iy,iz) + t3_cj*( fe%ez_x_g(ix,iy,iz)+fe%ez_y_g(ix,iy,iz) )
+              t3_rjfx_g(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jx_g(ix,iy,iz)
+              t3_rjfy_g(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jy_g(ix,iy,iz)
+              t3_rjfz_g(ix,iy,iz) = 0.5d0*(1.0d0+t3_c1)*t3_jz_g(ix,iy,iz)
+            end if
         end do
 
         if( mod(iter,i_3tm_out)==0 )then

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3310,7 +3310,7 @@ contains
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
     use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_get_front,ttm3_eps_sig,&
-                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen
+                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_front_ijk
     use phys_constants,  only: cspeed_au
     use math_constants,  only: pi
     implicit none
@@ -3613,11 +3613,14 @@ contains
           ! reads high in a finite slab).  Both written so the two can be compared.
           call ttm3_get_front( t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf )
           call ttm3_get_max  ( t3_Te ,t3_Th ,t3_Tl ,t3_Ne ,t3_Nh  )
+          call ttm3_front_ijk( ix, iy, iz )                  ! front cell, for the field-envelope diagnostic (col 12)
           if( comm_is_root(nproc_id_global) )then
             open(unit2,file='3tm_rt.data',status='old',position='append')
+            ! col 12 = front-cell field-intensity envelope |E|^2+|E_g|^2 [a.u.]; compare to the
+            ! reference surface intensity out_all(6)=3.509e16*|E|^2*n to localize the ~2x field factor.
             write(unit2,"(F16.8,99(1X,E23.15E3))") &
                  dble(iter)*dt_em*utime_from_au, &
-                 t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
+                 t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh, t3_env(ix,iy,iz)
             close(unit2)
           end if
         end if

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -252,7 +252,7 @@ contains
                                input_i3d_em,output_i3d_em,stop_em,input_r_txt_em,output_r_txt_em,input_r_bin_em, &
                                txtfile_copy_em
     use ttm,             only: use_ttm, init_ttm_parameters, init_ttm_grid, init_ttm_alloc
-    use ttm3,            only: use_ttm3, init_ttm3_parameters, ttm3_set_dt, init_ttm3_grid, init_ttm3_alloc
+    use ttm3,            only: use_ttm3, init_ttm3_parameters, ttm3_set_dt, init_ttm3_grid, init_ttm3_alloc, ttm3_set_xcomm
     implicit none
     type(s_fdtd_system),intent(inout) :: fs
     type(ls_fdtd_eh),   intent(inout) :: fe
@@ -877,6 +877,7 @@ contains
        call ttm3_set_dt( dt_em )   ! dt_em is finalised (CFL) by here; the early init captured 0
        call init_ttm3_grid( fs%hgs, fs%mg%is_array, fs%mg%is, fs%mg%ie, fs%imedia )
        call init_ttm3_alloc( fs%srg_ng, fs%mg )
+       call ttm3_set_xcomm( fs%icomm_x, fs%id_x, fs%isize_x )
        ! bound the time-series file: emit at most n_3tm_out_max rows, never finer than obs_samp_em
        i_3tm_out = max( obs_samp_em, (nt_em + n_3tm_out_max - 1)/n_3tm_out_max )
        if( comm_is_root(nproc_id_global) )then
@@ -6378,6 +6379,7 @@ contains
       write(*,*) "**************************"
     end if
     call init_communicator_dft(nproc_group_global,info)
+    fs%icomm_x = info%icomm_x; fs%id_x = info%id_x; fs%isize_x = info%isize_x
     
     !initialize r-grid
     call init_grid_whole(fs%rlsize,fs%hgs,fs%lg)

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3546,10 +3546,17 @@ contains
         else
           t3_power(:,:,:) = -t3_divS(:,:,:)
         end if
+        ! Energy-consistent carrier generation: one electron-hole pair per absorbed
+        ! photon, gen = (absorbed power)/(hbar*omega).  This ties generation to the
+        ! SAME absorbed power that heats (t3_power=-divS), so the gap cost gen*Egap is
+        ! always a bounded fraction (1-Egap/hw) of the absorbed power and Te cannot
+        ! diverge.  It mirrors the reference Se = alpha*I/(hbar*omega) (linear channel,
+        ! which dominates at 1.55 eV where two-photon absorption is negligible).
+        ! omega1 is the angular frequency in a.u., so hbar*omega = omega1 (hbar=1).
         do iz=fs%mg%is(3),fs%mg%ie(3)
         do iy=fs%mg%is(2),fs%mg%ie(2)
         do ix=fs%mg%is(1),fs%mg%ie(1)
-          t3_gen(ix,iy,iz) = ttm3_generation( t3_env(ix,iy,iz) )
+          t3_gen(ix,iy,iz) = max( t3_power(ix,iy,iz), 0.0d0 )/omega1
         end do
         end do
         end do

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3187,13 +3187,13 @@ contains
       
       !check ae_shape
       select case(ae_shape)
-      case('Ecos2','Acos2')
+      case('Ecos2','Acos2','Agauss')
         continue
       case default
         if     (ipulse==1) then
-          call stop_em('set ae_shape1 to "Ecos2" or "Acos2".')
+          call stop_em('set ae_shape1 to "Ecos2", "Acos2" or "Agauss".')
         elseif (ipulse==2) then
-          call stop_em('set ae_shape2 to "Ecos2" or "Acos2".')
+          call stop_em('set ae_shape2 to "Ecos2", "Acos2" or "Agauss".')
         end if
       end select
       
@@ -6620,6 +6620,18 @@ contains
                       -beta*cos(theta1)**2*sin(theta2_r))/beta*gamma
       e_inc_i = -amp*(-alpha*sin(2.d0*theta1)*cos(theta2_i) &
                       -beta*cos(theta1)**2*sin(theta2_i))/beta*gamma
+    elseif(aes=='Agauss') then
+      ! Gaussian-envelope pulse centred at 4*tw (so the field is ~0 at t=0 and rises
+      ! smoothly), envelope width tw.  Reproduces the standalone 3D3TM reference pulse
+      ! exp(-(t-4*tpulse)^2/tpulse^2) used for the carrier-generation study, where the
+      ! simulation window catches only the rising edge.  e_inc_i is the pi/2 quadrature
+      ! partner for the envelope feature.  No 0<=t<=tw window: the Gaussian decays itself.
+      gamma    = t - 4.0d0*tw                       ! time from the Gaussian centre
+      alpha    = exp( -gamma*gamma/(tw*tw) )        ! Gaussian envelope
+      theta2_r = omega*gamma + cep*2d0*pi
+      theta2_i = omega*gamma + cep*2d0*pi + 1.5d0*pi
+      e_inc_r  = amp*alpha*cos(theta2_r)
+      e_inc_i  = amp*alpha*cos(theta2_i)
     else
       e_inc_r=0.0d0; e_inc_i=0.0d0;
     end if

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -99,6 +99,8 @@ module fdtd_eh
     integer             :: ihz_x_is(3),ihz_x_ie(3),ihz_y_is(3),ihz_y_ie(3)                                     !h
     real(8),allocatable :: ex_s(:,:,:),ey_s(:,:,:),ez_s(:,:,:)     !e for save
     real(8),allocatable :: hx_s(:,:,:),hy_s(:,:,:),hz_s(:,:,:)     !h for save
+    real(8),allocatable :: ex_s_g(:,:,:),ey_s_g(:,:,:),ez_s_g(:,:,:) !ghost e for envelope poynting
+    real(8),allocatable :: hx_s_g(:,:,:),hy_s_g(:,:,:),hz_s_g(:,:,:) !ghost h for envelope poynting
     real(8),allocatable :: c2_jx(:,:,:),c2_jy(:,:,:),c2_jz(:,:,:)  !coeff. for general curr. dens.
     integer             :: num_ld                                  !LD: number of LD media
     integer             :: max_pole_num_ld                         !LD: maximum of pole_num_ld
@@ -803,6 +805,13 @@ contains
       call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hy_x_g)
       call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hz_x_g)
       call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hz_y_g)
+      !ghost cell-centered fields for envelope Poynting (cycle-averaged TTM source)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ex_s_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ey_s_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ez_s_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hx_s_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hy_s_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hz_s_g)
       !ghost LD state (only when LD media are present)
       if(fe%flag_ld) then
         call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%rjx_ld_g    )
@@ -3281,6 +3290,7 @@ contains
     !for ttm
     integer             :: jx,jy,jz,unit1=4000
     real(8),allocatable :: Spoynting(:,:,:,:), divS(:,:,:)
+    real(8),allocatable :: Spoynting_g(:,:,:,:), divS_g(:,:,:)
     real(8),allocatable :: u_energy(:,:,:), u_energy_p(:,:,:)
     real(8),allocatable :: work(:,:,:), work1(:,:,:), work2(:,:,:)
     real(8)             :: dV, tmp(4)
@@ -3422,11 +3432,21 @@ contains
         if ( .not.allocated(Spoynting) ) then
           call allocate_poynting(fs, Spoynting, divS, u_energy)
           call allocate_poynting(fs, u=u_energy_p)
+          if(yn_em_envelope=='y') call allocate_poynting(fs, Spoynting_g, divS_g)
         end if
         call calc_es_and_hs(fs, fe)
         call calc_poynting_vector(fs, fe, Spoynting)
         call calc_poynting_vector_div(fs, Spoynting, divS)
-        u_energy(:,:,:) = u_energy(:,:,:) - divS(:,:,:)*dt_em
+        if(yn_em_envelope=='y') then
+          !--- cycle-averaged (envelope) absorbed power via ghost Poynting:        ---!
+          !--- <-divS> = 0.5*( -divS[real] - divS[ghost] ) removes the 2*omega ripple ---!
+          call calc_es_and_hs_g(fs, fe)
+          call calc_poynting_vector_g(fs, fe, Spoynting_g)
+          call calc_poynting_vector_div(fs, Spoynting_g, divS_g)
+          u_energy(:,:,:) = u_energy(:,:,:) - 0.5d0*( divS(:,:,:) + divS_g(:,:,:) )*dt_em
+        else
+          u_energy(:,:,:) = u_energy(:,:,:) - divS(:,:,:)*dt_em
+        end if
         
         u_energy_p = u_energy
         call ttm_penetration( fs%mg%is, u_energy_p )
@@ -6274,6 +6294,69 @@ contains
       
       !deallocate temporary variable
       deallocate(f1,f2,f3)
+    elseif(var=='s_g') then
+      !ghost cell-centered collocation, mirror of 's' on the ghost (_g) fields
+      allocate(f1(fs%mg%is_array(1):fs%mg%ie_array(1),&
+                  fs%mg%is_array(2):fs%mg%ie_array(2),&
+                  fs%mg%is_array(3):fs%mg%ie_array(3)),&
+               f2(fs%mg%is_array(1):fs%mg%ie_array(1),&
+                  fs%mg%is_array(2):fs%mg%ie_array(2),&
+                  fs%mg%is_array(3):fs%mg%ie_array(3)),&
+               f3(fs%mg%is_array(1):fs%mg%ie_array(1),&
+                  fs%mg%is_array(2):fs%mg%ie_array(2),&
+                  fs%mg%is_array(3):fs%mg%ie_array(3)))
+      f1(:,:,:)=0.0d0; f2(:,:,:)=0.0d0; f3(:,:,:)=0.0d0;
+      !spatially adjust ghost e
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fs%mg%is(3),fs%mg%ie(3)
+      do iy=fs%mg%is(2),fs%mg%ie(2)
+      do ix=fs%mg%is(1),fs%mg%ie(1)
+        f1(ix,iy,iz)=( fe%ex_s_g(ix,iy,iz)+fe%ex_s_g(ix-1,iy,iz) )/2.0d0
+        f2(ix,iy,iz)=( fe%ey_s_g(ix,iy,iz)+fe%ey_s_g(ix,iy-1,iz) )/2.0d0
+        f3(ix,iy,iz)=( fe%ez_s_g(ix,iy,iz)+fe%ez_s_g(ix,iy,iz-1) )/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+      fe%ex_s_g(:,:,:)=f1(:,:,:); fe%ey_s_g(:,:,:)=f2(:,:,:); fe%ez_s_g(:,:,:)=f3(:,:,:);
+      f1(:,:,:)=0.0d0; f2(:,:,:)=0.0d0; f3(:,:,:)=0.0d0;
+      !spatially adjust ghost h
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fs%mg%is(3),fs%mg%ie(3)
+      do iy=fs%mg%is(2),fs%mg%ie(2)
+      do ix=fs%mg%is(1),fs%mg%ie(1)
+        f1(ix,iy,iz)=( fe%hx_s_g(ix,iy,iz)+fe%hx_s_g(ix,iy-1,iz) )/2.0d0
+        f2(ix,iy,iz)=( fe%hy_s_g(ix,iy,iz)+fe%hy_s_g(ix,iy,iz-1) )/2.0d0
+        f3(ix,iy,iz)=( fe%hz_s_g(ix,iy,iz)+fe%hz_s_g(ix-1,iy,iz) )/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+      fe%hx_s_g(:,:,:)=f1(:,:,:); fe%hy_s_g(:,:,:)=f2(:,:,:); fe%hz_s_g(:,:,:)=f3(:,:,:);
+      f1(:,:,:)=0.0d0; f2(:,:,:)=0.0d0; f3(:,:,:)=0.0d0;
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hx_s_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hy_s_g)
+      call update_overlap_real8(fs%srg_ng,fs%mg,fe%hz_s_g)
+!$omp parallel
+!$omp do private(ix,iy,iz) collapse(2)
+      do iz=fs%mg%is(3),fs%mg%ie(3)
+      do iy=fs%mg%is(2),fs%mg%ie(2)
+      do ix=fs%mg%is(1),fs%mg%ie(1)
+        f1(ix,iy,iz)=( fe%hx_s_g(ix,iy,iz)+fe%hx_s_g(ix,iy,iz-1) )/2.0d0
+        f2(ix,iy,iz)=( fe%hy_s_g(ix,iy,iz)+fe%hy_s_g(ix-1,iy,iz) )/2.0d0
+        f3(ix,iy,iz)=( fe%hz_s_g(ix,iy,iz)+fe%hz_s_g(ix,iy-1,iz) )/2.0d0
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+      fe%hx_s_g(:,:,:)=f1(:,:,:); fe%hy_s_g(:,:,:)=f2(:,:,:); fe%hz_s_g(:,:,:)=f3(:,:,:);
+      !deallocate temporary variable
+      deallocate(f1,f2,f3)
     end if
     
     return
@@ -6932,6 +7015,40 @@ contains
   end subroutine calc_es_and_hs
 
   !===========================================================================================
+  != cell-centered ghost fields for envelope Poynting (mirror of calc_es_and_hs) =============
+  subroutine calc_es_and_hs_g(fs, fe)
+    use structures, only: s_fdtd_system
+    use sendrecv_grid, only: update_overlap_real8
+    implicit none
+    type(s_fdtd_system),intent(inout) :: fs
+    type(ls_fdtd_eh), intent(inout)   :: fe
+    integer :: ix,iy,iz
+!$omp parallel
+!$omp do private(ix,iy,iz)
+    do iz=(fs%mg%is_array(3)),(fs%mg%ie_array(3))
+    do iy=(fs%mg%is_array(2)),(fs%mg%ie_array(2))
+    do ix=(fs%mg%is_array(1)),(fs%mg%ie_array(1))
+       fe%ex_s_g(ix,iy,iz)=fe%ex_y_g(ix,iy,iz)+fe%ex_z_g(ix,iy,iz)
+       fe%ey_s_g(ix,iy,iz)=fe%ey_z_g(ix,iy,iz)+fe%ey_x_g(ix,iy,iz)
+       fe%ez_s_g(ix,iy,iz)=fe%ez_x_g(ix,iy,iz)+fe%ez_y_g(ix,iy,iz)
+       fe%hx_s_g(ix,iy,iz)=( fe%hx_s_g(ix,iy,iz)+(fe%hx_y_g(ix,iy,iz)+fe%hx_z_g(ix,iy,iz)) )*0.5d0
+       fe%hy_s_g(ix,iy,iz)=( fe%hy_s_g(ix,iy,iz)+(fe%hy_z_g(ix,iy,iz)+fe%hy_x_g(ix,iy,iz)) )*0.5d0
+       fe%hz_s_g(ix,iy,iz)=( fe%hz_s_g(ix,iy,iz)+(fe%hz_x_g(ix,iy,iz)+fe%hz_y_g(ix,iy,iz)) )*0.5d0
+    end do
+    end do
+    end do
+!$omp end do
+!$omp end parallel
+    call eh_sendrecv(fs,fe,'s_g')
+    call update_overlap_real8( fs%srg_ng, fs%mg, fe%ex_s_g )
+    call update_overlap_real8( fs%srg_ng, fs%mg, fe%ey_s_g )
+    call update_overlap_real8( fs%srg_ng, fs%mg, fe%ez_s_g )
+    call update_overlap_real8( fs%srg_ng, fs%mg, fe%hx_s_g )
+    call update_overlap_real8( fs%srg_ng, fs%mg, fe%hy_s_g )
+    call update_overlap_real8( fs%srg_ng, fs%mg, fe%hz_s_g )
+  end subroutine calc_es_and_hs_g
+
+  !===========================================================================================
   != For ttm =================================================================================
   subroutine allocate_poynting(fs, S, divS, u)
     use structures, only: s_fdtd_system
@@ -6994,6 +7111,39 @@ contains
 !$omp end do
 !$omp end parallel
   end subroutine calc_poynting_vector
+
+  !===========================================================================================
+  != ghost Poynting vector for envelope (mirror of calc_poynting_vector on _g fields) ========
+  subroutine calc_poynting_vector_g(fs, fe, Spoynting)
+    use structures, only: s_fdtd_system
+    implicit none
+    type(s_fdtd_system),intent(inout) :: fs
+    type(ls_fdtd_eh), intent(inout)   :: fe
+    real(8), intent(inout) :: Spoynting(:,:,:,:)
+    integer :: ix,iy,iz,jx,jy,jz,ix0,iy0,iz0,ix1,iy1,iz1
+    ix0=fs%mg%is_array(1)
+    iy0=fs%mg%is_array(2)
+    iz0=fs%mg%is_array(3)
+    ix1=fs%mg%ie_array(1)
+    iy1=fs%mg%ie_array(2)
+    iz1=fs%mg%ie_array(3)
+!$omp parallel
+!$omp do private(ix,iy,iz,jx,jy,jz)
+    do iz = iz0, iz1
+       jz=iz-iz0+1
+    do iy = iy0, iy1
+       jy=iy-iy0+1
+    do ix = ix0, ix1
+       jx=ix-ix0+1
+       Spoynting(jx,jy,jz,1) = fe%ey_s_g(ix,iy,iz)*fe%hz_s_g(ix,iy,iz) - fe%ez_s_g(ix,iy,iz)*fe%hy_s_g(ix,iy,iz)
+       Spoynting(jx,jy,jz,2) = fe%ez_s_g(ix,iy,iz)*fe%hx_s_g(ix,iy,iz) - fe%ex_s_g(ix,iy,iz)*fe%hz_s_g(ix,iy,iz)
+       Spoynting(jx,jy,jz,3) = fe%ex_s_g(ix,iy,iz)*fe%hy_s_g(ix,iy,iz) - fe%ey_s_g(ix,iy,iz)*fe%hx_s_g(ix,iy,iz)
+    end do
+    end do
+    end do
+!$omp end do
+!$omp end parallel
+  end subroutine calc_poynting_vector_g
 
   !===========================================================================================
   != For ttm =================================================================================

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3310,7 +3310,7 @@ contains
     use common_maxwell,  only: output_r_txt_em,output_r_bin_em,txtfile_copy_em
     use ttm,             only: use_ttm,ttm_penetration,ttm_main,ttm_get_temperatures
     use ttm3,            only: use_ttm3,ttm3_main,ttm3_generation,ttm3_get_max,ttm3_get_front,ttm3_eps_sig,&
-                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_front_ijk
+                               ttm3_ninterior,ttm3_interior_cell,ttm3_linear_gen,ttm3_front_ijk,ttm3_write_profile
     use phys_constants,  only: cspeed_au
     use math_constants,  only: pi
     implicit none
@@ -3622,6 +3622,8 @@ contains
                  dble(iter)*dt_em*utime_from_au, &
                  t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf, t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh, t3_env(ix,iy,iz)
             close(unit2)
+            ! depth profile (time, ix, Te[K], Ne[cm-3], Tl[K]) for spatial-distribution diagnostics
+            call ttm3_write_profile( '3tm_prof.data', dble(iter)*dt_em*utime_from_au, unit2 )
           end if
         end if
       end if !use_ttm3

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -7146,6 +7146,48 @@ contains
   end subroutine calc_poynting_vector_g
 
   !===========================================================================================
+  != per-cell field-intensity envelope E^2 + E_g^2 (reuse hook) ==============================
+  != Returns the cycle-averaged field intensity |E|^2 + |E_g|^2 per cell, where E_g is the   =
+  != pi/2 quadrature (ghost) field. This is the smooth (2*omega-free) intensity envelope,    =
+  != the natural EM input for envelope-level models such as 3TM photo-ionization /            =
+  != carrier generation (distinct from the absorbed-power envelope used by the TTM source).   =
+  != Self-contained: built from the always-current split-Yee E components, independent of     =
+  != use_ttm / calc_es_and_hs. Valid only when yn_em_envelope=='y' (else returns 0).          =
+  subroutine eh_get_field_envelope(fs, fe, env)
+    use structures,    only: s_fdtd_system
+    use salmon_global, only: yn_em_envelope
+    implicit none
+    type(s_fdtd_system),intent(in) :: fs
+    type(ls_fdtd_eh),   intent(in) :: fe
+    real(8),intent(out) :: env(fs%mg%is_array(1):fs%mg%ie_array(1),&
+                               fs%mg%is_array(2):fs%mg%ie_array(2),&
+                               fs%mg%is_array(3):fs%mg%ie_array(3))
+    integer :: ix,iy,iz
+    real(8) :: ex,ey,ez,exg,eyg,ezg
+    if(yn_em_envelope/='y') then
+      env(:,:,:)=0.0d0
+      return
+    end if
+!$omp parallel
+!$omp do private(ix,iy,iz,ex,ey,ez,exg,eyg,ezg)
+    do iz=fs%mg%is_array(3),fs%mg%ie_array(3)
+    do iy=fs%mg%is_array(2),fs%mg%ie_array(2)
+    do ix=fs%mg%is_array(1),fs%mg%ie_array(1)
+      ex =fe%ex_y(ix,iy,iz)+fe%ex_z(ix,iy,iz)
+      ey =fe%ey_z(ix,iy,iz)+fe%ey_x(ix,iy,iz)
+      ez =fe%ez_x(ix,iy,iz)+fe%ez_y(ix,iy,iz)
+      exg=fe%ex_y_g(ix,iy,iz)+fe%ex_z_g(ix,iy,iz)
+      eyg=fe%ey_z_g(ix,iy,iz)+fe%ey_x_g(ix,iy,iz)
+      ezg=fe%ez_x_g(ix,iy,iz)+fe%ez_y_g(ix,iy,iz)
+      env(ix,iy,iz)=ex*ex+ey*ey+ez*ez+exg*exg+eyg*eyg+ezg*ezg
+    end do
+    end do
+    end do
+!$omp end do
+!$omp end parallel
+  end subroutine eh_get_field_envelope
+
+  !===========================================================================================
   != For ttm =================================================================================
   subroutine calc_poynting_vector_div(fs, Spoynting, divS)
     use structures, only: s_fdtd_system

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -3328,7 +3328,7 @@ contains
     real(8),allocatable :: t3_power(:,:,:), t3_gen(:,:,:), t3_env(:,:,:)
     real(8) :: t3_Te,t3_Th,t3_Tl,t3_Ne,t3_Nh
     real(8) :: t3_Tef,t3_Thf,t3_Tlf,t3_Nef,t3_Nhf
-    real(8) :: t3_eps,t3_sig,t3_de,t3_c1,t3_cx,t3_cy,t3_cz,t3_cj
+    real(8) :: t3_eps,t3_sig,t3_de,t3_c1,t3_cx,t3_cy,t3_cz,t3_cj,t3_gtpa
     integer :: t3_im
     real(8),allocatable :: u_energy(:,:,:), u_energy_p(:,:,:)
     real(8),allocatable :: work(:,:,:), work1(:,:,:), work2(:,:,:)
@@ -3557,17 +3557,20 @@ contains
         else
           t3_power(:,:,:) = -t3_divS(:,:,:)
         end if
-        ! Energy-consistent carrier generation: one electron-hole pair per absorbed
-        ! photon, gen = (absorbed power)/(hbar*omega).  This ties generation to the
-        ! SAME absorbed power that heats (t3_power=-divS), so the gap cost gen*Egap is
-        ! always a bounded fraction (1-Egap/hw) of the absorbed power and Te cannot
-        ! diverge.  It mirrors the reference Se = alpha*I/(hbar*omega) (linear channel,
-        ! which dominates at 1.55 eV where two-photon absorption is negligible).
-        ! omega1 is the angular frequency in a.u., so hbar*omega = omega1 (hbar=1).
+        ! Carrier generation channels (reference Se):
+        !  - linear (1 pair / absorbed photon): gen = max(-divS,0)/(hbar*omega), tied to the
+        !    SAME absorbed power that heats, so the gap cost is a bounded fraction of it;
+        !  - two-photon (TPA): gen_tpa = beta2*I_env^2 (ttm3_generation), 2 photons per pair.
+        !    Its absorbed power 2*hbar*omega*gen_tpa is added to the heating source so the
+        !    energy book-keeping stays consistent.  beta2=0 (physical at 1.55 eV, below the
+        !    TPA threshold) leaves the validated linear result unchanged; beta2>0 activates
+        !    the channel for higher photon energy / intensity.  hbar*omega = omega1 (hbar=1).
         do iz=fs%mg%is(3),fs%mg%ie(3)
         do iy=fs%mg%is(2),fs%mg%ie(2)
         do ix=fs%mg%is(1),fs%mg%ie(1)
-          t3_gen(ix,iy,iz) = max( t3_power(ix,iy,iz), 0.0d0 )/omega1
+          t3_gtpa = ttm3_generation( t3_env(ix,iy,iz) )                       ! beta2 * I_env^2
+          t3_gen(ix,iy,iz)   = max( t3_power(ix,iy,iz), 0.0d0 )/omega1 + t3_gtpa
+          t3_power(ix,iy,iz) = t3_power(ix,iy,iz) + 2.0d0*omega1*t3_gtpa      ! TPA: 2 hbar w per pair
         end do
         end do
         end do

--- a/src/maxwell/fdtd_eh.f90
+++ b/src/maxwell/fdtd_eh.f90
@@ -87,6 +87,13 @@ module fdtd_eh
     real(8),allocatable :: hx_y(:,:,:),c1_hx_y(:,:,:),c2_hx_y(:,:,:),hx_z(:,:,:),c1_hx_z(:,:,:),c2_hx_z(:,:,:) !h
     real(8),allocatable :: hy_z(:,:,:),c1_hy_z(:,:,:),c2_hy_z(:,:,:),hy_x(:,:,:),c1_hy_x(:,:,:),c2_hy_x(:,:,:) !h
     real(8),allocatable :: hz_x(:,:,:),c1_hz_x(:,:,:),c2_hz_x(:,:,:),hz_y(:,:,:),c1_hz_y(:,:,:),c2_hz_y(:,:,:) !h
+    !ghost (quadrature) EM field state arrays — allocated only when yn_em_envelope='y'
+    real(8),allocatable :: ex_y_g(:,:,:),ex_z_g(:,:,:)  !ghost e-field split-Yee state
+    real(8),allocatable :: ey_z_g(:,:,:),ey_x_g(:,:,:)  !ghost e-field split-Yee state
+    real(8),allocatable :: ez_x_g(:,:,:),ez_y_g(:,:,:)  !ghost e-field split-Yee state
+    real(8),allocatable :: hx_y_g(:,:,:),hx_z_g(:,:,:)  !ghost h-field split-Yee state
+    real(8),allocatable :: hy_z_g(:,:,:),hy_x_g(:,:,:)  !ghost h-field split-Yee state
+    real(8),allocatable :: hz_x_g(:,:,:),hz_y_g(:,:,:)  !ghost h-field split-Yee state
     integer             :: ihx_y_is(3),ihx_y_ie(3),ihx_z_is(3),ihx_z_ie(3)                                     !h
     integer             :: ihy_z_is(3),ihy_z_ie(3),ihy_x_is(3),ihy_x_ie(3)                                     !h
     integer             :: ihz_x_is(3),ihz_x_ie(3),ihz_y_is(3),ihz_y_ie(3)                                     !h
@@ -117,6 +124,19 @@ module fdtd_eh
     real(8),allocatable :: ex_old_ld(:,:,:),&                      !LD: old E
                            ey_old_ld(:,:,:),&                      !    (x,y,z)
                            ez_old_ld(:,:,:)                        !
+    !ghost LD state arrays — allocated only when yn_em_envelope='y' and flag_ld=.true.
+    real(8),allocatable :: rjx_ld_g(:,:,:,:),rjx_old_ld_g(:,:,:,:),& !ghost LD J and stock
+                           rjy_ld_g(:,:,:,:),rjy_old_ld_g(:,:,:,:),& !
+                           rjz_ld_g(:,:,:,:),rjz_old_ld_g(:,:,:,:)   !
+    real(8),allocatable ::  px_ld_g(:,:,:,:),&                        !ghost LD P vector
+                            py_ld_g(:,:,:,:),&                        !
+                            pz_ld_g(:,:,:,:)                          !
+    real(8),allocatable :: rjx_fdtd_ld_g(:,:,:),&                    !ghost LD J into FDTD
+                           rjy_fdtd_ld_g(:,:,:),&                    !
+                           rjz_fdtd_ld_g(:,:,:)                      !
+    real(8),allocatable :: ex_old_ld_g(:,:,:),&                      !ghost LD old E
+                           ey_old_ld_g(:,:,:),&                      !
+                           ez_old_ld_g(:,:,:)                        !
     real(8),allocatable :: rmedia(:,:,:)                           !Material information for tmp.
     real(8),allocatable :: time_lr(:)                              !LR: time
     real(8),allocatable :: fr_lr(:,:)                              !LR: Re[f]
@@ -209,7 +229,7 @@ contains
                                ase_smedia_id_em,ase_box_cent_em,ase_box_size_em,                           &
                                art_num_em,art_ene_min_em,art_ene_max_em,art_wav_min_em,art_wav_max_em,     &
                                art_smedia_id_em,art_plane_bot_em,art_plane_top_em,                         &
-                               yn_restart,directory_read_data,checkpoint_interval
+                               yn_restart,directory_read_data,checkpoint_interval,yn_em_envelope
     use inputoutput,     only: utime_from_au,ulength_from_au,uenergy_from_au,unit_system,&
                                uenergy_to_au,ulength_to_au,ucharge_to_au
     use parallelization, only: nproc_id_global,nproc_group_global,nproc_size_global
@@ -766,7 +786,43 @@ contains
       call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',                         r3d=fe%ey_old_ld  )
       call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',                         r3d=fe%ez_old_ld  )
     end if
-    
+
+    !*** allocate ghost (quadrature) EM field state arrays when envelope feature is enabled *******************!
+    if(yn_em_envelope=='y') then
+      !ghost split-Yee E field state
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ex_y_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ex_z_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ey_z_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ey_x_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ez_x_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%ez_y_g)
+      !ghost split-Yee H field state
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hx_y_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hx_z_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hy_z_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hy_x_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hz_x_g)
+      call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',r3d=fe%hz_y_g)
+      !ghost LD state (only when LD media are present)
+      if(fe%flag_ld) then
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%rjx_ld_g    )
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%rjy_ld_g    )
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%rjz_ld_g    )
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%rjx_old_ld_g)
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%rjy_old_ld_g)
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%rjz_old_ld_g)
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%px_ld_g     )
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%py_ld_g     )
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r4d',num4d=fe%max_pole_num_ld,r4d=fe%pz_ld_g     )
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',                         r3d=fe%rjx_fdtd_ld_g)
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',                         r3d=fe%rjy_fdtd_ld_g)
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',                         r3d=fe%rjz_fdtd_ld_g)
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',                         r3d=fe%ex_old_ld_g  )
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',                         r3d=fe%ey_old_ld_g  )
+        call eh_allocate(fs%mg%is_array,fs%mg%ie_array,'r3d',                         r3d=fe%ez_old_ld_g  )
+      end if
+    end if
+
     !*** set fdtd coeffient and light speed for media ID = 0 **************************************************!
     allocate(fe%rep(0:media_num),fe%rmu(0:media_num),fe%sig(0:media_num))
     fe%rep(:)=1.0d0; fe%rmu(:)=1.0d0; fe%sig(:)=0.0d0;

--- a/src/ttm/CMakeLists.txt
+++ b/src/ttm/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     ttm.f90
+    ttm3.f90
    )
 
 list_prepend(SOURCES ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -310,10 +310,10 @@ contains
   subroutine ttm3_main( srg, rg, source, gen )
     use structures, only: s_rgrid, s_sendrecv_grid
     implicit none
-    type(s_sendrecv_grid), intent(inout) :: srg     ! reserved for the transport stage
+    type(s_sendrecv_grid), intent(inout) :: srg     ! used by ttm3_transport (Stage 4)
     type(s_rgrid),         intent(in)    :: rg
-    real(8),intent(in) :: source(rg%is_array(1):,rg%is_array(2):,rg%is_array(3):)
-    real(8),intent(in) :: gen   (rg%is_array(1):,rg%is_array(2):,rg%is_array(3):)
+    real(8),intent(in) :: source(rg%is(1):,rg%is(2):,rg%is(3):)
+    real(8),intent(in) :: gen   (rg%is(1):,rg%is(2):,rg%is(3):)
     integer :: m,ix,iy,iz
 
 !$omp parallel do private(m,ix,iy,iz)

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -76,12 +76,15 @@ module ttm3
   real(8),allocatable :: rhs_te(:,:,:), rhs_th(:,:,:), rhs_tl(:,:,:)
   real(8),allocatable :: rhs_ne(:,:,:), rhs_nh(:,:,:)
 
-  ! Fermi-Dirac integral table F_j(eta) for j = -1/2, 1/2, 3/2 (indices 1,2,3),
-  ! built once at init by quadrature, interpolated in the inner loop (the same
-  ! table approach as the reference's Table_Fermi).  eta grid: f_eta0 + k*f_deta.
+  ! Fermi-Dirac integral table F_j(eta).  Indices 1,2,3 = j = -1/2,1/2,3/2 (heat
+  ! capacity / chemical potential); indices 4,5 = j = 1,2 (transport: mobility,
+  ! diffusion, thermal conductivity).  F_0(eta)=ln(1+exp(eta)) is analytic (ttm3_F0),
+  ! no table.  Built once at init by quadrature; interpolated in the inner loop (the
+  ! same table approach as the reference's Table_Fermi).  eta grid: f_eta0 + k*f_deta.
   integer,parameter   :: f_neta = 2400
   real(8),parameter   :: f_eta0 = -60.0d0, f_deta = 0.05d0
-  real(8)             :: f_tab(0:f_neta,3)
+  integer,parameter   :: f_nj   = 5
+  real(8)             :: f_tab(0:f_neta,f_nj)
   logical             :: f_built = .false.
 
   ! density floor to keep the carrier heat capacity well defined.  Set to the
@@ -325,14 +328,16 @@ contains
     implicit none
     integer,parameter :: nq=4000
     integer :: k,q,jj
-    real(8) :: eta,umax,du,u,integ,s,gam(3),jval(3)
-    jval = (/ -0.5d0, 0.5d0, 1.5d0 /)
-    gam  = (/ 1.7724538509055160d0, 0.8862269254527580d0, 1.3293403881791370d0 /) ! Gamma(j+1)
+    real(8) :: eta,umax,du,u,integ,s,gam(f_nj),jval(f_nj)
+    ! indices 1..5 = j = -1/2, 1/2, 3/2, 1, 2  (gam = Gamma(j+1))
+    jval = (/ -0.5d0, 0.5d0, 1.5d0, 1.0d0, 2.0d0 /)
+    gam  = (/ 1.7724538509055160d0, 0.8862269254527580d0, 1.3293403881791370d0, &
+              1.0d0, 2.0d0 /)                                            ! Gamma(2)=1, Gamma(3)=2
     do k=0,f_neta
        eta = f_eta0 + dble(k)*f_deta
        umax = sqrt( max(eta,0.0d0) + 50.0d0 )
        du = umax/dble(nq)
-       do jj=1,3
+       do jj=1,f_nj
           integ = 0.0d0
           do q=0,nq
              u = dble(q)*du
@@ -359,7 +364,7 @@ contains
     end if
   end subroutine ttm3_build_fermi_table
 
-  ! F_j(eta) by linear interpolation of the table (jidx: 1=-1/2, 2=1/2, 3=3/2).
+  ! F_j(eta) by linear interpolation of the table (jidx: 1=-1/2, 2=1/2, 3=3/2, 4=1, 5=2).
   pure function ttm3_fermi( jidx, eta ) result( F )
     implicit none
     integer,intent(in) :: jidx
@@ -373,6 +378,16 @@ contains
     end if
     F = (1.0d0-w)*f_tab(k,jidx) + w*f_tab(k+1,jidx)
   end function ttm3_fermi
+
+  ! F_0(eta) = ln(1+exp(eta)) (analytic; no table).  Overflow-guarded: -> eta for eta>>0.
+  pure function ttm3_F0( eta ) result( F )
+    implicit none
+    real(8),intent(in) :: eta
+    real(8) :: F
+    if( eta > 40.0d0 )then ; F = eta
+    else                   ; F = log( 1.0d0 + exp(eta) )
+    end if
+  end function ttm3_F0
 
   ! Reduced chemical potential eta from (T,mass,N) by bisecting N = Neff*F_{1/2}(eta),
   ! Neff = 2*(mass*T/(2*pi))^(3/2)  (atomic units).

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -75,6 +75,14 @@ module ttm3
   real(8),allocatable :: rhs_te(:,:,:), rhs_th(:,:,:), rhs_tl(:,:,:)
   real(8),allocatable :: rhs_ne(:,:,:), rhs_nh(:,:,:)
 
+  ! Fermi-Dirac integral table F_j(eta) for j = -1/2, 1/2, 3/2 (indices 1,2,3),
+  ! built once at init by quadrature, interpolated in the inner loop (the same
+  ! table approach as the reference's Table_Fermi).  eta grid: f_eta0 + k*f_deta.
+  integer,parameter   :: f_neta = 2400
+  real(8),parameter   :: f_eta0 = -60.0d0, f_deta = 0.05d0
+  real(8)             :: f_tab(0:f_neta,3)
+  logical             :: f_built = .false.
+
   ! density floor to keep the carrier heat capacity well defined
   real(8),parameter :: N_floor = 1.0d-9    ! [1/bohr^3] (~7e15 cm^-3 carrier floor)
   real(8),parameter :: T_clamp = 31.67d0   ! [a.u.] (~1e7 K) numerical temperature cap
@@ -187,6 +195,9 @@ contains
                        * atomic_unit_of_length**3 &
                        * hartree_kelvin_relationship
     tp3%Tini = tp3%Tini / hartree_kelvin_relationship
+
+    ! Fermi-Dirac integral table for the carrier heat capacity (built once)
+    call ttm3_build_fermi_table()
     ! mu_e, mu_h, eps_bg, beta2, dgap_c are taken as given (eps_bg,mu dimensionless; beta2,dgap_c in a.u.)
     tp3%N0    = tp3%N0 * (atomic_unit_of_length*1.0d2)**3                 ! [cm^-3] -> [bohr^-3]
     tp3%Ddiff = tp3%Ddiff * (1.0d-2/atomic_unit_of_length)**2 * atomic_unit_of_time   ! [cm^2/s] -> a.u.
@@ -302,6 +313,81 @@ contains
   end subroutine init_ttm3_alloc
 
   !---------------------------------------------------------------------------
+  ! Build the Fermi-Dirac integral table F_j(eta), j = -1/2, 1/2, 3/2, once.
+  ! F_j(eta) = (2/Gamma(j+1)) * Integral_0^inf u^(2j+1)/(exp(u^2-eta)+1) du
+  ! (the substitution t=u^2 removes the t^(-1/2) endpoint singularity).
+  subroutine ttm3_build_fermi_table()
+    implicit none
+    integer,parameter :: nq=4000
+    integer :: k,q,jj
+    real(8) :: eta,umax,du,u,integ,s,gam(3),jval(3)
+    jval = (/ -0.5d0, 0.5d0, 1.5d0 /)
+    gam  = (/ 1.7724538509055160d0, 0.8862269254527580d0, 1.3293403881791370d0 /) ! Gamma(j+1)
+    do k=0,f_neta
+       eta = f_eta0 + dble(k)*f_deta
+       umax = sqrt( max(eta,0.0d0) + 50.0d0 )
+       du = umax/dble(nq)
+       do jj=1,3
+          integ = 0.0d0
+          do q=0,nq
+             u = dble(q)*du
+             s = u**(2.0d0*jval(jj)+1.0d0)/( exp(u*u-eta) + 1.0d0 )
+             if(q==0 .or. q==nq)then       ; integ=integ+s
+             elseif(mod(q,2)==1)then        ; integ=integ+4.0d0*s
+             else                           ; integ=integ+2.0d0*s
+             end if
+          end do
+          f_tab(k,jj) = 2.0d0*integ*du/3.0d0/gam(jj)
+       end do
+    end do
+    f_built = .true.
+  end subroutine ttm3_build_fermi_table
+
+  ! F_j(eta) by linear interpolation of the table (jidx: 1=-1/2, 2=1/2, 3=3/2).
+  pure function ttm3_fermi( jidx, eta ) result( F )
+    implicit none
+    integer,intent(in) :: jidx
+    real(8),intent(in) :: eta
+    real(8) :: F,x,w
+    integer :: k
+    x = (eta - f_eta0)/f_deta
+    if(x <= 0.0d0)then            ; k=0       ; w=0.0d0
+    elseif(x >= dble(f_neta))then ; k=f_neta-1; w=1.0d0
+    else                          ; k=int(x)  ; w=x-dble(k)
+    end if
+    F = (1.0d0-w)*f_tab(k,jidx) + w*f_tab(k+1,jidx)
+  end function ttm3_fermi
+
+  ! Reduced chemical potential eta from (T,mass,N) by bisecting N = Neff*F_{1/2}(eta),
+  ! Neff = 2*(mass*T/(2*pi))^(3/2)  (atomic units).
+  pure function ttm3_chem_pot( T, mc, N ) result( eta )
+    implicit none
+    real(8),intent(in) :: T,mc,N
+    real(8) :: eta,Neff,lo,hi,mid,f
+    integer :: it
+    Neff = 2.0d0*( mc*max(T,1.0d-12)/(2.0d0*pi_) )**1.5d0
+    lo = f_eta0; hi = f_eta0 + dble(f_neta)*f_deta
+    do it=1,60
+       mid = 0.5d0*(lo+hi)
+       f = N - Neff*ttm3_fermi(2,mid)
+       if(f > 0.0d0)then; lo=mid; else; hi=mid; end if
+    end do
+    eta = 0.5d0*(lo+hi)
+  end function ttm3_chem_pot
+
+  ! Fermi-Dirac carrier heat capacity (per volume, atomic units, kB=1):
+  ! Ce/N = (15/4) F_{3/2}/F_{1/2} - (9/4) F_{1/2}/F_{-1/2}
+  ! (-> 3/2 in the non-degenerate limit, recovering the classical value).
+  pure function ttm3_heat_capacity( T, mc, N ) result( Ce )
+    implicit none
+    real(8),intent(in) :: T,mc,N
+    real(8) :: Ce,eta,Fm,F0,Fp
+    eta = ttm3_chem_pot(T,mc,N)
+    Fm = ttm3_fermi(1,eta); F0 = ttm3_fermi(2,eta); Fp = ttm3_fermi(3,eta)
+    Ce = N*( 3.75d0*Fp/F0 - 2.25d0*F0/Fm )
+  end function ttm3_heat_capacity
+
+  !---------------------------------------------------------------------------
   ! Local rates for one cell (the right-hand side of the five ODEs).
   pure subroutine ttm3_rates( Te_,Th_,Tl_,Ne_,Nh_, source_, gen_, &
                               dTe,dTh,dTl,dNe,dNh )
@@ -310,9 +396,10 @@ contains
     real(8),intent(out) :: dTe,dTh,dTl,dNe,dNh
     real(8) :: Ce,Ch,R,inv_tau,geff,q_heat
 
-    ! classical carrier heat capacities (floored to stay well defined)
-    Ce = 1.5d0*(Ne_ + N_floor)
-    Ch = 1.5d0*(Nh_ + N_floor)
+    ! Fermi-Dirac carrier heat capacities (reduce to the classical 3/2 N when
+    ! non-degenerate; suppressed when degenerate)
+    Ce = ttm3_heat_capacity( Te_, tp3%mu_e, Ne_+N_floor )
+    Ch = ttm3_heat_capacity( Th_, tp3%mu_h, Nh_+N_floor )
     inv_tau = 1.0d0/tp3%tau
 
     ! generation, saturated at the reference/atomic density N0 (cannot exceed it)

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -344,19 +344,25 @@ contains
     allocate( Ne(i1:j1,i2:j2,i3:j3), Nh(i1:j1,i2:j2,i3:j3) )
     allocate( rhs_te(i1:j1,i2:j2,i3:j3), rhs_th(i1:j1,i2:j2,i3:j3), rhs_tl(i1:j1,i2:j2,i3:j3) )
     allocate( rhs_ne(i1:j1,i2:j2,i3:j3), rhs_nh(i1:j1,i2:j2,i3:j3) )
-    allocate( Kc_e(i1:j1,i2:j2,i3:j3), Kc_h(i1:j1,i2:j2,i3:j3) )
-    allocate( Dc_e(i1:j1,i2:j2,i3:j3), Dc_h(i1:j1,i2:j2,i3:j3) )
-    allocate( Mc_e(i1:j1,i2:j2,i3:j3), Mc_h(i1:j1,i2:j2,i3:j3) )
-    allocate( Jc_e(i1:j1,i2:j2,i3:j3,3), Jc_h(i1:j1,i2:j2,i3:j3,3) )
-    allocate( rgap(i1:j1,i2:j2,i3:j3), Efld(i1:j1,i2:j2,i3:j3) )
-    allocate( Cj_e(i1:j1,i2:j2,i3:j3), Cj_h(i1:j1,i2:j2,i3:j3) )
 
     Te = tp3%Tini ; Th = tp3%Tini ; Tl = tp3%Tini
     Ne = N_floor  ; Nh = N_floor
-    Kc_e = 0.0d0  ; Kc_h = 0.0d0
-    Dc_e = 0.0d0  ; Dc_h = 0.0d0 ; Mc_e = 0.0d0 ; Mc_h = 0.0d0
-    Jc_e = 0.0d0  ; Jc_h = 0.0d0 ; rgap = tp3%Egap ; Efld = 0.0d0
-    Cj_e = 0.0d0  ; Cj_h = 0.0d0
+
+    ! Set A (Fermi transport) coefficient/current arrays: ~18 full-grid arrays accessed only
+    ! inside the use_fermi branch of ttm3_transport.  Allocate them only when transport is on
+    ! (mobility>0) so a non-transport run does not pay their memory.
+    if( tp3%mob_e0>0.0d0 .or. tp3%mob_h0>0.0d0 )then
+       allocate( Kc_e(i1:j1,i2:j2,i3:j3), Kc_h(i1:j1,i2:j2,i3:j3) )
+       allocate( Dc_e(i1:j1,i2:j2,i3:j3), Dc_h(i1:j1,i2:j2,i3:j3) )
+       allocate( Mc_e(i1:j1,i2:j2,i3:j3), Mc_h(i1:j1,i2:j2,i3:j3) )
+       allocate( Jc_e(i1:j1,i2:j2,i3:j3,3), Jc_h(i1:j1,i2:j2,i3:j3,3) )
+       allocate( rgap(i1:j1,i2:j2,i3:j3), Efld(i1:j1,i2:j2,i3:j3) )
+       allocate( Cj_e(i1:j1,i2:j2,i3:j3), Cj_h(i1:j1,i2:j2,i3:j3) )
+       Kc_e = 0.0d0  ; Kc_h = 0.0d0
+       Dc_e = 0.0d0  ; Dc_h = 0.0d0 ; Mc_e = 0.0d0 ; Mc_h = 0.0d0
+       Jc_e = 0.0d0  ; Jc_h = 0.0d0 ; rgap = tp3%Egap ; Efld = 0.0d0
+       Cj_e = 0.0d0  ; Cj_h = 0.0d0
+    end if
   end subroutine init_ttm3_alloc
 
   !---------------------------------------------------------------------------
@@ -428,21 +434,31 @@ contains
     end if
   end function ttm3_F0
 
-  ! Reduced chemical potential eta from (T,mass,N) by bisecting N = Neff*F_{1/2}(eta),
-  ! Neff = 2*(mass*T/(2*pi))^(3/2)  (atomic units).
+  ! Reduced chemical potential eta from (T,mass,N): invert N = Neff*F_{1/2}(eta),
+  ! Neff = 2*(mass*T/(2*pi))^(3/2).  F_{1/2} is tabulated (monotone in eta), so invert by a
+  ! binary search on the table + linear interpolation.  Because the table is piecewise-linear
+  ! in eta, this returns the SAME eta as inverting that piecewise-linear F_{1/2} -- i.e. it is
+  ! mathematically identical to the old 60-iteration bisection, but ~10x cheaper (no repeated
+  ! Fermi-table evaluation in the loop).
   pure function ttm3_chem_pot( T, mc, N ) result( eta )
     implicit none
     real(8),intent(in) :: T,mc,N
-    real(8) :: eta,Neff,lo,hi,mid,f
-    integer :: it
+    real(8) :: eta,Neff,y,w
+    integer :: lo,hi,mid
     Neff = 2.0d0*( mc*max(T,1.0d-12)/(2.0d0*pi_) )**1.5d0
-    lo = f_eta0; hi = f_eta0 + dble(f_neta)*f_deta
-    do it=1,60
-       mid = 0.5d0*(lo+hi)
-       f = N - Neff*ttm3_fermi(2,mid)
-       if(f > 0.0d0)then; lo=mid; else; hi=mid; end if
+    y = N/Neff                                       ! target value of F_{1/2}(eta)
+    if( y <= f_tab(0,2) )then
+       eta = f_eta0; return
+    elseif( y >= f_tab(f_neta,2) )then
+       eta = f_eta0 + dble(f_neta)*f_deta; return
+    end if
+    lo = 0; hi = f_neta
+    do while( hi-lo > 1 )                            ! binary search: f_tab(lo,2) <= y < f_tab(hi,2)
+       mid = (lo+hi)/2
+       if( f_tab(mid,2) <= y )then; lo=mid; else; hi=mid; end if
     end do
-    eta = 0.5d0*(lo+hi)
+    w = ( y - f_tab(lo,2) )/( f_tab(lo+1,2) - f_tab(lo,2) )
+    eta = f_eta0 + ( dble(lo) + w )*f_deta
   end function ttm3_chem_pot
 
   ! Fermi-Dirac carrier heat capacity (per volume, atomic units, kB=1):

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -89,6 +89,7 @@ module ttm3
   real(8),allocatable :: Dc_e(:,:,:), Dc_h(:,:,:), Mc_e(:,:,:), Mc_h(:,:,:)
   real(8),allocatable :: Jc_e(:,:,:,:), Jc_h(:,:,:,:)   ! (i,j,k,dir) -- dir last for contiguous halo
   real(8),allocatable :: rgap(:,:,:), Efld(:,:,:)       ! local gap, space-charge field (x)
+  real(8),allocatable :: Cj_e(:,:,:), Cj_h(:,:,:)       ! Set A layer 3: heat per carrier (cJeh)
 
   ! Fermi-Dirac integral table F_j(eta).  Indices 1,2,3 = j = -1/2,1/2,3/2 (heat
   ! capacity / chemical potential); indices 4,5 = j = 1,2 (transport: mobility,
@@ -346,12 +347,14 @@ contains
     allocate( Mc_e(i1:j1,i2:j2,i3:j3), Mc_h(i1:j1,i2:j2,i3:j3) )
     allocate( Jc_e(i1:j1,i2:j2,i3:j3,3), Jc_h(i1:j1,i2:j2,i3:j3,3) )
     allocate( rgap(i1:j1,i2:j2,i3:j3), Efld(i1:j1,i2:j2,i3:j3) )
+    allocate( Cj_e(i1:j1,i2:j2,i3:j3), Cj_h(i1:j1,i2:j2,i3:j3) )
 
     Te = tp3%Tini ; Th = tp3%Tini ; Tl = tp3%Tini
     Ne = N_floor  ; Nh = N_floor
     Kc_e = 0.0d0  ; Kc_h = 0.0d0
     Dc_e = 0.0d0  ; Dc_h = 0.0d0 ; Mc_e = 0.0d0 ; Mc_h = 0.0d0
     Jc_e = 0.0d0  ; Jc_h = 0.0d0 ; rgap = tp3%Egap ; Efld = 0.0d0
+    Cj_e = 0.0d0  ; Cj_h = 0.0d0
   end subroutine init_ttm3_alloc
 
   !---------------------------------------------------------------------------
@@ -603,7 +606,7 @@ contains
     real(8) :: cx,cy,cz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,Dmax,Dd
     real(8) :: gx,gy,gz,gKe,gKh
     real(8) :: eta,F0,Fm,F12,F1,F2,kT,cjE,cjT,fp4i
-    real(8) :: dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh
+    real(8) :: dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh,gCJe,gCJh
     logical :: use_fermi
 
     use_fermi = ( tp3%mob_e0>0.0d0 .or. tp3%mob_h0>0.0d0 )
@@ -650,6 +653,7 @@ contains
           Jc_e(ix,iy,iz,1)=(Ne(ix+1,iy,iz)-Ne(ix-1,iy,iz))*gx + cjE*(rgap(ix+1,iy,iz)-rgap(ix-1,iy,iz))*gx + cjT*(Te(ix+1,iy,iz)-Te(ix-1,iy,iz))*gx
           Jc_e(ix,iy,iz,2)=(Ne(ix,iy+1,iz)-Ne(ix,iy-1,iz))*gy + cjE*(rgap(ix,iy+1,iz)-rgap(ix,iy-1,iz))*gy + cjT*(Te(ix,iy+1,iz)-Te(ix,iy-1,iz))*gy
           Jc_e(ix,iy,iz,3)=(Ne(ix,iy,iz+1)-Ne(ix,iy,iz-1))*gz + cjE*(rgap(ix,iy,iz+1)-rgap(ix,iy,iz-1))*gz + cjT*(Te(ix,iy,iz+1)-Te(ix,iy,iz-1))*gz
+          Cj_e(ix,iy,iz)=2.0d0*kT*F1/F0 + (tp3%mu_h/(tp3%mu_e+tp3%mu_h))*rgap(ix,iy,iz)   ! heat per carrier
           ! holes
           kT=Th(ix,iy,iz); eta=ttm3_chem_pot(kT,tp3%mu_h,Nh(ix,iy,iz)+N_floor)
           F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
@@ -662,18 +666,20 @@ contains
           Jc_h(ix,iy,iz,1)=(Nh(ix+1,iy,iz)-Nh(ix-1,iy,iz))*gx + cjE*(rgap(ix+1,iy,iz)-rgap(ix-1,iy,iz))*gx + cjT*(Th(ix+1,iy,iz)-Th(ix-1,iy,iz))*gx
           Jc_h(ix,iy,iz,2)=(Nh(ix,iy+1,iz)-Nh(ix,iy-1,iz))*gy + cjE*(rgap(ix,iy+1,iz)-rgap(ix,iy-1,iz))*gy + cjT*(Th(ix,iy+1,iz)-Th(ix,iy-1,iz))*gy
           Jc_h(ix,iy,iz,3)=(Nh(ix,iy,iz+1)-Nh(ix,iy,iz-1))*gz + cjE*(rgap(ix,iy,iz+1)-rgap(ix,iy,iz-1))*gz + cjT*(Th(ix,iy,iz+1)-Th(ix,iy,iz-1))*gz
+          Cj_h(ix,iy,iz)=2.0d0*kT*F1/F0 + (tp3%mu_e/(tp3%mu_e+tp3%mu_h))*rgap(ix,iy,iz)   ! heat per carrier
        end do
 !$omp end parallel do
        call update_overlap_real8(srg, rg, Dc_e); call update_overlap_real8(srg, rg, Dc_h)
        call update_overlap_real8(srg, rg, Mc_e); call update_overlap_real8(srg, rg, Mc_h)
        call update_overlap_real8(srg, rg, Kc_e); call update_overlap_real8(srg, rg, Kc_h)
+       call update_overlap_real8(srg, rg, Cj_e); call update_overlap_real8(srg, rg, Cj_h)
        call update_overlap_real8(srg, rg, Jc_e(:,:,:,1)); call update_overlap_real8(srg, rg, Jc_e(:,:,:,2)); call update_overlap_real8(srg, rg, Jc_e(:,:,:,3))
        call update_overlap_real8(srg, rg, Jc_h(:,:,:,1)); call update_overlap_real8(srg, rg, Jc_h(:,:,:,2)); call update_overlap_real8(srg, rg, Jc_h(:,:,:,3))
        call ttm3_space_charge()                 ! Efld = space-charge field (prefix sum along x)
     end if
 
 !$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,gKe,gKh, &
-!$omp&                    dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh)
+!$omp&                    dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh,gCJe,gCJh)
     do m=1,nmedia_myrnk
        ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
        lTe=(Te(ix+1,iy,iz)-2*Te(ix,iy,iz)+Te(ix-1,iy,iz))*cx+(Te(ix,iy+1,iz)-2*Te(ix,iy,iz)+Te(ix,iy-1,iz))*cy+(Te(ix,iy,iz+1)-2*Te(ix,iy,iz)+Te(ix,iy,iz-1))*cz
@@ -696,6 +702,12 @@ contains
           dJh=(Jc_h(ix+1,iy,iz,1)-Jc_h(ix-1,iy,iz,1))*gx+(Jc_h(ix,iy+1,iz,2)-Jc_h(ix,iy-1,iz,2))*gy+(Jc_h(ix,iy,iz+1,3)-Jc_h(ix,iy,iz-1,3))*gz
           gDJe=(Dc_e(ix+1,iy,iz)-Dc_e(ix-1,iy,iz))*gx*Jc_e(ix,iy,iz,1)+(Dc_e(ix,iy+1,iz)-Dc_e(ix,iy-1,iz))*gy*Jc_e(ix,iy,iz,2)+(Dc_e(ix,iy,iz+1)-Dc_e(ix,iy,iz-1))*gz*Jc_e(ix,iy,iz,3)
           gDJh=(Dc_h(ix+1,iy,iz)-Dc_h(ix-1,iy,iz))*gx*Jc_h(ix,iy,iz,1)+(Dc_h(ix,iy+1,iz)-Dc_h(ix,iy-1,iz))*gy*Jc_h(ix,iy,iz,2)+(Dc_h(ix,iy,iz+1)-Dc_h(ix,iy,iz-1))*gz*Jc_h(ix,iy,iz,3)
+          ! Layer 3: convective heat -- the carrier current carries energy cJeh per carrier:
+          ! nabW += cJeh*(Dc div Jc + grad Dc . Jc) + Dc*(grad cJeh . Jc).  Added to the heat RHS.
+          gCJe=(Cj_e(ix+1,iy,iz)-Cj_e(ix-1,iy,iz))*gx*Jc_e(ix,iy,iz,1)+(Cj_e(ix,iy+1,iz)-Cj_e(ix,iy-1,iz))*gy*Jc_e(ix,iy,iz,2)+(Cj_e(ix,iy,iz+1)-Cj_e(ix,iy,iz-1))*gz*Jc_e(ix,iy,iz,3)
+          gCJh=(Cj_h(ix+1,iy,iz)-Cj_h(ix-1,iy,iz))*gx*Jc_h(ix,iy,iz,1)+(Cj_h(ix,iy+1,iz)-Cj_h(ix,iy-1,iz))*gy*Jc_h(ix,iy,iz,2)+(Cj_h(ix,iy,iz+1)-Cj_h(ix,iy,iz-1))*gz*Jc_h(ix,iy,iz,3)
+          rhs_te(ix,iy,iz)=rhs_te(ix,iy,iz)+dt*( Cj_e(ix,iy,iz)*(Dc_e(ix,iy,iz)*dJe+gDJe) + Dc_e(ix,iy,iz)*gCJe )/Ce
+          rhs_th(ix,iy,iz)=rhs_th(ix,iy,iz)+dt*( Cj_h(ix,iy,iz)*(Dc_h(ix,iy,iz)*dJh+gDJh) + Dc_h(ix,iy,iz)*gCJh )/Ch
           gMxe=(Mc_e(ix+1,iy,iz)-Mc_e(ix-1,iy,iz))*gx; gNxe=(Ne(ix+1,iy,iz)-Ne(ix-1,iy,iz))*gx
           gMxh=(Mc_h(ix+1,iy,iz)-Mc_h(ix-1,iy,iz))*gx; gNxh=(Nh(ix+1,iy,iz)-Nh(ix-1,iy,iz))*gx
           dEf=fp4i*(Ne(ix,iy,iz)-Nh(ix,iy,iz))               ! 4*pi*inveps*(Ne-Nh)

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -20,6 +20,7 @@ module ttm3
   implicit none
   private
   public :: init_ttm3_parameters
+  public :: ttm3_set_dt
   public :: init_ttm3_grid
   public :: init_ttm3_alloc
   public :: ttm3_main
@@ -70,7 +71,8 @@ module ttm3
   real(8),allocatable :: rhs_ne(:,:,:), rhs_nh(:,:,:)
 
   ! density floor to keep the carrier heat capacity well defined
-  real(8),parameter :: N_floor = 1.0d-24   ! [1/bohr^3]
+  real(8),parameter :: N_floor = 1.0d-9    ! [1/bohr^3] (~7e15 cm^-3 carrier floor)
+  real(8),parameter :: T_clamp = 31.67d0   ! [a.u.] (~1e7 K) numerical temperature cap
   real(8),parameter :: pi_ = 3.14159265358979323846d0
 
   character(12) :: ttm3_file = 'ttm3.inp_3tm'
@@ -194,6 +196,16 @@ contains
   end subroutine init_ttm3_parameters
 
   !---------------------------------------------------------------------------
+  ! Set the time step.  init_ttm3_parameters is called early (so use_ttm3 can
+  ! feed flag_save) before dt_em is finalised by the CFL condition; this setter
+  ! is called afterwards with the correct dt_em.
+  subroutine ttm3_set_dt( dt_em )
+    implicit none
+    real(8),intent(in) :: dt_em
+    dt = dt_em
+  end subroutine ttm3_set_dt
+
+  !---------------------------------------------------------------------------
   subroutine init_ttm3_grid( hgs_in, is_a, is, ie, imedia )
     implicit none
     real(8),intent(in) :: hgs_in(3)
@@ -303,7 +315,11 @@ contains
 
     y = y + (dt_in/6.0d0)*( k1 + 2.0d0*k2 + 2.0d0*k3 + k4 )
 
-    Te_=y(1); Th_=y(2); Tl_=y(3); Ne_=max(y(4),0.0d0); Nh_=max(y(5),0.0d0)
+    ! numerical guard: clamp temperatures to a finite range so the coupled run
+    ! stays bounded where the recommended source/C heating is stiff at low Ne
+    ! (the exact Fermi heat capacity removes this stiffness; see the design notes).
+    Te_=min(max(y(1),0.0d0),T_clamp); Th_=min(max(y(2),0.0d0),T_clamp); Tl_=max(y(3),0.0d0)
+    Ne_=max(y(4),0.0d0); Nh_=max(y(5),0.0d0)
   end subroutine ttm3_step_cell
 
   !---------------------------------------------------------------------------

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -29,6 +29,7 @@ module ttm3
   public :: ttm3_get_max
   public :: ttm3_get_front
   public :: ttm3_front_ijk
+  public :: ttm3_set_xcomm
   public :: ttm3_write_profile
   public :: ttm3_permittivity
   public :: ttm3_linear_gen
@@ -87,6 +88,8 @@ module ttm3
   integer :: is_array(3), ie_array(3)
   integer :: is_inner(3), ie_inner(3)   ! inner (no-halo) bounds, for the space-charge prefix sum
   integer :: comm
+  integer :: nprocs_g = 1                            ! # MPI ranks (diagnostic global reductions)
+  integer :: xc_icomm = 0, xc_id = 0, xc_isize = 1   ! x-axis sub-comm (space-charge x-decomposition)
   real(8) :: hgs(3)
   real(8) :: dt
 
@@ -123,7 +126,7 @@ module ttm3
   ! carrier population can reach the reference's near-transparent regime; this is
   ! safe only because the carrier temperatures use the exponential integrator
   ! (the old RK4 step blew up at such low Ne -- see ttm3_step_cell).
-  real(8),parameter :: N_floor = 5.4d-15   ! [1/bohr^3] (~3.4e10 cm^-3, reference seed)
+  real(8),parameter :: N_floor = 3.657d-14  ! [1/bohr^3] (=2.468e11 cm^-3, standalone 3D3TM intrinsic seed Ns)
   real(8),parameter :: T_clamp = 31.67d0   ! [a.u.] (~1e7 K) numerical temperature cap
   real(8),parameter :: pi_ = 3.14159265358979323846d0
   real(8),parameter :: hk_kelvin = 3.1577502480407d5   ! a.u. temperature -> Kelvin
@@ -137,6 +140,10 @@ contains
   !---------------------------------------------------------------------------
   subroutine init_ttm3_parameters( dt_em )
     use communication, only: comm_get_globalinfo, comm_is_root, comm_bcast
+    use salmon_global, only: theory, yn_use_ttm3, ttm_egap, ttm_mu_e, ttm_mu_h, ttm_auger_e, ttm_auger_h, &
+                             ttm_tau, ttm_cl, ttm_tini, ttm_eps_bg, ttm_n0, ttm_beta2, &
+                             ttm_ddiff, ttm_kappa_e, ttm_kappa_l, ttm_dgap, &
+                             ttm_mob_e, ttm_mob_h, ttm_sig_cold, ttm_coupling
     implicit none
     real(8), intent(in) :: dt_em
     integer, parameter :: unit=1112
@@ -150,92 +157,39 @@ contains
     real(8), parameter :: hartree_ev = 27.211386245988d0 ! [eV]
 
     call comm_get_globalinfo( comm, npid, nprocs )
+    nprocs_g = nprocs
     DISPLAY = comm_is_root(npid)
 
     if ( DISPLAY ) write(*,'(a60)') repeat("-",30)//" init_ttm3_parameters(start)"
 
-    inquire( FILE=ttm3_file, EXIST=flag )
-    if( .not.flag )then
+    use_ttm3 = yn_use_ttm3
+    if( .not.use_ttm3 )then
        if( DISPLAY )then
-          write(*,*) "No three-temperature file ("//ttm3_file//")."
-          write(*,*) "Three-temperature + carrier model is not used."
+          write(*,*) "theory /= 'maxwell-3tm': three-temperature + carrier model is not used."
           write(*,'(a60)') repeat("-",30)//" init_ttm3_parameters(end  )"
        end if
        return
-    else
-       if( DISPLAY )then
-          write(*,*) "Three-temperature file ("//ttm3_file//") is found."
-          write(*,*) "Calculation uses the three-temperature + carrier model."
-       end if
-       use_ttm3 = .true.
     end if
+    if( DISPLAY ) write(*,*) "theory = 'maxwell-3tm': three-temperature + carrier model (&ttm)."
 
     dt = dt_em
 
-! Input parameters (one value per line):
-!   Egap [eV], mu_e [-], mu_h [-], A_e [cm^6/s], A_h [cm^6/s],
-!   tau [fs], Cl [J/(m^3 K)], Tini [K]
-    if( comm_is_root(npid) )then
-       open(unit, file=ttm3_file, status='old')
-       read(unit,*) tp3%Egap
-       read(unit,*) tp3%mu_e
-       read(unit,*) tp3%mu_h
-       read(unit,*) tp3%A_e
-       read(unit,*) tp3%A_h
-       read(unit,*) tp3%tau
-       read(unit,*) tp3%Cl
-       read(unit,*) tp3%Tini
-       read(unit,*) tp3%eps_bg
-       read(unit,*) tp3%N0
-       read(unit,*) tp3%beta2
-       read(unit,*) tp3%Ddiff
-       read(unit,*) tp3%kappa_e
-       read(unit,*) tp3%kappa_l
-       read(unit,*) tp3%dgap_c
-       tp3%mob_e0 = 0.0d0; tp3%mob_h0 = 0.0d0     ! optional (Set A Fermi transport)
-       read(unit,*,iostat=ios) tp3%mob_e0
-       read(unit,*,iostat=ios) tp3%mob_h0
-       tp3%sig_cold = 0.0d0                        ! optional (Layer C-a bound/Drude split); <=0 disables
-       read(unit,*,iostat=ios) tp3%sig_cold
-       tp3%coupling_mode = 0                       ! optional: 0=J-update (default), 1=eps-update
-       read(unit,*,iostat=ios) tp3%coupling_mode
-       close(unit)
+    ! &ttm namelist parameters (read + broadcast by inputoutput; physical units, converted below)
+    tp3%Egap   = ttm_egap    ; tp3%mu_e   = ttm_mu_e   ; tp3%mu_h   = ttm_mu_h
+    tp3%A_e    = ttm_auger_e ; tp3%A_h    = ttm_auger_h
+    tp3%tau    = ttm_tau     ; tp3%Cl     = ttm_cl     ; tp3%Tini   = ttm_tini
+    tp3%eps_bg = ttm_eps_bg  ; tp3%N0     = ttm_n0     ; tp3%beta2  = ttm_beta2
+    tp3%Ddiff  = ttm_ddiff   ; tp3%kappa_e= ttm_kappa_e; tp3%kappa_l= ttm_kappa_l
+    tp3%dgap_c = ttm_dgap    ; tp3%mob_e0 = ttm_mob_e  ; tp3%mob_h0 = ttm_mob_h
+    tp3%sig_cold = ttm_sig_cold ; tp3%coupling_mode = ttm_coupling
+    if( DISPLAY )then
        write(*,*) "Egap[eV]    =",tp3%Egap
-       write(*,*) "mu_e        =",tp3%mu_e
-       write(*,*) "mu_h        =",tp3%mu_h
-       write(*,*) "A_e[cm6/s]  =",tp3%A_e
-       write(*,*) "A_h[cm6/s]  =",tp3%A_h
+       write(*,*) "mu_e/mu_h   =",tp3%mu_e, tp3%mu_h
        write(*,*) "tau[fs]     =",tp3%tau
-       write(*,*) "Cl[J/m3K]   =",tp3%Cl
-       write(*,*) "Tini[K]     =",tp3%Tini
-       write(*,*) "eps_bg      =",tp3%eps_bg
-       write(*,*) "N0[cm-3]    =",tp3%N0
-       write(*,*) "beta2[a.u.] =",tp3%beta2
-       write(*,*) "Ddiff[cm2/s]=",tp3%Ddiff
-       write(*,*) "kappa_e[W/mK]=",tp3%kappa_e
-       write(*,*) "kappa_l[W/mK]=",tp3%kappa_l
-       write(*,*) "dgap_c[a.u.]=",tp3%dgap_c
+       write(*,*) "eps_bg / N0 =",tp3%eps_bg, tp3%N0
+       write(*,*) "mob_e/mob_h =",tp3%mob_e0, tp3%mob_h0
+       write(*,*) "sig_cold/cm =",tp3%sig_cold, tp3%coupling_mode
     end if
-
-    call comm_bcast(tp3%Egap,comm,0)
-    call comm_bcast(tp3%mu_e,comm,0)
-    call comm_bcast(tp3%mu_h,comm,0)
-    call comm_bcast(tp3%A_e ,comm,0)
-    call comm_bcast(tp3%A_h ,comm,0)
-    call comm_bcast(tp3%tau ,comm,0)
-    call comm_bcast(tp3%Cl  ,comm,0)
-    call comm_bcast(tp3%Tini,comm,0)
-    call comm_bcast(tp3%eps_bg ,comm,0)
-    call comm_bcast(tp3%N0     ,comm,0)
-    call comm_bcast(tp3%beta2  ,comm,0)
-    call comm_bcast(tp3%Ddiff  ,comm,0)
-    call comm_bcast(tp3%kappa_e,comm,0)
-    call comm_bcast(tp3%kappa_l,comm,0)
-    call comm_bcast(tp3%dgap_c ,comm,0)
-    call comm_bcast(tp3%mob_e0 ,comm,0)
-    call comm_bcast(tp3%mob_h0 ,comm,0)
-    call comm_bcast(tp3%sig_cold,comm,0)
-    call comm_bcast(tp3%coupling_mode,comm,0)
 
 ! Convert to atomic units
     tp3%Egap = tp3%Egap / hartree_ev
@@ -355,6 +309,16 @@ contains
     end do
     end do
   end subroutine init_ttm3_grid
+
+  !---------------------------------------------------------------------------
+  ! Register the x-axis sub-communicator (icomm_x) for the space-charge prefix
+  ! sum under x-direction domain decomposition (nproc_rgrid(1)>1).  Called once
+  ! at init from the FDTD driver.  isz<=1 (default) keeps the single-domain path.
+  subroutine ttm3_set_xcomm( ic, idx, isz )
+    implicit none
+    integer,intent(in) :: ic, idx, isz
+    xc_icomm = ic; xc_id = idx; xc_isize = isz
+  end subroutine ttm3_set_xcomm
 
   !---------------------------------------------------------------------------
   subroutine init_ttm3_alloc( srg, rg )
@@ -591,7 +555,7 @@ contains
     geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
     Cef_e = tp3%A_e*Ne_*Nh_ ; Re = Ne_*Cef_e/( 1.0d0 + T_au*Cef_e )   ! saturated Auger (e)
     Cef_h = tp3%A_h*Ne_*Nh_ ; Rh = Nh_*Cef_h/( 1.0d0 + T_au*Cef_h )   ! saturated Auger (h)
-    R    = Re + Rh
+    R    = ( Re + Rh ) * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )   ! band-filling (matches standalone Reh*Rate_eh)
     red_e = tp3%mu_h/(tp3%mu_e+tp3%mu_h)
     red_h = tp3%mu_e/(tp3%mu_e+tp3%mu_h)
     gap = ttm3_gap( Ne_, Tl_ )                                   ! carrier + thermal (Varshni) gap
@@ -809,28 +773,65 @@ contains
   ! rho=(Nh-Ne) (charge density; zero in non-medium cells, Ne=Nh=floor).  Per (iy,iz)
   ! line, a prefix sum over the local inner x-range (single-domain; nproc_rgrid=1).
   subroutine ttm3_space_charge()
+    use communication, only: comm_summation
     implicit none
-    integer :: ix,iy,iz
+    integer :: ix,iy,iz,p
     real(8) :: dV,c2,total,pre,rho
+    real(8),allocatable :: ain(:,:,:), aout(:,:,:)
     dV = hgs(1)*hgs(2)*hgs(3)
     c2 = 2.0d0*pi_/tp3%eps_bg
+    if( xc_isize <= 1 )then
+       ! single x-domain (nproc_rgrid(1)=1): local exclusive prefix sum per (iy,iz) line
 !$omp parallel do collapse(2) private(ix,iy,iz,total,pre,rho)
-    do iz=is_inner(3),ie_inner(3)
-    do iy=is_inner(2),ie_inner(2)
-       total=0.0d0
-       do ix=is_inner(1),ie_inner(1)
-          total=total+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
+       do iz=is_inner(3),ie_inner(3)
+       do iy=is_inner(2),ie_inner(2)
+          total=0.0d0
+          do ix=is_inner(1),ie_inner(1)
+             total=total+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
+          end do
+          pre=0.0d0                                  ! exclusive prefix sum (i<ix)
+          do ix=is_inner(1),ie_inner(1)
+             rho=Nh(ix,iy,iz)-Ne(ix,iy,iz)
+             ! Ef = (left - right)*dV*c2 ;  right = total - pre - rho
+             Efld(ix,iy,iz)=c2*dV*( 2.0d0*pre + rho - total )
+             pre=pre+rho
+          end do
        end do
-       pre=0.0d0                                  ! exclusive prefix sum (i<ix)
-       do ix=is_inner(1),ie_inner(1)
-          rho=Nh(ix,iy,iz)-Ne(ix,iy,iz)
-          ! Ef = (left - right)*dV*c2 ;  right = total - pre - rho
-          Efld(ix,iy,iz)=c2*dV*( 2.0d0*pre + rho - total )
-          pre=pre+rho
        end do
-    end do
-    end do
 !$omp end parallel do
+    else
+       ! x-decomposed (nproc_rgrid(1)>1): each x-rank deposits its per-(iy,iz)-line
+       ! charge total into its own slot; an allreduce over icomm_x gathers all x-ranks
+       ! (= allgather), giving the left-offset and global total per line for the prefix.
+       allocate( ain (0:xc_isize-1, is_inner(2):ie_inner(2), is_inner(3):ie_inner(3)) )
+       allocate( aout(0:xc_isize-1, is_inner(2):ie_inner(2), is_inner(3):ie_inner(3)) )
+       ain = 0.0d0
+       do iz=is_inner(3),ie_inner(3)
+       do iy=is_inner(2),ie_inner(2)
+          rho=0.0d0
+          do ix=is_inner(1),ie_inner(1)
+             rho=rho+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
+          end do
+          ain(xc_id,iy,iz)=rho
+       end do
+       end do
+       call comm_summation( ain, aout, size(ain), xc_icomm )
+       do iz=is_inner(3),ie_inner(3)
+       do iy=is_inner(2),ie_inner(2)
+          total=0.0d0; pre=0.0d0
+          do p=0,xc_isize-1
+             total=total+aout(p,iy,iz)
+             if( p<xc_id ) pre=pre+aout(p,iy,iz)   ! charge in x-domains left of this one
+          end do
+          do ix=is_inner(1),ie_inner(1)
+             rho=Nh(ix,iy,iz)-Ne(ix,iy,iz)
+             Efld(ix,iy,iz)=c2*dV*( 2.0d0*pre + rho - total )
+             pre=pre+rho
+          end do
+       end do
+       end do
+       deallocate( ain, aout )
+    end if
   end subroutine ttm3_space_charge
 
   !---------------------------------------------------------------------------
@@ -854,11 +855,12 @@ contains
   !---------------------------------------------------------------------------
   ! Peak values over this rank's medium cells (output units), for diagnostics.
   subroutine ttm3_get_max( Te_o, Th_o, Tl_o, Ne_o, Nh_o )
+    use communication, only: comm_get_max
     implicit none
     real(8),intent(out) :: Te_o, Th_o, Tl_o, Ne_o, Nh_o   ! [K],[K],[K],[1/cm^3],[1/cm^3]
     real(8), parameter :: hartree_kelvin_relationship = 3.1577502480407d5
     real(8), parameter :: atomic_unit_of_length = 5.29177210903d-11
-    real(8) :: cm3_per_bohr3
+    real(8) :: cm3_per_bohr3, vin(5), vout(5)
     integer :: m,ix,iy,iz
     Te_o=0d0; Th_o=0d0; Tl_o=0d0; Ne_o=0d0; Nh_o=0d0
     cm3_per_bohr3 = (atomic_unit_of_length*1.0d2)**3
@@ -870,6 +872,11 @@ contains
     Te_o=Te_o*hartree_kelvin_relationship; Th_o=Th_o*hartree_kelvin_relationship
     Tl_o=Tl_o*hartree_kelvin_relationship
     Ne_o=Ne_o/cm3_per_bohr3; Nh_o=Nh_o/cm3_per_bohr3
+    if( nprocs_g>1 )then            ! global max across the spatial (r-space) decomposition
+       vin(1)=Te_o; vin(2)=Th_o; vin(3)=Tl_o; vin(4)=Ne_o; vin(5)=Nh_o
+       call comm_get_max( vin, vout, 5, comm )
+       Te_o=vout(1); Th_o=vout(2); Tl_o=vout(3); Ne_o=vout(4); Nh_o=vout(5)
+    end if
   end subroutine ttm3_get_max
 
   !---------------------------------------------------------------------------
@@ -878,41 +885,56 @@ contains
   ! and, unlike ttm3_get_max, is not biased by the Fabry-Perot field antinodes that
   ! form inside a finite slab (which sit deeper than the front face and read high).
   subroutine ttm3_get_front( Te_o, Th_o, Tl_o, Ne_o, Nh_o )
+    use communication, only: comm_get_min, comm_get_max
     implicit none
     real(8),intent(out) :: Te_o, Th_o, Tl_o, Ne_o, Nh_o   ! [K],[K],[K],[1/cm^3],[1/cm^3]
     real(8), parameter :: hartree_kelvin_relationship = 3.1577502480407d5
     real(8), parameter :: atomic_unit_of_length = 5.29177210903d-11
-    real(8) :: cm3_per_bohr3, cy, cz
-    integer :: m,ix,iy,iz,ixmin,nmin,a(3),dbest,d
+    real(8) :: cm3_per_bohr3, cy, cz, gfix, vin(5), vout(5)
+    integer :: m,ix,iy,iz,ixmin,nmin,a(3),dbest,d,lfix
     Te_o=tp3%Tini*hartree_kelvin_relationship; Th_o=Te_o; Tl_o=Te_o; Ne_o=0d0; Nh_o=0d0
-    if( nmedia_myrnk<=0 ) return
-    cm3_per_bohr3 = (atomic_unit_of_length*1.0d2)**3
-    ! minimum ix among medium cells = the illuminated face
-    ixmin = ijk_media_myrnk(1,1)
-    do m=2,nmedia_myrnk
-       if( ijk_media_myrnk(1,m) < ixmin ) ixmin = ijk_media_myrnk(1,m)
-    end do
-    ! transverse centroid of that face
-    cy=0d0; cz=0d0; nmin=0
-    do m=1,nmedia_myrnk
-       if( ijk_media_myrnk(1,m)==ixmin )then
-          cy=cy+ijk_media_myrnk(2,m); cz=cz+ijk_media_myrnk(3,m); nmin=nmin+1
+    lfix = huge(0)
+    if( nmedia_myrnk>0 )then
+       cm3_per_bohr3 = (atomic_unit_of_length*1.0d2)**3
+       ! minimum ix among medium cells = the illuminated face
+       ixmin = ijk_media_myrnk(1,1)
+       do m=2,nmedia_myrnk
+          if( ijk_media_myrnk(1,m) < ixmin ) ixmin = ijk_media_myrnk(1,m)
+       end do
+       ! transverse centroid of that face
+       cy=0d0; cz=0d0; nmin=0
+       do m=1,nmedia_myrnk
+          if( ijk_media_myrnk(1,m)==ixmin )then
+             cy=cy+ijk_media_myrnk(2,m); cz=cz+ijk_media_myrnk(3,m); nmin=nmin+1
+          end if
+       end do
+       cy=cy/max(nmin,1); cz=cz/max(nmin,1)
+       ! face cell nearest the centroid
+       a = ijk_media_myrnk(1:3,1); dbest=huge(0)
+       do m=1,nmedia_myrnk
+          if( ijk_media_myrnk(1,m)==ixmin )then
+             iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+             d = (iy-nint(cy))**2 + (iz-nint(cz))**2
+             if( d<dbest )then; dbest=d; a=ijk_media_myrnk(1:3,m); end if
+          end if
+       end do
+       Te_o=Te(a(1),a(2),a(3))*hartree_kelvin_relationship
+       Th_o=Th(a(1),a(2),a(3))*hartree_kelvin_relationship
+       Tl_o=Tl(a(1),a(2),a(3))*hartree_kelvin_relationship
+       Ne_o=Ne(a(1),a(2),a(3))/cm3_per_bohr3; Nh_o=Nh(a(1),a(2),a(3))/cm3_per_bohr3
+       lfix = ixmin
+    end if
+    if( nprocs_g>1 )then     ! select values from the rank holding the global illuminated face (min ix)
+       gfix = dble(lfix)
+       call comm_get_min( gfix, comm )
+       if( lfix == nint(gfix) )then
+          vin(1)=Te_o; vin(2)=Th_o; vin(3)=Tl_o; vin(4)=Ne_o; vin(5)=Nh_o
+       else
+          vin(:) = -huge(1.0d0)
        end if
-    end do
-    cy=cy/max(nmin,1); cz=cz/max(nmin,1)
-    ! face cell nearest the centroid
-    a = ijk_media_myrnk(1:3,1); dbest=huge(0)
-    do m=1,nmedia_myrnk
-       if( ijk_media_myrnk(1,m)==ixmin )then
-          iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
-          d = (iy-nint(cy))**2 + (iz-nint(cz))**2
-          if( d<dbest )then; dbest=d; a=ijk_media_myrnk(1:3,m); end if
-       end if
-    end do
-    Te_o=Te(a(1),a(2),a(3))*hartree_kelvin_relationship
-    Th_o=Th(a(1),a(2),a(3))*hartree_kelvin_relationship
-    Tl_o=Tl(a(1),a(2),a(3))*hartree_kelvin_relationship
-    Ne_o=Ne(a(1),a(2),a(3))/cm3_per_bohr3; Nh_o=Nh(a(1),a(2),a(3))/cm3_per_bohr3
+       call comm_get_max( vin, vout, 5, comm )
+       Te_o=vout(1); Th_o=vout(2); Tl_o=vout(3); Ne_o=vout(4); Nh_o=vout(5)
+    end if
   end subroutine ttm3_get_front
 
   ! Index of the illuminated front-face medium cell (same selection as ttm3_get_front).

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -1051,14 +1051,27 @@ contains
           rhs_ne(ix,iy,iz) = rne
           rhs_nh(ix,iy,iz) = rnh
           rmax = max( rmax, rr )
-          tsc = max( Te(ix,iy,iz), 0.05d0*tp3%Tini )
-          relmax = max( relmax, abs(rhs_te(ix,iy,iz))/tsc )
-          tsc = max( Th(ix,iy,iz), 0.05d0*tp3%Tini )
-          relmax = max( relmax, abs(rhs_th(ix,iy,iz))/tsc )
-          tsc = max( Tl(ix,iy,iz), 0.05d0*tp3%Tini )
-          relmax = max( relmax, abs(rhs_tl(ix,iy,iz))/tsc )
-          relmax = max( relmax, abs(rhs_ne(ix,iy,iz))/(Ne(ix,iy,iz)+N_floor) )
-          relmax = max( relmax, abs(rhs_nh(ix,iy,iz))/(Nh(ix,iy,iz)+N_floor) )
+          ! relative-change guard.  Channels that sit AT their floor and keep draining
+          ! must not throttle dt_s: the commit clamp makes the downward dynamics inert
+          ! there, and holding dt_s hostage to an unresolvable decay deadlocks the
+          ! sub-stepper at nit_max (s8b: front-face Th collapse, 2026-07-06).  Carrier
+          ! scales are floored at a ppb of the saturation density for the same reason.
+          if( .not.( Te(ix,iy,iz) <= 1.01d0*T_floor .and. rhs_te(ix,iy,iz) < 0.0d0 ) )then
+             tsc = max( Te(ix,iy,iz), 0.05d0*tp3%Tini )
+             relmax = max( relmax, abs(rhs_te(ix,iy,iz))/tsc )
+          end if
+          if( .not.( Th(ix,iy,iz) <= 1.01d0*T_floor .and. rhs_th(ix,iy,iz) < 0.0d0 ) )then
+             tsc = max( Th(ix,iy,iz), 0.05d0*tp3%Tini )
+             relmax = max( relmax, abs(rhs_th(ix,iy,iz))/tsc )
+          end if
+          if( .not.( Tl(ix,iy,iz) <= 1.01d0*T_floor .and. rhs_tl(ix,iy,iz) < 0.0d0 ) )then
+             tsc = max( Tl(ix,iy,iz), 0.05d0*tp3%Tini )
+             relmax = max( relmax, abs(rhs_tl(ix,iy,iz))/tsc )
+          end if
+          if( .not.( Ne(ix,iy,iz) <= 0.0d0 .and. rhs_ne(ix,iy,iz) < 0.0d0 ) ) &
+             relmax = max( relmax, abs(rhs_ne(ix,iy,iz))/max(Ne(ix,iy,iz),N_floor,1.0d-9*tp3%N0) )
+          if( .not.( Nh(ix,iy,iz) <= 0.0d0 .and. rhs_nh(ix,iy,iz) < 0.0d0 ) ) &
+             relmax = max( relmax, abs(rhs_nh(ix,iy,iz))/max(Nh(ix,iy,iz),N_floor,1.0d-9*tp3%N0) )
        end do
 !$omp end parallel do
 

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -67,7 +67,7 @@ module ttm3
      ! When >0 the diffusion/conductivity are computed from the Fermi-Dirac integrals
      ! (mu=mob0*F0/F12, D=mob0*Te*F0/Fm, K=(6 F2/F0-4(F1/F0)^2) N Te mu), superseding
      ! the constant Ddiff/kappa_e.  Input m^2/Vs, converted to a.u. at read.
-     real(8) :: mob_e0   ! electron mobility                 [a.u. = m^2/Vs*2.353e-5]
+     real(8) :: mob_e0   ! electron mobility                 [a.u. = m^2/Vs * 2.3505e+5]
      real(8) :: mob_h0   ! hole mobility                     [a.u.]
      ! Layer C-a (ablation): cold bound (interband) conductivity (optional 18th input line).
      ! When >0, carrier generation is restricted to the BOUND absorption fraction
@@ -75,9 +75,12 @@ module ttm3
      ! free-carrier (Drude) absorption heats rather than ionises -> generation self-limits in
      ! the metallisation regime.  <=0 disables the split (generation = full absorbed power).
      real(8) :: sig_cold ! cold interband conductivity       [a.u.]         (Layer C-a)
-     integer :: coupling_mode ! 0=J-update (current-source ADE, default), 1=eps-update
-                              ! (carrier eps/sigma folded into the FDTD media coefficients).
-                              ! For isolating the Maxwell-coupling METHOD on an identical run.
+     integer :: coupling_mode ! Maxwell-coupling method (&ttm ttm_coupling):
+                              ! 0=J-update (current-source ADE, bilinear), 1=eps-update (carrier
+                              ! eps/sigma folded into the FDTD media coefficients; diverges when
+                              ! eps_re -> 0/negative = deep metallization), 2=J-update with ETD
+                              ! integrator, 3=exact 2x2 matrix-exponential JE (unconditionally
+                              ! stable, energy-conserving -- the DEFAULT).
   end type ttm3_param
 
   integer,allocatable :: ijk_media_whole(:,:)
@@ -90,6 +93,16 @@ module ttm3
   integer :: comm
   integer :: nprocs_g = 1                            ! # MPI ranks (diagnostic global reductions)
   integer :: xc_icomm = 0, xc_id = 0, xc_isize = 1   ! x-axis sub-comm (space-charge x-decomposition)
+  integer :: gx0 = 0, gx1 = -1                       ! global inner x-range (depth-profile gather)
+  ! medium surface faces (medium cell whose neighbour across face dir is not medium):
+  ! ttm3_transport mirrors state across these faces = reflecting (zero-flux) boundary,
+  ! matching the standalone 3D3TM (a fixed vacuum neighbour would act as a Dirichlet sink).
+  integer,allocatable :: ijk_surf(:,:)               ! (4,nsurf): ix,iy,iz, face dir (+-1,+-2,+-3)
+  integer :: nsurf = 0
+  ! medium mask over the full (halo) box: the space-charge sum must skip vacuum cells,
+  ! whose Ne/Nh now hold mirrored (nonzero) values from the reflecting boundary.
+  logical,allocatable :: med_mask(:,:,:)
+  real(8) :: dcap_worst = 1.0d0                      ! worst D/Dmax seen (CFL-cap diagnostic)
   real(8) :: hgs(3)
   real(8) :: dt
 
@@ -118,16 +131,25 @@ module ttm3
   integer,parameter   :: f_neta = 2400
   real(8),parameter   :: f_eta0 = -60.0d0, f_deta = 0.05d0
   integer,parameter   :: f_nj   = 5
+  ! j values and Gamma(j+1) for indices 1..5 = j = -1/2, 1/2, 3/2, 1, 2 (shared by the
+  ! table builder and the degenerate (eta > +60) Sommerfeld tail of ttm3_fermi).
+  real(8),parameter   :: f_jval(f_nj) = (/ -0.5d0, 0.5d0, 1.5d0, 1.0d0, 2.0d0 /)
+  real(8),parameter   :: f_gam1(f_nj) = (/ 1.7724538509055160d0, 0.8862269254527580d0, &
+                                           1.3293403881791370d0, 1.0d0, 2.0d0 /)
   real(8)             :: f_tab(0:f_neta,f_nj)
   logical             :: f_built = .false.
 
   ! density floor to keep the carrier heat capacity well defined.  Set to the
-  ! reference's intrinsic seed density Ns ~ 5.4e-15 bohr^-3 (~3.4e10 cm^-3) so the
-  ! carrier population can reach the reference's near-transparent regime; this is
+  ! standalone 3D3TM's thermal intrinsic seed density Ns(300 K) so the carrier
+  ! population can reach the reference's near-transparent regime; this is
   ! safe only because the carrier temperatures use the exponential integrator
   ! (the old RK4 step blew up at such low Ne -- see ttm3_step_cell).
   real(8),parameter :: N_floor = 3.657d-14  ! [1/bohr^3] (=2.468e11 cm^-3, standalone 3D3TM intrinsic seed Ns)
   real(8),parameter :: T_clamp = 31.67d0   ! [a.u.] (~1e7 K) numerical temperature cap
+  ! positivity floor for the temperatures (~1 K).  The explicit transport step can
+  ! undershoot at steep (metallization) fronts; a negative temperature would flip the
+  ! heat equation backward and turn exp(-1.5*gap/T) into an overflow -> NaN cascade.
+  real(8),parameter :: T_floor = 3.17d-6   ! [a.u.] (~1 K)
   real(8),parameter :: pi_ = 3.14159265358979323846d0
   real(8),parameter :: hk_kelvin = 3.1577502480407d5   ! a.u. temperature -> Kelvin
   real(8),parameter :: T_au = 2.48036d5                ! [a.u.time] Auger saturation timescale
@@ -191,12 +213,21 @@ contains
        write(*,*) "sig_cold/cm =",tp3%sig_cold, tp3%coupling_mode
     end if
 
+    if( tp3%coupling_mode < 0 .or. tp3%coupling_mode > 3 )then
+       if( DISPLAY ) write(*,'(A,I6)') " ERROR: ttm_coupling must be 0..3, got ", tp3%coupling_mode
+       error stop 'invalid ttm_coupling'
+    end if
+
 ! Convert to atomic units
     tp3%Egap = tp3%Egap / hartree_ev
-    ! mobility [m^2/Vs] -> a.u.  (mob_au = mob_SI * E_h * a_t * 1e-5 / a_B^2, the reference's
-    ! conversion: 8.5e-3 -> 2.0e-7).  Kept in SI-derived form via the atomic-unit constants.
-    tp3%mob_e0 = tp3%mob_e0 * hartree_ev*(atomic_unit_of_time*1.0d15)*1.0d-5/(atomic_unit_of_length*1.0d10)**2
-    tp3%mob_h0 = tp3%mob_h0 * hartree_ev*(atomic_unit_of_time*1.0d15)*1.0d-5/(atomic_unit_of_length*1.0d10)**2
+    ! mobility [m^2/Vs] -> a.u.: 1 m^2/Vs = 1e20 A^2/(V s) = 1e5 A^2/(V fs), then x E_h*a_t/a_B^2
+    ! => mob_au = mob_SI * 2.3505e5 (8.5e-3 m^2/Vs = 85 cm^2/Vs -> 1998 a.u.).  Cross-check via the
+    ! Einstein relation with this file's own Ddiff conversion: mu*kT(300 K) = 1998*9.5e-4 = 1.90
+    ! bohr^2/aut = 2.2 cm^2/s, the textbook ambipolar D of Si.  (The standalone reference's init
+    ! conversion, 8.5e-3 -> 2.0e-7, is 1e10 too small = its Fermi transport is effectively inert;
+    ! the port used to reproduce that number verbatim.)
+    tp3%mob_e0 = tp3%mob_e0 * hartree_ev*(atomic_unit_of_time*1.0d15)*1.0d+5/(atomic_unit_of_length*1.0d10)**2
+    tp3%mob_h0 = tp3%mob_h0 * hartree_ev*(atomic_unit_of_time*1.0d15)*1.0d+5/(atomic_unit_of_length*1.0d10)**2
     ! Auger coefficient [cm^6/s] -> [bohr^6 / a.u.time]
     tp3%A_e  = tp3%A_e * (1.0d-2/atomic_unit_of_length)**6 * atomic_unit_of_time
     tp3%A_h  = tp3%A_h * (1.0d-2/atomic_unit_of_length)**6 * atomic_unit_of_time
@@ -234,12 +265,16 @@ contains
 
   !---------------------------------------------------------------------------
   subroutine init_ttm3_grid( hgs_in, is_a, is, ie, imedia )
+    use communication, only: comm_get_min, comm_get_max
     implicit none
     real(8),intent(in) :: hgs_in(3)
     integer,intent(in) :: is_a(3), is(3), ie(3)
     integer,intent(in) :: imedia(is_a(1):,is_a(2):,is_a(3):)
-    integer :: ix,iy,iz,m
+    integer :: ix,iy,iz,m,id,jx,jy,jz,ndup
+    integer :: dirs(3,6)
     logical :: allmed
+    logical,allocatable :: seen(:,:,:)
+    real(8) :: g1(1),g2(1)
 
     ! Ablation mode (sig_cold>0): the surface metallizes, so the carrier-dependent optics
     ! back-action must reach the illuminated face cell too -> include ALL medium cells, not
@@ -308,6 +343,67 @@ contains
     end do
     end do
     end do
+
+    ! medium surface faces: medium cell whose face-d neighbour is not medium.  ttm3_transport
+    ! mirrors state across these faces (reflecting, zero-flux) so the never-evolved vacuum
+    ! neighbours do not act as a Dirichlet heat/carrier sink.  imedia halos are already
+    ! exchanged here, so faces at rank boundaries are classified correctly.
+    dirs = reshape( (/ 1,0,0, -1,0,0, 0,1,0, 0,-1,0, 0,0,1, 0,0,-1 /), (/3,6/) )
+    m = 0
+    do iz=is(3),ie(3)
+    do iy=is(2),ie(2)
+    do ix=is(1),ie(1)
+       if( imedia(ix,iy,iz) /= 0 )then
+          do id=1,6
+             if( imedia(ix+dirs(1,id),iy+dirs(2,id),iz+dirs(3,id)) == 0 ) m = m + 1
+          end do
+       end if
+    end do
+    end do
+    end do
+    nsurf = m
+    if( allocated(ijk_surf) ) deallocate(ijk_surf)
+    allocate( ijk_surf(4,max(m,1)) )
+    allocate( seen(is_a(1):ubound(imedia,1), is_a(2):ubound(imedia,2), is_a(3):ubound(imedia,3)) )
+    seen = .false. ; ndup = 0 ; m = 0
+    do iz=is(3),ie(3)
+    do iy=is(2),ie(2)
+    do ix=is(1),ie(1)
+       if( imedia(ix,iy,iz) /= 0 )then
+          do id=1,6
+             jx=ix+dirs(1,id); jy=iy+dirs(2,id); jz=iz+dirs(3,id)
+             if( imedia(jx,jy,jz) == 0 )then
+                m = m + 1
+                ijk_surf(1,m)=ix ; ijk_surf(2,m)=iy ; ijk_surf(3,m)=iz
+                ijk_surf(4,m) = merge( (id+1)/2, -((id+1)/2), mod(id,2)==1 )   ! +-1,+-2,+-3
+                if( seen(jx,jy,jz) ) ndup = ndup + 1
+                seen(jx,jy,jz) = .true.
+             end if
+          end do
+       end if
+    end do
+    end do
+    end do
+    deallocate( seen )
+    if( nprocs_g > 1 )then                       ! duplicates can sit on any rank
+       g1(1) = dble(ndup) ; call comm_get_max( g1, g2, 1, comm ) ; ndup = nint(g2(1))
+    end if
+    if( ndup > 0 .and. DISPLAY ) write(*,'(A,I8,A)') &
+       " ttm3 WARNING: non-slab geometry --", ndup, " vacuum cells border multiple medium faces;" &
+       // " the reflecting boundary is approximate at those corners."
+
+    ! medium mask (full halo box) for the space-charge sum
+    if( allocated(med_mask) ) deallocate(med_mask)
+    allocate( med_mask(is_a(1):ubound(imedia,1), is_a(2):ubound(imedia,2), is_a(3):ubound(imedia,3)) )
+    med_mask(:,:,:) = ( imedia(:,:,:) /= 0 )
+
+    ! global inner x-range (for the depth-profile gather under x-decomposition)
+    if( nprocs_g > 1 )then
+       g1(1) = dble(is(1)) ; call comm_get_min( g1(1), comm ) ; gx0 = nint(g1(1))
+       g1(1) = dble(ie(1)) ; call comm_get_max( g1, g2, 1, comm ) ; gx1 = nint(g2(1))
+    else
+       gx0 = is(1) ; gx1 = ie(1)
+    end if
   end subroutine init_ttm3_grid
 
   !---------------------------------------------------------------------------
@@ -365,11 +461,8 @@ contains
     implicit none
     integer,parameter :: nq=4000
     integer :: k,q,jj
-    real(8) :: eta,umax,du,u,integ,s,gam(f_nj),jval(f_nj)
-    ! indices 1..5 = j = -1/2, 1/2, 3/2, 1, 2  (gam = Gamma(j+1))
-    jval = (/ -0.5d0, 0.5d0, 1.5d0, 1.0d0, 2.0d0 /)
-    gam  = (/ 1.7724538509055160d0, 0.8862269254527580d0, 1.3293403881791370d0, &
-              1.0d0, 2.0d0 /)                                            ! Gamma(2)=1, Gamma(3)=2
+    real(8) :: eta,umax,du,u,integ,s
+    ! indices 1..5 = j = -1/2, 1/2, 3/2, 1, 2  (f_jval/f_gam1 = module constants)
     do k=0,f_neta
        eta = f_eta0 + dble(k)*f_deta
        umax = sqrt( max(eta,0.0d0) + 50.0d0 )
@@ -378,13 +471,13 @@ contains
           integ = 0.0d0
           do q=0,nq
              u = dble(q)*du
-             s = u**(2.0d0*jval(jj)+1.0d0)/( exp(u*u-eta) + 1.0d0 )
+             s = u**(2.0d0*f_jval(jj)+1.0d0)/( exp(u*u-eta) + 1.0d0 )
              if(q==0 .or. q==nq)then       ; integ=integ+s
              elseif(mod(q,2)==1)then        ; integ=integ+4.0d0*s
              else                           ; integ=integ+2.0d0*s
              end if
           end do
-          f_tab(k,jj) = 2.0d0*integ*du/3.0d0/gam(jj)
+          f_tab(k,jj) = 2.0d0*integ*du/3.0d0/f_gam1(jj)
        end do
     end do
     f_built = .true.
@@ -402,15 +495,26 @@ contains
   end subroutine ttm3_build_fermi_table
 
   ! F_j(eta) by linear interpolation of the table (jidx: 1=-1/2, 2=1/2, 3=3/2, 4=1, 5=2).
+  ! Above the table (eta > +60, deep degeneracy -- reached after metallization) a two-term
+  ! Sommerfeld expansion replaces the old hard clamp (which froze all F-ratios and
+  ! overestimated the carrier heat capacity by up to ~20x at Ne ~ 1e22 cm^-3):
+  !   F_j(eta) = eta^{j+1}/Gamma(j+2) * [ 1 + pi^2/6 j(j+1)/eta^2
+  !                                        + 7pi^4/360 (j+1)j(j-1)(j-2)/eta^4 ]
+  ! (this table's normalization; at eta=60 it matches the quadrature to <1e-3).
   pure function ttm3_fermi( jidx, eta ) result( F )
     implicit none
     integer,intent(in) :: jidx
     real(8),intent(in) :: eta
-    real(8) :: F,x,w
+    real(8) :: F,x,w,jv
     integer :: k
     x = (eta - f_eta0)/f_deta
     if(x <= 0.0d0)then            ; k=0       ; w=0.0d0
-    elseif(x >= dble(f_neta))then ; k=f_neta-1; w=1.0d0
+    elseif(x >= dble(f_neta))then
+       jv = f_jval(jidx)
+       F  = eta**(jv+1.0d0)/( (jv+1.0d0)*f_gam1(jidx) ) * &
+            ( 1.0d0 + (pi_*pi_/6.0d0)*jv*(jv+1.0d0)/(eta*eta) &
+                    + (7.0d0*pi_**4/360.0d0)*(jv+1.0d0)*jv*(jv-1.0d0)*(jv-2.0d0)/(eta**4) )
+       return
     else                          ; k=int(x)  ; w=x-dble(k)
     end if
     F = (1.0d0-w)*f_tab(k,jidx) + w*f_tab(k+1,jidx)
@@ -435,14 +539,23 @@ contains
   pure function ttm3_chem_pot( T, mc, N ) result( eta )
     implicit none
     real(8),intent(in) :: T,mc,N
-    real(8) :: eta,Neff,y,w
-    integer :: lo,hi,mid
+    real(8) :: eta,Neff,y,w,g52
+    integer :: lo,hi,mid,it
     Neff = 2.0d0*( mc*max(T,1.0d-12)/(2.0d0*pi_) )**1.5d0
     y = N/Neff                                       ! target value of F_{1/2}(eta)
     if( y <= f_tab(0,2) )then
        eta = f_eta0; return
     elseif( y >= f_tab(f_neta,2) )then
-       eta = f_eta0 + dble(f_neta)*f_deta; return
+       ! deep degeneracy (eta > +60): invert the two-term Sommerfeld F_{1/2}(eta)
+       !   F_{1/2} = ( eta^{3/2} + (pi^2/8) eta^{-1/2} ) / Gamma(5/2)
+       ! leading order eta = (Gamma(5/2) y)^{2/3}, then two Newton corrections.
+       g52 = f_gam1(3)                                ! Gamma(5/2) = 1.32934...
+       eta = ( g52*y )**(2.0d0/3.0d0)
+       do it=1,2
+          eta = eta - ( (eta**1.5d0 + 0.125d0*pi_*pi_/sqrt(eta))/g52 - y ) &
+                     /( (1.5d0*sqrt(eta) - 0.0625d0*pi_*pi_*eta**(-1.5d0))/g52 )
+       end do
+       return
     end if
     lo = 0; hi = f_neta
     do while( hi-lo > 1 )                            ! binary search: f_tab(lo,2) <= y < f_tab(hi,2)
@@ -496,8 +609,14 @@ contains
     Ch = ttm3_heat_capacity( Th_, tp3%mu_h, Nh_+N_floor )
     inv_tau = 1.0d0/tp3%tau
 
-    ! generation, saturated at the reference/atomic density N0 (cannot exceed it)
-    geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
+    ! generation, saturated at the reference/atomic density N0 (cannot exceed it).
+    ! Single bleach: when sig_cold>0 the band-filling factor is already applied once
+    ! inside ttm3_linear_gen (same convention as ttm3_step_cell).
+    if( tp3%sig_cold > 0.0d0 )then
+       geff = gen_
+    else
+       geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
+    end if
 
     ! standard Auger recombination (removes electron-hole pairs).  This is the
     ! unsaturated limit of the reference R = N*A*N*Ne*Nh/(1+T_au*A*Ne*Nh): at the
@@ -552,7 +671,13 @@ contains
     Ce = ttm3_heat_capacity( Te_, tp3%mu_e, Ne_+N_floor )
     Ch = ttm3_heat_capacity( Th_, tp3%mu_h, Nh_+N_floor )
     inv_tau = (1.0d0/tp3%tau)/( 1.0d0 + (Ne_*8443.9d0)**2 )      ! density-dependent e-ph relaxation
-    geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
+    if( tp3%sig_cold > 0.0d0 )then
+       ! band filling is already applied once inside ttm3_linear_gen (sig_b = sig_cold*bf),
+       ! matching the reference's single bleach; a second factor here would give bf^2.
+       geff = gen_
+    else
+       geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
+    end if
     Cef_e = tp3%A_e*Ne_*Nh_ ; Re = Ne_*Cef_e/( 1.0d0 + T_au*Cef_e )   ! saturated Auger (e)
     Cef_h = tp3%A_h*Ne_*Nh_ ; Rh = Nh_*Cef_h/( 1.0d0 + T_au*Cef_h )   ! saturated Auger (h)
     R    = ( Re + Rh ) * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )   ! band-filling (matches standalone Reh*Rate_eh)
@@ -565,9 +690,11 @@ contains
           * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
 
     ! lattice: relaxation heating from the carriers (non-stiff, Cl large), with the
-    ! temperature-dependent lattice heat capacity Cl(Tl) (= input value at 300 K)
-    TlK    = Tl_*hk_kelvin
-    Cl_eff = tp3%Cl*( 1.978d0 + 3.54d-4*TlK - 3.68d0/(TlK*TlK) )/2.084d0
+    ! temperature-dependent lattice heat capacity Cl(Tl) (= input value at 300 K).
+    ! Floored: the polynomial goes negative below ~1.4 K (and -inf at 0), which would
+    ! flip the carrier->lattice coupling sign.
+    TlK    = max(Tl_,T_floor)*hk_kelvin
+    Cl_eff = tp3%Cl*max( 1.978d0 + 3.54d-4*TlK - 3.68d0/(TlK*TlK), 0.2d0 )/2.084d0
     dTl = ( Ce*(Te_-Tl_) + Ch*(Th_-Tl_) )*inv_tau / Cl_eff
 
     ! carrier temperatures: exponential integrator (stiff relaxation + dilution).
@@ -591,10 +718,10 @@ contains
     ! carrier densities and lattice: explicit Euler (non-stiff); +Col thermal generation
     Ne_ = min( max( Ne_ + dt_in*(geff - R + Col), 0.0d0 ), tp3%N0 )   ! cap at valence density
     Nh_ = min( max( Nh_ + dt_in*(geff - R + Col), 0.0d0 ), tp3%N0 )
-    Tl_ = max( Tl_ + dt_in*dTl, 0.0d0 )
+    Tl_ = max( Tl_ + dt_in*dTl, T_floor )
 
     ! numerical guard (should not trigger now that the stiff modes are integrated exactly)
-    Te_ = min(max(Te_,0.0d0),T_clamp); Th_ = min(max(Th_,0.0d0),T_clamp)
+    Te_ = min(max(Te_,T_floor),T_clamp); Th_ = min(max(Th_,T_floor),T_clamp)
   end subroutine ttm3_step_cell
 
   !---------------------------------------------------------------------------
@@ -636,6 +763,7 @@ contains
     real(8) :: gx,gy,gz,gKe,gKh
     real(8) :: eta,F0,Fm,F12,F1,F2,kT,cjE,cjT,fp4i
     real(8) :: dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh,gCJe,gCJh
+    real(8) :: TlK_t,Cl_t,dcap
     logical :: use_fermi
 
     use_fermi = ( tp3%mob_e0>0.0d0 .or. tp3%mob_h0>0.0d0 )
@@ -663,6 +791,10 @@ contains
     call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
     call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)
     call update_overlap_real8(srg, rg, Tl)
+    ! reflecting (zero-flux) slab boundary: mirror the state into the vacuum face
+    ! neighbours (after the halo exchange, so the exchange cannot overwrite it).
+    ! Without this the never-evolved vacuum cells act as an infinite Dirichlet sink.
+    call ttm3_mirror_state( use_fermi )
 
     if( use_fermi )then
        ! pass 1: Fermi coefficients (mobility Mc, diffusion Dc, conductivity Kc) and the
@@ -671,7 +803,7 @@ contains
        do m=1,nmedia_myrnk
           ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
           ! electrons
-          kT=Te(ix,iy,iz); eta=ttm3_chem_pot(kT,tp3%mu_e,Ne(ix,iy,iz)+N_floor)
+          kT=max(Te(ix,iy,iz),T_floor); eta=ttm3_chem_pot(kT,tp3%mu_e,Ne(ix,iy,iz)+N_floor)
           F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
           F1=ttm3_fermi(4,eta); F2=ttm3_fermi(5,eta)
           Mc_e(ix,iy,iz)=tp3%mob_e0*F0/F12
@@ -684,7 +816,7 @@ contains
           Jc_e(ix,iy,iz,3)=(Ne(ix,iy,iz+1)-Ne(ix,iy,iz-1))*gz + cjE*(rgap(ix,iy,iz+1)-rgap(ix,iy,iz-1))*gz + cjT*(Te(ix,iy,iz+1)-Te(ix,iy,iz-1))*gz
           Cj_e(ix,iy,iz)=2.0d0*kT*F1/F0 + (tp3%mu_h/(tp3%mu_e+tp3%mu_h))*rgap(ix,iy,iz)   ! heat per carrier
           ! holes
-          kT=Th(ix,iy,iz); eta=ttm3_chem_pot(kT,tp3%mu_h,Nh(ix,iy,iz)+N_floor)
+          kT=max(Th(ix,iy,iz),T_floor); eta=ttm3_chem_pot(kT,tp3%mu_h,Nh(ix,iy,iz)+N_floor)
           F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
           F1=ttm3_fermi(4,eta); F2=ttm3_fermi(5,eta)
           Mc_h(ix,iy,iz)=tp3%mob_h0*F0/F12
@@ -704,11 +836,14 @@ contains
        call update_overlap_real8(srg, rg, Cj_e); call update_overlap_real8(srg, rg, Cj_h)
        call update_overlap_real8(srg, rg, Jc_e(:,:,:,1)); call update_overlap_real8(srg, rg, Jc_e(:,:,:,2)); call update_overlap_real8(srg, rg, Jc_e(:,:,:,3))
        call update_overlap_real8(srg, rg, Jc_h(:,:,:,1)); call update_overlap_real8(srg, rg, Jc_h(:,:,:,2)); call update_overlap_real8(srg, rg, Jc_h(:,:,:,3))
+       call ttm3_mirror_coefs()                 ! reflecting BC for the derived fields (J.n=0)
        call ttm3_space_charge()                 ! Efld = space-charge field (prefix sum along x)
     end if
 
+    dcap = 0.0d0
 !$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,gKe,gKh, &
-!$omp&                    dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh,gCJe,gCJh)
+!$omp&                    dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh,gCJe,gCJh, &
+!$omp&                    TlK_t,Cl_t) reduction(max:dcap)
     do m=1,nmedia_myrnk
        ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
        lTe=(Te(ix+1,iy,iz)-2*Te(ix,iy,iz)+Te(ix-1,iy,iz))*cx+(Te(ix,iy+1,iz)-2*Te(ix,iy,iz)+Te(ix,iy-1,iz))*cy+(Te(ix,iy,iz+1)-2*Te(ix,iy,iz)+Te(ix,iy,iz-1))*cz
@@ -724,6 +859,10 @@ contains
           gKh=(Kc_h(ix+1,iy,iz)-Kc_h(ix-1,iy,iz))*gx*(Th(ix+1,iy,iz)-Th(ix-1,iy,iz))*gx &
              +(Kc_h(ix,iy+1,iz)-Kc_h(ix,iy-1,iz))*gy*(Th(ix,iy+1,iz)-Th(ix,iy-1,iz))*gy &
              +(Kc_h(ix,iy,iz+1)-Kc_h(ix,iy,iz-1))*gz*(Th(ix,iy,iz+1)-Th(ix,iy,iz-1))*gz
+          ! CFL-cap diagnostic: when a diffusivity exceeds Dmax the min() silently reduces
+          ! the physics -- track the worst ratio so ttm3_transport can warn (see loop end).
+          dcap = max( dcap, Kc_e(ix,iy,iz)/Ce/Dmax, Kc_h(ix,iy,iz)/Ch/Dmax, &
+                            Dc_e(ix,iy,iz)/Dmax,    Dc_h(ix,iy,iz)/Dmax )
           rhs_te(ix,iy,iz)=dt*( min(Kc_e(ix,iy,iz)/Ce,Dmax)*lTe + gKe/Ce )
           rhs_th(ix,iy,iz)=dt*( min(Kc_h(ix,iy,iz)/Ch,Dmax)*lTh + gKh/Ch )
           ! carrier transport: nab.(Dc Jc) - drift(space charge).  reference Evolve_N_T.
@@ -739,9 +878,16 @@ contains
           rhs_th(ix,iy,iz)=rhs_th(ix,iy,iz)+dt*( Cj_h(ix,iy,iz)*(Dc_h(ix,iy,iz)*dJh+gDJh) + Dc_h(ix,iy,iz)*gCJh )/Ch
           gMxe=(Mc_e(ix+1,iy,iz)-Mc_e(ix-1,iy,iz))*gx; gNxe=(Ne(ix+1,iy,iz)-Ne(ix-1,iy,iz))*gx
           gMxh=(Mc_h(ix+1,iy,iz)-Mc_h(ix-1,iy,iz))*gx; gNxh=(Nh(ix+1,iy,iz)-Nh(ix-1,iy,iz))*gx
-          dEf=fp4i*(Ne(ix,iy,iz)-Nh(ix,iy,iz))               ! 4*pi*inveps*(Ne-Nh)
-          nabNe=min(Dc_e(ix,iy,iz),Dmax)*dJe + gDJe - (gMxe*Ne(ix,iy,iz)+Mc_e(ix,iy,iz)*gNxe)*Efld(ix,iy,iz) - Mc_e(ix,iy,iz)*Ne(ix,iy,iz)*dEf
-          nabNh=min(Dc_h(ix,iy,iz),Dmax)*dJh + gDJh + (gMxh*Nh(ix,iy,iz)+Mc_h(ix,iy,iz)*gNxh)*Efld(ix,iy,iz) + Mc_h(ix,iy,iz)*Nh(ix,iy,iz)*dEf
+          dEf=fp4i*(Ne(ix,iy,iz)-Nh(ix,iy,iz))               ! 4*pi*inveps*(Ne-Nh) = -dE/dx
+          ! drift (Efld = physical E from the sheet prefix sum, pointing away from net + charge):
+          !   electrons (v=-mu*E):  dNe/dt|drift = +div(mu_e Ne E) = +grad(mu_e Ne).E + mu_e Ne divE
+          !   holes     (v=+mu*E):  dNh/dt|drift = -div(mu_h Nh E) = -grad(mu_h Nh).E - mu_h Nh divE
+          ! with divE = -dEf; the gradient and divergence terms must carry CONSISTENT signs or
+          ! the drift is not a conservative flux (the old code had the gradient terms flipped).
+          nabNe=min(Dc_e(ix,iy,iz),Dmax)*dJe + gDJe &
+                + (gMxe*Ne(ix,iy,iz)+Mc_e(ix,iy,iz)*gNxe)*Efld(ix,iy,iz) - Mc_e(ix,iy,iz)*Ne(ix,iy,iz)*dEf
+          nabNh=min(Dc_h(ix,iy,iz),Dmax)*dJh + gDJh &
+                - (gMxh*Nh(ix,iy,iz)+Mc_h(ix,iy,iz)*gNxh)*Efld(ix,iy,iz) + Mc_h(ix,iy,iz)*Nh(ix,iy,iz)*dEf
           rhs_ne(ix,iy,iz)=dt*nabNe
           rhs_nh(ix,iy,iz)=dt*nabNh
        else
@@ -752,33 +898,97 @@ contains
           rhs_te(ix,iy,iz)=dt*min(tp3%kappa_e/Ce,Dmax)*lTe
           rhs_th(ix,iy,iz)=dt*min(tp3%kappa_e/Ch,Dmax)*lTh
        end if
-       rhs_tl(ix,iy,iz)=dt*min( tp3%kappa_l*(Tl(ix,iy,iz)*hk_kelvin/300.0d0)**(-1.23d0)/tp3%Cl, Dmax )*lTl  ! Kl(Tl)
+       ! lattice conduction Kl(Tl)/Cl(Tl): both temperature-dependent, Tl floored before
+       ! the power/polynomial (a zero/negative Tl would give inf/NaN before any commit floor)
+       TlK_t = max(Tl(ix,iy,iz),T_floor)*hk_kelvin
+       Cl_t  = tp3%Cl*max( 1.978d0 + 3.54d-4*TlK_t - 3.68d0/(TlK_t*TlK_t), 0.2d0 )/2.084d0
+       dcap  = max( dcap, tp3%kappa_l*(TlK_t/300.0d0)**(-1.23d0)/Cl_t/Dmax )
+       rhs_tl(ix,iy,iz)=dt*min( tp3%kappa_l*(TlK_t/300.0d0)**(-1.23d0)/Cl_t, Dmax )*lTl  ! Kl(Tl)
     end do
 !$omp end parallel do
+
+    ! warn (rank-local, log-cadence) when the CFL cap is actually rewriting the physics
+    if( dcap > 1.0d0 .and. dcap > 1.999d0*dcap_worst )then
+       write(*,'(A,ES10.2,A)') " ttm3 WARNING: transport diffusivity CFL-capped (worst D/Dmax =", dcap, &
+                               " ) -- conduction/diffusion locally reduced; consider sub-stepping."
+    end if
+    dcap_worst = max( dcap_worst, dcap )
 
 !$omp parallel do private(m,ix,iy,iz)
     do m=1,nmedia_myrnk
        ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
        Ne(ix,iy,iz)=max(Ne(ix,iy,iz)+rhs_ne(ix,iy,iz),0.0d0)
        Nh(ix,iy,iz)=max(Nh(ix,iy,iz)+rhs_nh(ix,iy,iz),0.0d0)
-       Te(ix,iy,iz)=Te(ix,iy,iz)+rhs_te(ix,iy,iz)
-       Th(ix,iy,iz)=Th(ix,iy,iz)+rhs_th(ix,iy,iz)
-       Tl(ix,iy,iz)=Tl(ix,iy,iz)+rhs_tl(ix,iy,iz)
+       ! positivity floors: an explicit-step undershoot to T<=0 would flip the heat
+       ! equation backward and blow up exp(-1.5*gap/T) in the next local step
+       Te(ix,iy,iz)=max(Te(ix,iy,iz)+rhs_te(ix,iy,iz),T_floor)
+       Th(ix,iy,iz)=max(Th(ix,iy,iz)+rhs_th(ix,iy,iz),T_floor)
+       Tl(ix,iy,iz)=max(Tl(ix,iy,iz)+rhs_tl(ix,iy,iz),T_floor)
     end do
 !$omp end parallel do
   end subroutine ttm3_transport
 
   !---------------------------------------------------------------------------
-  ! Space-charge field Efld along x: Ef(ix)=2*pi*inveps*[sum_{i<ix} - sum_{i>ix}] rho dV,
-  ! rho=(Nh-Ne) (charge density; zero in non-medium cells, Ne=Nh=floor).  Per (iy,iz)
-  ! line, a prefix sum over the local inner x-range (single-domain; nproc_rgrid=1).
+  ! Reflecting (zero-flux) closure at the medium surface: copy each surface cell's
+  ! state into its vacuum face neighbour, so the central differences see a zero
+  ! normal gradient.  Serial loops (nsurf is small; deterministic on duplicate
+  ! targets, which only occur for non-slab corner geometries -- warned at init).
+  subroutine ttm3_mirror_state( use_fermi_ )
+    implicit none
+    logical,intent(in) :: use_fermi_
+    integer :: m,ix,iy,iz,id,jx,jy,jz
+    do m=1,nsurf
+       ix=ijk_surf(1,m); iy=ijk_surf(2,m); iz=ijk_surf(3,m); id=ijk_surf(4,m)
+       jx=ix; jy=iy; jz=iz
+       select case( abs(id) )
+       case(1); jx = ix + sign(1,id)
+       case(2); jy = iy + sign(1,id)
+       case(3); jz = iz + sign(1,id)
+       end select
+       Ne(jx,jy,jz)=Ne(ix,iy,iz); Nh(jx,jy,jz)=Nh(ix,iy,iz)
+       Te(jx,jy,jz)=Te(ix,iy,iz); Th(jx,jy,jz)=Th(ix,iy,iz); Tl(jx,jy,jz)=Tl(ix,iy,iz)
+       if( use_fermi_ ) rgap(jx,jy,jz)=rgap(ix,iy,iz)
+    end do
+  end subroutine ttm3_mirror_state
+
+  ! Same closure for the pass-1 derived fields: transport coefficients mirror
+  ! symmetrically; the carrier-current NORMAL component mirrors antisymmetrically
+  ! (J.n = 0 at the surface).  Only the normal component of the neighbour's Jc is
+  ! ever read by the divergence stencil.
+  subroutine ttm3_mirror_coefs()
+    implicit none
+    integer :: m,ix,iy,iz,id,jx,jy,jz,d
+    do m=1,nsurf
+       ix=ijk_surf(1,m); iy=ijk_surf(2,m); iz=ijk_surf(3,m); id=ijk_surf(4,m)
+       jx=ix; jy=iy; jz=iz; d=abs(id)
+       select case( d )
+       case(1); jx = ix + sign(1,id)
+       case(2); jy = iy + sign(1,id)
+       case(3); jz = iz + sign(1,id)
+       end select
+       Dc_e(jx,jy,jz)=Dc_e(ix,iy,iz); Dc_h(jx,jy,jz)=Dc_h(ix,iy,iz)
+       Mc_e(jx,jy,jz)=Mc_e(ix,iy,iz); Mc_h(jx,jy,jz)=Mc_h(ix,iy,iz)
+       Kc_e(jx,jy,jz)=Kc_e(ix,iy,iz); Kc_h(jx,jy,jz)=Kc_h(ix,iy,iz)
+       Cj_e(jx,jy,jz)=Cj_e(ix,iy,iz); Cj_h(jx,jy,jz)=Cj_h(ix,iy,iz)
+       Jc_e(jx,jy,jz,d)=-Jc_e(ix,iy,iz,d)
+       Jc_h(jx,jy,jz,d)=-Jc_h(ix,iy,iz,d)
+    end do
+  end subroutine ttm3_mirror_coefs
+
+  !---------------------------------------------------------------------------
+  ! Space-charge field Efld along x: Ef(ix)=2*pi*inveps*[sum_{i<ix} - sum_{i>ix}] rho*dx.
+  ! A sheet at x' with areal charge sigma = rho*dx contributes E = +-2*pi*sigma/eps, so the
+  ! prefix weight is the x cell size hgs(1) ONLY (the old dV=hx*hy*hz overscaled Efld by the
+  ! transverse cell area and made it dimensionally inconsistent with the local Gauss term).
+  ! rho=(Nh-Ne) on MEDIUM cells only (vacuum cells hold mirrored values from the reflecting
+  ! boundary and must not contribute).  Per (iy,iz) line, prefix sum over the inner x-range.
   subroutine ttm3_space_charge()
     use communication, only: comm_summation
     implicit none
     integer :: ix,iy,iz,p
-    real(8) :: dV,c2,total,pre,rho
+    real(8) :: dx,c2,total,pre,rho
     real(8),allocatable :: ain(:,:,:), aout(:,:,:)
-    dV = hgs(1)*hgs(2)*hgs(3)
+    dx = hgs(1)
     c2 = 2.0d0*pi_/tp3%eps_bg
     if( xc_isize <= 1 )then
        ! single x-domain (nproc_rgrid(1)=1): local exclusive prefix sum per (iy,iz) line
@@ -787,13 +997,13 @@ contains
        do iy=is_inner(2),ie_inner(2)
           total=0.0d0
           do ix=is_inner(1),ie_inner(1)
-             total=total+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
+             if( med_mask(ix,iy,iz) ) total=total+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
           end do
           pre=0.0d0                                  ! exclusive prefix sum (i<ix)
           do ix=is_inner(1),ie_inner(1)
-             rho=Nh(ix,iy,iz)-Ne(ix,iy,iz)
-             ! Ef = (left - right)*dV*c2 ;  right = total - pre - rho
-             Efld(ix,iy,iz)=c2*dV*( 2.0d0*pre + rho - total )
+             rho=merge( Nh(ix,iy,iz)-Ne(ix,iy,iz), 0.0d0, med_mask(ix,iy,iz) )
+             ! Ef = (left - right)*dx*c2 ;  right = total - pre - rho
+             Efld(ix,iy,iz)=c2*dx*( 2.0d0*pre + rho - total )
              pre=pre+rho
           end do
        end do
@@ -810,7 +1020,7 @@ contains
        do iy=is_inner(2),ie_inner(2)
           rho=0.0d0
           do ix=is_inner(1),ie_inner(1)
-             rho=rho+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
+             if( med_mask(ix,iy,iz) ) rho=rho+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
           end do
           ain(xc_id,iy,iz)=rho
        end do
@@ -824,8 +1034,8 @@ contains
              if( p<xc_id ) pre=pre+aout(p,iy,iz)   ! charge in x-domains left of this one
           end do
           do ix=is_inner(1),ie_inner(1)
-             rho=Nh(ix,iy,iz)-Ne(ix,iy,iz)
-             Efld(ix,iy,iz)=c2*dV*( 2.0d0*pre + rho - total )
+             rho=merge( Nh(ix,iy,iz)-Ne(ix,iy,iz), 0.0d0, med_mask(ix,iy,iz) )
+             Efld(ix,iy,iz)=c2*dx*( 2.0d0*pre + rho - total )
              pre=pre+rho
           end do
        end do
@@ -880,61 +1090,110 @@ contains
   end subroutine ttm3_get_max
 
   !---------------------------------------------------------------------------
-  ! State at the illuminated front face: the minimum-ix medium cell nearest the
-  ! transverse centroid.  This is the analogue of the reference's x=0 surface cell
-  ! and, unlike ttm3_get_max, is not biased by the Fabry-Perot field antinodes that
-  ! form inside a finite slab (which sit deeper than the front face and read high).
-  subroutine ttm3_get_front( Te_o, Th_o, Tl_o, Ne_o, Nh_o )
-    use communication, only: comm_get_min, comm_get_max
+  ! State at the illuminated front face: the medium cell on the GLOBAL minimum-ix
+  ! plane nearest the GLOBAL transverse centroid -- the analogue of the reference's
+  ! x=0 surface cell and, unlike ttm3_get_max, not biased by internal Fabry-Perot
+  ! antinodes.  COLLECTIVE: must be called by every rank.  The winner cell is chosen
+  ! by a decomposition-independent key that is unique per cell (centroid distance,
+  ! then iy,iz), so ALL outputs -- state, env/power/gen, indices -- come from the
+  ! same single cell for any MPI layout (the old per-rank centroid + elementwise max
+  ! could mix fields from different cells and report a vacuum cell on rank 0).
+  subroutine ttm3_get_front( env, pw, gn, Te_o, Th_o, Tl_o, Ne_o, Nh_o, &
+                             env_o, pow_o, gen_o, gjx, gjy, gjz )
+    use communication, only: comm_get_min, comm_get_max, comm_summation
     implicit none
+    real(8),intent(in)  :: env(is_array(1):,is_array(2):,is_array(3):)  ! field envelope
+    real(8),intent(in)  :: pw (is_inner(1):,is_inner(2):,is_inner(3):)  ! heating source
+    real(8),intent(in)  :: gn (is_inner(1):,is_inner(2):,is_inner(3):)  ! generation rate
     real(8),intent(out) :: Te_o, Th_o, Tl_o, Ne_o, Nh_o   ! [K],[K],[K],[1/cm^3],[1/cm^3]
+    real(8),intent(out) :: env_o, pow_o, gen_o            ! [a.u.] at the front cell
+    integer,intent(out) :: gjx, gjy, gjz                  ! front cell (global grid indices)
     real(8), parameter :: hartree_kelvin_relationship = 3.1577502480407d5
     real(8), parameter :: atomic_unit_of_length = 5.29177210903d-11
-    real(8) :: cm3_per_bohr3, cy, cz, gfix, vin(5), vout(5)
-    integer :: m,ix,iy,iz,ixmin,nmin,a(3),dbest,d,lfix
-    Te_o=tp3%Tini*hartree_kelvin_relationship; Th_o=Te_o; Tl_o=Te_o; Ne_o=0d0; Nh_o=0d0
-    lfix = huge(0)
-    if( nmedia_myrnk>0 )then
-       cm3_per_bohr3 = (atomic_unit_of_length*1.0d2)**3
-       ! minimum ix among medium cells = the illuminated face
-       ixmin = ijk_media_myrnk(1,1)
-       do m=2,nmedia_myrnk
-          if( ijk_media_myrnk(1,m) < ixmin ) ixmin = ijk_media_myrnk(1,m)
-       end do
-       ! transverse centroid of that face
-       cy=0d0; cz=0d0; nmin=0
-       do m=1,nmedia_myrnk
-          if( ijk_media_myrnk(1,m)==ixmin )then
-             cy=cy+ijk_media_myrnk(2,m); cz=cz+ijk_media_myrnk(3,m); nmin=nmin+1
-          end if
-       end do
-       cy=cy/max(nmin,1); cz=cz/max(nmin,1)
-       ! face cell nearest the centroid
-       a = ijk_media_myrnk(1:3,1); dbest=huge(0)
-       do m=1,nmedia_myrnk
-          if( ijk_media_myrnk(1,m)==ixmin )then
-             iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
-             d = (iy-nint(cy))**2 + (iz-nint(cz))**2
-             if( d<dbest )then; dbest=d; a=ijk_media_myrnk(1:3,m); end if
-          end if
-       end do
-       Te_o=Te(a(1),a(2),a(3))*hartree_kelvin_relationship
-       Th_o=Th(a(1),a(2),a(3))*hartree_kelvin_relationship
-       Tl_o=Tl(a(1),a(2),a(3))*hartree_kelvin_relationship
-       Ne_o=Ne(a(1),a(2),a(3))/cm3_per_bohr3; Nh_o=Nh(a(1),a(2),a(3))/cm3_per_bohr3
-       lfix = ixmin
-    end if
-    if( nprocs_g>1 )then     ! select values from the rank holding the global illuminated face (min ix)
-       gfix = dble(lfix)
-       call comm_get_min( gfix, comm )
-       if( lfix == nint(gfix) )then
-          vin(1)=Te_o; vin(2)=Th_o; vin(3)=Tl_o; vin(4)=Ne_o; vin(5)=Nh_o
-       else
-          vin(:) = -huge(1.0d0)
+    real(8) :: cm3_per_bohr3, cy, cz, gfix, dkey, dkeyg, cyz(3), cyzg(3), vin(11), vout(11)
+    integer :: m,ix,iy,iz,ixmin,a(3),dbest,d
+    logical :: have
+
+    Te_o=tp3%Tini*hartree_kelvin_relationship; Th_o=Te_o; Tl_o=Te_o
+    Ne_o=0d0; Nh_o=0d0; env_o=0d0; pow_o=0d0; gen_o=0d0
+    gjx=is_inner(1); gjy=is_inner(2); gjz=is_inner(3)
+    cm3_per_bohr3 = (atomic_unit_of_length*1.0d2)**3
+
+    ! (1) global front plane = min ix over all medium cells
+    gfix = dble(huge(1))
+    do m=1,nmedia_myrnk
+       gfix = min( gfix, dble(ijk_media_myrnk(1,m)) )
+    end do
+    if( nprocs_g>1 ) call comm_get_min( gfix, comm )
+    if( gfix >= dble(huge(1)) ) return                  ! no medium cell anywhere
+    ixmin = nint(gfix)
+
+    ! (2) global transverse centroid of the front plane
+    cyz = 0.0d0
+    do m=1,nmedia_myrnk
+       if( ijk_media_myrnk(1,m)==ixmin )then
+          cyz(1)=cyz(1)+dble(ijk_media_myrnk(2,m)); cyz(2)=cyz(2)+dble(ijk_media_myrnk(3,m))
+          cyz(3)=cyz(3)+1.0d0
        end if
-       call comm_get_max( vin, vout, 5, comm )
-       Te_o=vout(1); Th_o=vout(2); Tl_o=vout(3); Ne_o=vout(4); Nh_o=vout(5)
+    end do
+    if( nprocs_g>1 )then
+       call comm_summation( cyz, cyzg, 3, comm )
+    else
+       cyzg = cyz
     end if
+    cy = cyzg(1)/max(cyzg(3),1.0d0); cz = cyzg(2)/max(cyzg(3),1.0d0)
+
+    ! (3) local candidate on the plane: nearest the centroid, ties broken by (iy,iz)
+    have=.false.; dbest=huge(0); a=(/ixmin,0,0/)
+    do m=1,nmedia_myrnk
+       if( ijk_media_myrnk(1,m)==ixmin )then
+          iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+          d = (iy-nint(cy))**2 + (iz-nint(cz))**2
+          if( .not.have .or. d<dbest .or. ( d==dbest .and. ( iy<a(2) .or. &
+              ( iy==a(2) .and. iz<a(3) ) ) ) )then
+             dbest=d; a(2)=iy; a(3)=iz; have=.true.
+          end if
+       end if
+    end do
+
+    ! (4) global winner by staged exact min-reductions on (distance, iy, iz):
+    !     integer values carried in doubles are exact, so the winner cell is unique
+    !     (one owner rank) for any grid size -- no packed-key collisions.
+    dkey = merge( dble(dbest), huge(1.0d0), have )
+    dkeyg = dkey
+    if( nprocs_g>1 ) call comm_get_min( dkeyg, comm )
+    if( dkeyg >= huge(1.0d0) ) return                   ! no candidate anywhere (paranoia)
+    have = have .and. ( dkey == dkeyg )
+    dkey = merge( dble(a(2)), huge(1.0d0), have )
+    dkeyg = dkey
+    if( nprocs_g>1 ) call comm_get_min( dkeyg, comm )
+    have = have .and. ( dkey == dkeyg )
+    dkey = merge( dble(a(3)), huge(1.0d0), have )
+    dkeyg = dkey
+    if( nprocs_g>1 ) call comm_get_min( dkeyg, comm )
+    have = have .and. ( dkey == dkeyg )
+
+    ! (5) the winner packs every output from its candidate cell; elementwise max
+    !     is then a pure broadcast (all non-winners contribute -huge)
+    if( have )then
+       ix=a(1); iy=a(2); iz=a(3)
+       vin(1)=Te(ix,iy,iz); vin(2)=Th(ix,iy,iz); vin(3)=Tl(ix,iy,iz)
+       vin(4)=Ne(ix,iy,iz); vin(5)=Nh(ix,iy,iz)
+       vin(6)=env(ix,iy,iz); vin(7)=pw(ix,iy,iz); vin(8)=gn(ix,iy,iz)
+       vin(9)=dble(ix); vin(10)=dble(iy); vin(11)=dble(iz)
+    else
+       vin(:) = -huge(1.0d0)
+    end if
+    if( nprocs_g>1 )then
+       call comm_get_max( vin, vout, 11, comm )
+    else
+       vout = vin
+    end if
+    Te_o=vout(1)*hartree_kelvin_relationship; Th_o=vout(2)*hartree_kelvin_relationship
+    Tl_o=vout(3)*hartree_kelvin_relationship
+    Ne_o=vout(4)/cm3_per_bohr3; Nh_o=vout(5)/cm3_per_bohr3
+    env_o=vout(6); pow_o=vout(7); gen_o=vout(8)
+    gjx=nint(vout(9)); gjy=nint(vout(10)); gjz=nint(vout(11))
   end subroutine ttm3_get_front
 
   ! Index of the illuminated front-face medium cell (same selection as ttm3_get_front).
@@ -969,32 +1228,50 @@ contains
     jx=a(1); jy=a(2); jz=a(3)
   end subroutine ttm3_front_ijk
 
-  ! Depth profile along x at the transverse centre line (front cell's iy,iz): writes
-  ! one block per call (time, ix, Te[K], Ne[cm^-3], Tl[K]) for spatial-distribution diagnostics.
-  subroutine ttm3_write_profile( fname, t_fs, u, field )
+  ! Depth profile along x at the GLOBAL front-cell transverse line (gjy,gjz from
+  ! ttm3_get_front): each rank fills its slice of the global x-line, a sum-gather
+  ! assembles it, and root writes one block per call (time, ix, Te[K], Ne[cm^-3],
+  ! Tl[K], |E|^2).  COLLECTIVE: must be called by every rank (the old version wrote
+  ! only root's own x-slice = truncated profile under x-decomposition).
+  subroutine ttm3_write_profile( fname, t_fs, u, field, gjy, gjz )
+    use communication, only: comm_summation
     implicit none
     character(*),intent(in) :: fname
     real(8),     intent(in) :: t_fs
-    integer,     intent(in) :: u
+    integer,     intent(in) :: u, gjy, gjz
     real(8),     intent(in) :: field(is_array(1):,is_array(2):,is_array(3):)  ! |E|^2 envelope [a.u.]
     real(8),parameter :: hk = 3.1577502480407d5, aul = 5.29177210903d-11
     real(8) :: cm3
-    integer :: m,ix,iy,iz,fx,fy,fz
-    if( nmedia_myrnk<=0 ) return
-    call ttm3_front_ijk( fx, fy, fz )                 ! transverse centre = front cell line
+    integer :: m,ix,iy,iz
+    real(8),allocatable :: buf(:,:), bufg(:,:)
+    if( gx1 < gx0 ) return
+    allocate( buf(gx0:gx1,0:4), bufg(gx0:gx1,0:4) ); buf=0.0d0
     cm3 = (aul*1.0d2)**3
-    open(u, file=fname, status='unknown', position='append')
-    do ix=is_inner(1),ie_inner(1)                     ! sorted by depth
-       do m=1,nmedia_myrnk
-          if( ijk_media_myrnk(1,m)==ix .and. ijk_media_myrnk(2,m)==fy .and. ijk_media_myrnk(3,m)==fz )then
-             iy=fy; iz=fz
-             write(u,'(F12.4,1X,I6,4(1X,E16.8))') t_fs, ix, &
-                  Te(ix,iy,iz)*hk, Ne(ix,iy,iz)/cm3, Tl(ix,iy,iz)*hk, field(ix,iy,iz)
-          end if
-       end do
+    do m=1,nmedia_myrnk
+       ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+       if( iy==gjy .and. iz==gjz )then                ! my cells on the global centre line
+          buf(ix,0)=1.0d0                             ! occupancy (skips vacuum rows on write)
+          buf(ix,1)=Te(ix,iy,iz)*hk
+          buf(ix,2)=Ne(ix,iy,iz)/cm3
+          buf(ix,3)=Tl(ix,iy,iz)*hk
+          buf(ix,4)=field(ix,iy,iz)
+       end if
     end do
-    write(u,*) ' '                                    ! blank line separates time blocks
-    close(u)
+    if( nprocs_g>1 )then
+       call comm_summation( buf, bufg, size(buf), comm )
+    else
+       bufg = buf
+    end if
+    if( DISPLAY )then
+       open(u, file=fname, status='unknown', position='append')
+       do ix=gx0,gx1                                  ! sorted by depth
+          if( bufg(ix,0) > 0.5d0 ) &
+             write(u,'(F12.4,1X,I6,4(1X,E16.8))') t_fs, ix, bufg(ix,1), bufg(ix,2), bufg(ix,3), bufg(ix,4)
+       end do
+       write(u,*) ' '                                 ! blank line separates time blocks
+       close(u)
+    end if
+    deallocate( buf, bufg )
   end subroutine ttm3_write_profile
 
   !---------------------------------------------------------------------------
@@ -1078,7 +1355,11 @@ contains
     call ttm3_gamma_wp2( Ne_, Te_, Tl_, ge, wp2 )
     if( tp3%coupling_mode == 2 )then              ! ETD (exponential) Drude current integrator
        c1  = exp( -ge*dt )
-       c2  = ( 1.0d0 - c1 )/ge * wp2/( 4.0d0*pi_ )
+       if( ge*dt > 1.0d-6 )then
+          c2 = ( 1.0d0 - c1 )/ge * wp2/( 4.0d0*pi_ )
+       else                                       ! series form: (1-exp(-x))/x -> catastrophic
+          c2 = dt*( 1.0d0 - 0.5d0*ge*dt ) * wp2/( 4.0d0*pi_ )   ! cancellation for x <~ 1e-8
+       end if
     else                                          ! bilinear (Crank-Nicolson), mode 0
        c0  = 1.0d0 + ge*dt/2.0d0
        c1  = ( 1.0d0 - ge*dt/2.0d0 )/c0
@@ -1114,7 +1395,9 @@ contains
        ! Layer C-a/b: band-filled bound interband part + strong carrier-T Drude.
        call ttm3_drude( Ne_, Te_, Th_, Tl_, omega, eps_d, sig_d )
        bf     = max( 1.0d0 - Ne_/tp3%N0, 0.0d0 )
-       eps_re = tp3%eps_bg*bf + eps_d
+       ! band filling depletes only the interband SUSCEPTIBILITY (eps_bg-1), not the
+       ! vacuum contribution: full depletion must leave eps -> 1 + eps_Drude, not eps_Drude.
+       eps_re = 1.0d0 + (tp3%eps_bg-1.0d0)*bf + eps_d
        sig    = tp3%sig_cold*bf + sig_d
     else
        wp2    = 4.0d0*pi_*( Ne_/tp3%mu_e + Nh_/tp3%mu_h )          ! legacy simple Drude

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -110,6 +110,8 @@ module ttm3
   real(8),parameter :: N_floor = 5.4d-15   ! [1/bohr^3] (~3.4e10 cm^-3, reference seed)
   real(8),parameter :: T_clamp = 31.67d0   ! [a.u.] (~1e7 K) numerical temperature cap
   real(8),parameter :: pi_ = 3.14159265358979323846d0
+  real(8),parameter :: hk_kelvin = 3.1577502480407d5   ! a.u. temperature -> Kelvin
+  real(8),parameter :: T_au = 2.48036d5                ! [a.u.time] Auger saturation timescale
 
   character(12) :: ttm3_file = 'ttm3.inp_3tm'
   logical :: DISPLAY=.false.
@@ -537,19 +539,28 @@ contains
     real(8),intent(in)    :: source_, gen_, dt_in
     real(8) :: Ce,Ch,R,geff,q_heat,red_e,red_h,inv_tau
     real(8) :: rate_e,rate_h,Te_star,Th_star,dTl
+    real(8) :: Cef_e,Cef_h,Re,Rh,gap,TlK,Cl_eff,Col
 
     Ce = ttm3_heat_capacity( Te_, tp3%mu_e, Ne_+N_floor )
     Ch = ttm3_heat_capacity( Th_, tp3%mu_h, Nh_+N_floor )
-    inv_tau = 1.0d0/tp3%tau
+    inv_tau = (1.0d0/tp3%tau)/( 1.0d0 + (Ne_*8443.9d0)**2 )      ! density-dependent e-ph relaxation
     geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
-    R    = ( tp3%A_e*Ne_ + tp3%A_h*Nh_ )*Ne_*Nh_
+    Cef_e = tp3%A_e*Ne_*Nh_ ; Re = Ne_*Cef_e/( 1.0d0 + T_au*Cef_e )   ! saturated Auger (e)
+    Cef_h = tp3%A_h*Ne_*Nh_ ; Rh = Nh_*Cef_h/( 1.0d0 + T_au*Cef_h )   ! saturated Auger (h)
+    R    = Re + Rh
     red_e = tp3%mu_h/(tp3%mu_e+tp3%mu_h)
     red_h = tp3%mu_e/(tp3%mu_e+tp3%mu_h)
-    q_heat = max( source_ - geff*tp3%Egap, 0.0d0 )
+    gap = ttm3_gap( Ne_, Tl_ )                                   ! carrier + thermal (Varshni) gap
+    q_heat = max( source_ - geff*gap, 0.0d0 )
+    ! thermal across-gap (collisional) carrier generation, Pauli-blocked
+    Col = 3.6d-5*2.419d-2*0.5d0*( Ne_*exp(-1.5d0*gap/Te_) + Nh_*exp(-1.5d0*gap/Th_) ) &
+          * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
 
-    ! lattice: relaxation heating from the carriers (non-stiff, Cl large), using
-    ! the start-of-step carrier temperatures (energy-conserving relaxation channel)
-    dTl = ( Ce*(Te_-Tl_) + Ch*(Th_-Tl_) )*inv_tau / tp3%Cl
+    ! lattice: relaxation heating from the carriers (non-stiff, Cl large), with the
+    ! temperature-dependent lattice heat capacity Cl(Tl) (= input value at 300 K)
+    TlK    = Tl_*hk_kelvin
+    Cl_eff = tp3%Cl*( 1.978d0 + 3.54d-4*TlK - 3.68d0/(TlK*TlK) )/2.084d0
+    dTl = ( Ce*(Te_-Tl_) + Ch*(Th_-Tl_) )*inv_tau / Cl_eff
 
     ! carrier temperatures: exponential integrator (stiff relaxation + dilution)
     rate_e = inv_tau + geff/(Ne_+N_floor)
@@ -559,9 +570,9 @@ contains
     Te_ = Te_star + (Te_-Te_star)*exp( -rate_e*dt_in )
     Th_ = Th_star + (Th_-Th_star)*exp( -rate_h*dt_in )
 
-    ! carrier densities and lattice: explicit Euler (non-stiff)
-    Ne_ = max( Ne_ + dt_in*(geff - R), 0.0d0 )
-    Nh_ = max( Nh_ + dt_in*(geff - R), 0.0d0 )
+    ! carrier densities and lattice: explicit Euler (non-stiff); +Col thermal generation
+    Ne_ = max( Ne_ + dt_in*(geff - R + Col), 0.0d0 )
+    Nh_ = max( Nh_ + dt_in*(geff - R + Col), 0.0d0 )
     Tl_ = max( Tl_ + dt_in*dTl, 0.0d0 )
 
     ! numerical guard (should not trigger now that the stiff modes are integrated exactly)
@@ -625,7 +636,7 @@ contains
 !$omp parallel do private(m,ix,iy,iz)
        do m=1,nmedia_myrnk
           ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
-          rgap(ix,iy,iz)=ttm3_gap( Ne(ix,iy,iz) )    ! carrier-renormalised band gap
+          rgap(ix,iy,iz)=ttm3_gap( Ne(ix,iy,iz), Tl(ix,iy,iz) )    ! carrier + thermal renormalised gap
        end do
 !$omp end parallel do
        call update_overlap_real8(srg, rg, rgap)
@@ -723,7 +734,7 @@ contains
           rhs_te(ix,iy,iz)=dt*min(tp3%kappa_e/Ce,Dmax)*lTe
           rhs_th(ix,iy,iz)=dt*min(tp3%kappa_e/Ch,Dmax)*lTh
        end if
-       rhs_tl(ix,iy,iz)=dt*min(tp3%kappa_l/tp3%Cl,Dmax)*lTl
+       rhs_tl(ix,iy,iz)=dt*min( tp3%kappa_l*(Tl(ix,iy,iz)*hk_kelvin/300.0d0)**(-1.23d0)/tp3%Cl, Dmax )*lTl  ! Kl(Tl)
     end do
 !$omp end parallel do
 
@@ -900,13 +911,15 @@ contains
   end function ttm3_generation
 
   !---------------------------------------------------------------------------
-  ! Stage 5: band-gap renormalisation (recommended form).
-  ! Eg(Ne) = Egap - dgap_c * Ne^(1/3)  (band-gap shrinkage with carrier density).
-  pure function ttm3_gap( Ne_ ) result( Eg )
+  ! Band-gap renormalisation: carrier-density shrinkage (dgap_c*Ne^(1/3)) plus the
+  ! thermal (Varshni) shift dET = 7.02e-4*TlK^2/(TlK+1108)/E_h [Hartree], TlK = Tl in K.
+  pure function ttm3_gap( Ne_, Tl_ ) result( Eg )
     implicit none
-    real(8),intent(in) :: Ne_
-    real(8) :: Eg
-    Eg = tp3%Egap - tp3%dgap_c*( max(Ne_,0.0d0) )**(1.0d0/3.0d0)
+    real(8),intent(in) :: Ne_, Tl_
+    real(8) :: Eg, TlK
+    TlK = Tl_*hk_kelvin
+    Eg = tp3%Egap - tp3%dgap_c*( max(Ne_,0.0d0) )**(1.0d0/3.0d0) &
+                  - 7.02d-4*TlK*TlK/(TlK+1108.0d0)/27.2114d0
   end function ttm3_gap
 
 end module ttm3

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -69,6 +69,7 @@ module ttm3
   integer :: nmedia_myrnk
   integer :: ninterior
   integer :: is_array(3), ie_array(3)
+  integer :: is_inner(3), ie_inner(3)   ! inner (no-halo) bounds, for the space-charge prefix sum
   integer :: comm
   real(8) :: hgs(3)
   real(8) :: dt
@@ -83,6 +84,11 @@ module ttm3
   real(8),allocatable :: rhs_ne(:,:,:), rhs_nh(:,:,:)
   ! Set A (Fermi transport): per-cell thermal conductivity (electron/hole)
   real(8),allocatable :: Kc_e(:,:,:), Kc_h(:,:,:)
+  ! Set A layer 2 (carrier transport): diffusion Dc, mobility Mc, current components
+  ! Jc(species,dir)=grad N + coefjE grad gap + coefjT grad T, band gap, space-charge field.
+  real(8),allocatable :: Dc_e(:,:,:), Dc_h(:,:,:), Mc_e(:,:,:), Mc_h(:,:,:)
+  real(8),allocatable :: Jc_e(:,:,:,:), Jc_h(:,:,:,:)   ! (i,j,k,dir) -- dir last for contiguous halo
+  real(8),allocatable :: rgap(:,:,:), Efld(:,:,:)       ! local gap, space-charge field (x)
 
   ! Fermi-Dirac integral table F_j(eta).  Indices 1,2,3 = j = -1/2,1/2,3/2 (heat
   ! capacity / chemical potential); indices 4,5 = j = 1,2 (transport: mobility,
@@ -258,6 +264,8 @@ contains
     hgs(:)      = hgs_in(:)
     is_array(:) = is_a(:)
     ie_array(:) = ie(:)
+    is_inner(:) = is(:)
+    ie_inner(:) = ie(:)
 
     ! the temperatures/carriers live only on medium cells (imedia /= 0):
     ! build the local medium-cell index list, mirroring the two-temperature setup
@@ -334,10 +342,16 @@ contains
     allocate( rhs_te(i1:j1,i2:j2,i3:j3), rhs_th(i1:j1,i2:j2,i3:j3), rhs_tl(i1:j1,i2:j2,i3:j3) )
     allocate( rhs_ne(i1:j1,i2:j2,i3:j3), rhs_nh(i1:j1,i2:j2,i3:j3) )
     allocate( Kc_e(i1:j1,i2:j2,i3:j3), Kc_h(i1:j1,i2:j2,i3:j3) )
+    allocate( Dc_e(i1:j1,i2:j2,i3:j3), Dc_h(i1:j1,i2:j2,i3:j3) )
+    allocate( Mc_e(i1:j1,i2:j2,i3:j3), Mc_h(i1:j1,i2:j2,i3:j3) )
+    allocate( Jc_e(i1:j1,i2:j2,i3:j3,3), Jc_h(i1:j1,i2:j2,i3:j3,3) )
+    allocate( rgap(i1:j1,i2:j2,i3:j3), Efld(i1:j1,i2:j2,i3:j3) )
 
     Te = tp3%Tini ; Th = tp3%Tini ; Tl = tp3%Tini
     Ne = N_floor  ; Nh = N_floor
     Kc_e = 0.0d0  ; Kc_h = 0.0d0
+    Dc_e = 0.0d0  ; Dc_h = 0.0d0 ; Mc_e = 0.0d0 ; Mc_h = 0.0d0
+    Jc_e = 0.0d0  ; Jc_h = 0.0d0 ; rgap = tp3%Egap ; Efld = 0.0d0
   end subroutine init_ttm3_alloc
 
   !---------------------------------------------------------------------------
@@ -588,6 +602,8 @@ contains
     integer :: m,ix,iy,iz
     real(8) :: cx,cy,cz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,Dmax,Dd
     real(8) :: gx,gy,gz,gKe,gKh
+    real(8) :: eta,F0,Fm,F12,F1,F2,kT,cjE,cjT,fp4i
+    real(8) :: dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh
     logical :: use_fermi
 
     use_fermi = ( tp3%mob_e0>0.0d0 .or. tp3%mob_h0>0.0d0 )
@@ -596,57 +612,77 @@ contains
 
     cx=1.0d0/hgs(1)**2; cy=1.0d0/hgs(2)**2; cz=1.0d0/hgs(3)**2
     gx=0.5d0/hgs(1); gy=0.5d0/hgs(2); gz=0.5d0/hgs(3)   ! central first-difference
-    ! explicit FTCS diffusion stability: the update u += dt*D*lap with the 7-point
-    ! Laplacian amplifies unless dt*D*2*(cx+cy+cz) <= 1.  Cap every diffusivity so
-    ! this factor stays at 0.5 (safety).  [The previous 0.4*min(h)^2/dt cap was the
-    ! 1-D form; in 3-D it gives dt*D*6/h^2 = 2.4 > 1, i.e. unstable -> Te blow-up.]
+    ! explicit FTCS diffusion stability: cap every diffusivity so dt*D*2*(cx+cy+cz)<=0.5.
     Dmax = 0.5d0/( 2.0d0*dt*(cx+cy+cz) )
     Dd   = min(tp3%Ddiff, Dmax)
+    fp4i = 4.0d0*pi_/tp3%eps_bg                ! 4*pi*inveps (local Gauss term, dEf)
 
-    ! Set A: per-cell Fermi-Dirac thermal conductivity (electron/hole), replacing the
-    ! constant kappa_e in the conduction term.  Density-dependent (K ~ N*mu), so the
-    ! conductivity shrinks with the carrier population, as in the reference.
+    ! Set A: per-cell Fermi-Dirac transport coefficients + carrier current components.
     if( use_fermi )then
 !$omp parallel do private(m,ix,iy,iz)
        do m=1,nmedia_myrnk
           ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
-          Kc_e(ix,iy,iz)=ttm3_thermal_cond( Te(ix,iy,iz),tp3%mu_e,Ne(ix,iy,iz)+N_floor,tp3%mob_e0 )
-          Kc_h(ix,iy,iz)=ttm3_thermal_cond( Th(ix,iy,iz),tp3%mu_h,Nh(ix,iy,iz)+N_floor,tp3%mob_h0 )
+          rgap(ix,iy,iz)=ttm3_gap( Ne(ix,iy,iz) )    ! carrier-renormalised band gap
        end do
 !$omp end parallel do
-       call update_overlap_real8(srg, rg, Kc_e); call update_overlap_real8(srg, rg, Kc_h)
+       call update_overlap_real8(srg, rg, rgap)
     end if
 
     call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
     call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)
     call update_overlap_real8(srg, rg, Tl)
 
-!$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,gKe,gKh)
+    if( use_fermi )then
+       ! pass 1: Fermi coefficients (mobility Mc, diffusion Dc, conductivity Kc) and the
+       ! current components Jc(dir)=grad N + coefjE grad gap + coefjT grad T (per species).
+!$omp parallel do private(m,ix,iy,iz,eta,F0,Fm,F12,F1,F2,kT,cjE,cjT)
+       do m=1,nmedia_myrnk
+          ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+          ! electrons
+          kT=Te(ix,iy,iz); eta=ttm3_chem_pot(kT,tp3%mu_e,Ne(ix,iy,iz)+N_floor)
+          F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
+          F1=ttm3_fermi(4,eta); F2=ttm3_fermi(5,eta)
+          Mc_e(ix,iy,iz)=tp3%mob_e0*F0/F12
+          Dc_e(ix,iy,iz)=tp3%mob_e0*kT*F0/Fm
+          Kc_e(ix,iy,iz)=(6.0d0*F2/F0-4.0d0*(F1/F0)**2)*Ne(ix,iy,iz)*kT*Mc_e(ix,iy,iz)
+          cjE=(tp3%mu_h/(tp3%mu_e+tp3%mu_h))*(Ne(ix,iy,iz)+N_floor)*Fm/F12/kT
+          cjT=(Ne(ix,iy,iz)+N_floor)*(2.0d0*Fm*F1/(F12*F0)-1.5d0)/kT
+          Jc_e(ix,iy,iz,1)=(Ne(ix+1,iy,iz)-Ne(ix-1,iy,iz))*gx + cjE*(rgap(ix+1,iy,iz)-rgap(ix-1,iy,iz))*gx + cjT*(Te(ix+1,iy,iz)-Te(ix-1,iy,iz))*gx
+          Jc_e(ix,iy,iz,2)=(Ne(ix,iy+1,iz)-Ne(ix,iy-1,iz))*gy + cjE*(rgap(ix,iy+1,iz)-rgap(ix,iy-1,iz))*gy + cjT*(Te(ix,iy+1,iz)-Te(ix,iy-1,iz))*gy
+          Jc_e(ix,iy,iz,3)=(Ne(ix,iy,iz+1)-Ne(ix,iy,iz-1))*gz + cjE*(rgap(ix,iy,iz+1)-rgap(ix,iy,iz-1))*gz + cjT*(Te(ix,iy,iz+1)-Te(ix,iy,iz-1))*gz
+          ! holes
+          kT=Th(ix,iy,iz); eta=ttm3_chem_pot(kT,tp3%mu_h,Nh(ix,iy,iz)+N_floor)
+          F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
+          F1=ttm3_fermi(4,eta); F2=ttm3_fermi(5,eta)
+          Mc_h(ix,iy,iz)=tp3%mob_h0*F0/F12
+          Dc_h(ix,iy,iz)=tp3%mob_h0*kT*F0/Fm
+          Kc_h(ix,iy,iz)=(6.0d0*F2/F0-4.0d0*(F1/F0)**2)*Nh(ix,iy,iz)*kT*Mc_h(ix,iy,iz)
+          cjE=(tp3%mu_e/(tp3%mu_e+tp3%mu_h))*(Nh(ix,iy,iz)+N_floor)*Fm/F12/kT
+          cjT=(Nh(ix,iy,iz)+N_floor)*(2.0d0*Fm*F1/(F12*F0)-1.5d0)/kT
+          Jc_h(ix,iy,iz,1)=(Nh(ix+1,iy,iz)-Nh(ix-1,iy,iz))*gx + cjE*(rgap(ix+1,iy,iz)-rgap(ix-1,iy,iz))*gx + cjT*(Th(ix+1,iy,iz)-Th(ix-1,iy,iz))*gx
+          Jc_h(ix,iy,iz,2)=(Nh(ix,iy+1,iz)-Nh(ix,iy-1,iz))*gy + cjE*(rgap(ix,iy+1,iz)-rgap(ix,iy-1,iz))*gy + cjT*(Th(ix,iy+1,iz)-Th(ix,iy-1,iz))*gy
+          Jc_h(ix,iy,iz,3)=(Nh(ix,iy,iz+1)-Nh(ix,iy,iz-1))*gz + cjE*(rgap(ix,iy,iz+1)-rgap(ix,iy,iz-1))*gz + cjT*(Th(ix,iy,iz+1)-Th(ix,iy,iz-1))*gz
+       end do
+!$omp end parallel do
+       call update_overlap_real8(srg, rg, Dc_e); call update_overlap_real8(srg, rg, Dc_h)
+       call update_overlap_real8(srg, rg, Mc_e); call update_overlap_real8(srg, rg, Mc_h)
+       call update_overlap_real8(srg, rg, Kc_e); call update_overlap_real8(srg, rg, Kc_h)
+       call update_overlap_real8(srg, rg, Jc_e(:,:,:,1)); call update_overlap_real8(srg, rg, Jc_e(:,:,:,2)); call update_overlap_real8(srg, rg, Jc_e(:,:,:,3))
+       call update_overlap_real8(srg, rg, Jc_h(:,:,:,1)); call update_overlap_real8(srg, rg, Jc_h(:,:,:,2)); call update_overlap_real8(srg, rg, Jc_h(:,:,:,3))
+       call ttm3_space_charge()                 ! Efld = space-charge field (prefix sum along x)
+    end if
+
+!$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,gKe,gKh, &
+!$omp&                    dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh)
     do m=1,nmedia_myrnk
        ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
-       lNe=(Ne(ix+1,iy,iz)-2*Ne(ix,iy,iz)+Ne(ix-1,iy,iz))*cx &
-          +(Ne(ix,iy+1,iz)-2*Ne(ix,iy,iz)+Ne(ix,iy-1,iz))*cy &
-          +(Ne(ix,iy,iz+1)-2*Ne(ix,iy,iz)+Ne(ix,iy,iz-1))*cz
-       lNh=(Nh(ix+1,iy,iz)-2*Nh(ix,iy,iz)+Nh(ix-1,iy,iz))*cx &
-          +(Nh(ix,iy+1,iz)-2*Nh(ix,iy,iz)+Nh(ix,iy-1,iz))*cy &
-          +(Nh(ix,iy,iz+1)-2*Nh(ix,iy,iz)+Nh(ix,iy,iz-1))*cz
-       lTe=(Te(ix+1,iy,iz)-2*Te(ix,iy,iz)+Te(ix-1,iy,iz))*cx &
-          +(Te(ix,iy+1,iz)-2*Te(ix,iy,iz)+Te(ix,iy-1,iz))*cy &
-          +(Te(ix,iy,iz+1)-2*Te(ix,iy,iz)+Te(ix,iy,iz-1))*cz
-       lTh=(Th(ix+1,iy,iz)-2*Th(ix,iy,iz)+Th(ix-1,iy,iz))*cx &
-          +(Th(ix,iy+1,iz)-2*Th(ix,iy,iz)+Th(ix,iy-1,iz))*cy &
-          +(Th(ix,iy,iz+1)-2*Th(ix,iy,iz)+Th(ix,iy,iz-1))*cz
-       lTl=(Tl(ix+1,iy,iz)-2*Tl(ix,iy,iz)+Tl(ix-1,iy,iz))*cx &
-          +(Tl(ix,iy+1,iz)-2*Tl(ix,iy,iz)+Tl(ix,iy-1,iz))*cy &
-          +(Tl(ix,iy,iz+1)-2*Tl(ix,iy,iz)+Tl(ix,iy,iz-1))*cz
+       lTe=(Te(ix+1,iy,iz)-2*Te(ix,iy,iz)+Te(ix-1,iy,iz))*cx+(Te(ix,iy+1,iz)-2*Te(ix,iy,iz)+Te(ix,iy-1,iz))*cy+(Te(ix,iy,iz+1)-2*Te(ix,iy,iz)+Te(ix,iy,iz-1))*cz
+       lTh=(Th(ix+1,iy,iz)-2*Th(ix,iy,iz)+Th(ix-1,iy,iz))*cx+(Th(ix,iy+1,iz)-2*Th(ix,iy,iz)+Th(ix,iy-1,iz))*cy+(Th(ix,iy,iz+1)-2*Th(ix,iy,iz)+Th(ix,iy,iz-1))*cz
+       lTl=(Tl(ix+1,iy,iz)-2*Tl(ix,iy,iz)+Tl(ix-1,iy,iz))*cx+(Tl(ix,iy+1,iz)-2*Tl(ix,iy,iz)+Tl(ix,iy-1,iz))*cy+(Tl(ix,iy,iz+1)-2*Tl(ix,iy,iz)+Tl(ix,iy,iz-1))*cz
        Ce=ttm3_heat_capacity(Te(ix,iy,iz),tp3%mu_e,Ne(ix,iy,iz)+N_floor)
        Ch=ttm3_heat_capacity(Th(ix,iy,iz),tp3%mu_h,Nh(ix,iy,iz)+N_floor)
-       rhs_ne(ix,iy,iz)=dt*Dd*lNe
-       rhs_nh(ix,iy,iz)=dt*Dd*lNh
        if( use_fermi )then
-          ! heat conduction nab.(K nabT) = nabK.nabT + K lap(T), divided by the heat
-          ! capacity; the K lap(T) diffusivity K/Ce is CFL-capped, the nabK.nabT term
-          ! is a bounded first-order correction.
+          ! heat conduction nab.(K nabT) = nabK.nabT + K lap(T), /Ce (K/Ce CFL-capped)
           gKe=(Kc_e(ix+1,iy,iz)-Kc_e(ix-1,iy,iz))*gx*(Te(ix+1,iy,iz)-Te(ix-1,iy,iz))*gx &
              +(Kc_e(ix,iy+1,iz)-Kc_e(ix,iy-1,iz))*gy*(Te(ix,iy+1,iz)-Te(ix,iy-1,iz))*gy &
              +(Kc_e(ix,iy,iz+1)-Kc_e(ix,iy,iz-1))*gz*(Te(ix,iy,iz+1)-Te(ix,iy,iz-1))*gz
@@ -655,7 +691,23 @@ contains
              +(Kc_h(ix,iy,iz+1)-Kc_h(ix,iy,iz-1))*gz*(Th(ix,iy,iz+1)-Th(ix,iy,iz-1))*gz
           rhs_te(ix,iy,iz)=dt*( min(Kc_e(ix,iy,iz)/Ce,Dmax)*lTe + gKe/Ce )
           rhs_th(ix,iy,iz)=dt*( min(Kc_h(ix,iy,iz)/Ch,Dmax)*lTh + gKh/Ch )
+          ! carrier transport: nab.(Dc Jc) - drift(space charge).  reference Evolve_N_T.
+          dJe=(Jc_e(ix+1,iy,iz,1)-Jc_e(ix-1,iy,iz,1))*gx+(Jc_e(ix,iy+1,iz,2)-Jc_e(ix,iy-1,iz,2))*gy+(Jc_e(ix,iy,iz+1,3)-Jc_e(ix,iy,iz-1,3))*gz
+          dJh=(Jc_h(ix+1,iy,iz,1)-Jc_h(ix-1,iy,iz,1))*gx+(Jc_h(ix,iy+1,iz,2)-Jc_h(ix,iy-1,iz,2))*gy+(Jc_h(ix,iy,iz+1,3)-Jc_h(ix,iy,iz-1,3))*gz
+          gDJe=(Dc_e(ix+1,iy,iz)-Dc_e(ix-1,iy,iz))*gx*Jc_e(ix,iy,iz,1)+(Dc_e(ix,iy+1,iz)-Dc_e(ix,iy-1,iz))*gy*Jc_e(ix,iy,iz,2)+(Dc_e(ix,iy,iz+1)-Dc_e(ix,iy,iz-1))*gz*Jc_e(ix,iy,iz,3)
+          gDJh=(Dc_h(ix+1,iy,iz)-Dc_h(ix-1,iy,iz))*gx*Jc_h(ix,iy,iz,1)+(Dc_h(ix,iy+1,iz)-Dc_h(ix,iy-1,iz))*gy*Jc_h(ix,iy,iz,2)+(Dc_h(ix,iy,iz+1)-Dc_h(ix,iy,iz-1))*gz*Jc_h(ix,iy,iz,3)
+          gMxe=(Mc_e(ix+1,iy,iz)-Mc_e(ix-1,iy,iz))*gx; gNxe=(Ne(ix+1,iy,iz)-Ne(ix-1,iy,iz))*gx
+          gMxh=(Mc_h(ix+1,iy,iz)-Mc_h(ix-1,iy,iz))*gx; gNxh=(Nh(ix+1,iy,iz)-Nh(ix-1,iy,iz))*gx
+          dEf=fp4i*(Ne(ix,iy,iz)-Nh(ix,iy,iz))               ! 4*pi*inveps*(Ne-Nh)
+          nabNe=min(Dc_e(ix,iy,iz),Dmax)*dJe + gDJe - (gMxe*Ne(ix,iy,iz)+Mc_e(ix,iy,iz)*gNxe)*Efld(ix,iy,iz) - Mc_e(ix,iy,iz)*Ne(ix,iy,iz)*dEf
+          nabNh=min(Dc_h(ix,iy,iz),Dmax)*dJh + gDJh + (gMxh*Nh(ix,iy,iz)+Mc_h(ix,iy,iz)*gNxh)*Efld(ix,iy,iz) + Mc_h(ix,iy,iz)*Nh(ix,iy,iz)*dEf
+          rhs_ne(ix,iy,iz)=dt*nabNe
+          rhs_nh(ix,iy,iz)=dt*nabNh
        else
+          lNe=(Ne(ix+1,iy,iz)-2*Ne(ix,iy,iz)+Ne(ix-1,iy,iz))*cx+(Ne(ix,iy+1,iz)-2*Ne(ix,iy,iz)+Ne(ix,iy-1,iz))*cy+(Ne(ix,iy,iz+1)-2*Ne(ix,iy,iz)+Ne(ix,iy,iz-1))*cz
+          lNh=(Nh(ix+1,iy,iz)-2*Nh(ix,iy,iz)+Nh(ix-1,iy,iz))*cx+(Nh(ix,iy+1,iz)-2*Nh(ix,iy,iz)+Nh(ix,iy-1,iz))*cy+(Nh(ix,iy,iz+1)-2*Nh(ix,iy,iz)+Nh(ix,iy,iz-1))*cz
+          rhs_ne(ix,iy,iz)=dt*Dd*lNe
+          rhs_nh(ix,iy,iz)=dt*Dd*lNh
           rhs_te(ix,iy,iz)=dt*min(tp3%kappa_e/Ce,Dmax)*lTe
           rhs_th(ix,iy,iz)=dt*min(tp3%kappa_e/Ch,Dmax)*lTh
        end if
@@ -674,6 +726,35 @@ contains
     end do
 !$omp end parallel do
   end subroutine ttm3_transport
+
+  !---------------------------------------------------------------------------
+  ! Space-charge field Efld along x: Ef(ix)=2*pi*inveps*[sum_{i<ix} - sum_{i>ix}] rho dV,
+  ! rho=(Nh-Ne) (charge density; zero in non-medium cells, Ne=Nh=floor).  Per (iy,iz)
+  ! line, a prefix sum over the local inner x-range (single-domain; nproc_rgrid=1).
+  subroutine ttm3_space_charge()
+    implicit none
+    integer :: ix,iy,iz
+    real(8) :: dV,c2,total,pre,rho
+    dV = hgs(1)*hgs(2)*hgs(3)
+    c2 = 2.0d0*pi_/tp3%eps_bg
+!$omp parallel do collapse(2) private(ix,iy,iz,total,pre,rho)
+    do iz=is_inner(3),ie_inner(3)
+    do iy=is_inner(2),ie_inner(2)
+       total=0.0d0
+       do ix=is_inner(1),ie_inner(1)
+          total=total+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
+       end do
+       pre=0.0d0                                  ! exclusive prefix sum (i<ix)
+       do ix=is_inner(1),ie_inner(1)
+          rho=Nh(ix,iy,iz)-Ne(ix,iy,iz)
+          ! Ef = (left - right)*dV*c2 ;  right = total - pre - rho
+          Efld(ix,iy,iz)=c2*dV*( 2.0d0*pre + rho - total )
+          pre=pre+rho
+       end do
+    end do
+    end do
+!$omp end parallel do
+  end subroutine ttm3_space_charge
 
   !---------------------------------------------------------------------------
   ! Return the five fields at a probe cell, converted to output units.

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -27,6 +27,7 @@ module ttm3
   public :: ttm3_step_cell
   public :: ttm3_get_state
   public :: ttm3_get_max
+  public :: ttm3_get_front
   public :: ttm3_permittivity
   public :: ttm3_eps_sig
   public :: ttm3_ninterior
@@ -626,6 +627,49 @@ contains
     Tl_o=Tl_o*hartree_kelvin_relationship
     Ne_o=Ne_o/cm3_per_bohr3; Nh_o=Nh_o/cm3_per_bohr3
   end subroutine ttm3_get_max
+
+  !---------------------------------------------------------------------------
+  ! State at the illuminated front face: the minimum-ix medium cell nearest the
+  ! transverse centroid.  This is the analogue of the reference's x=0 surface cell
+  ! and, unlike ttm3_get_max, is not biased by the Fabry-Perot field antinodes that
+  ! form inside a finite slab (which sit deeper than the front face and read high).
+  subroutine ttm3_get_front( Te_o, Th_o, Tl_o, Ne_o, Nh_o )
+    implicit none
+    real(8),intent(out) :: Te_o, Th_o, Tl_o, Ne_o, Nh_o   ! [K],[K],[K],[1/cm^3],[1/cm^3]
+    real(8), parameter :: hartree_kelvin_relationship = 3.1577502480407d5
+    real(8), parameter :: atomic_unit_of_length = 5.29177210903d-11
+    real(8) :: cm3_per_bohr3, cy, cz
+    integer :: m,ix,iy,iz,ixmin,nmin,a(3),dbest,d
+    Te_o=tp3%Tini*hartree_kelvin_relationship; Th_o=Te_o; Tl_o=Te_o; Ne_o=0d0; Nh_o=0d0
+    if( nmedia_myrnk<=0 ) return
+    cm3_per_bohr3 = (atomic_unit_of_length*1.0d2)**3
+    ! minimum ix among medium cells = the illuminated face
+    ixmin = ijk_media_myrnk(1,1)
+    do m=2,nmedia_myrnk
+       if( ijk_media_myrnk(1,m) < ixmin ) ixmin = ijk_media_myrnk(1,m)
+    end do
+    ! transverse centroid of that face
+    cy=0d0; cz=0d0; nmin=0
+    do m=1,nmedia_myrnk
+       if( ijk_media_myrnk(1,m)==ixmin )then
+          cy=cy+ijk_media_myrnk(2,m); cz=cz+ijk_media_myrnk(3,m); nmin=nmin+1
+       end if
+    end do
+    cy=cy/max(nmin,1); cz=cz/max(nmin,1)
+    ! face cell nearest the centroid
+    a = ijk_media_myrnk(1:3,1); dbest=huge(0)
+    do m=1,nmedia_myrnk
+       if( ijk_media_myrnk(1,m)==ixmin )then
+          iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+          d = (iy-nint(cy))**2 + (iz-nint(cz))**2
+          if( d<dbest )then; dbest=d; a=ijk_media_myrnk(1:3,m); end if
+       end if
+    end do
+    Te_o=Te(a(1),a(2),a(3))*hartree_kelvin_relationship
+    Th_o=Th(a(1),a(2),a(3))*hartree_kelvin_relationship
+    Tl_o=Tl(a(1),a(2),a(3))*hartree_kelvin_relationship
+    Ne_o=Ne(a(1),a(2),a(3))/cm3_per_bohr3; Nh_o=Nh(a(1),a(2),a(3))/cm3_per_bohr3
+  end subroutine ttm3_get_front
 
   !---------------------------------------------------------------------------
   ! Stage 2: carrier-dependent permittivity (recommended Drude model).

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -29,6 +29,7 @@ module ttm3
   public :: ttm3_get_max
   public :: ttm3_get_front
   public :: ttm3_permittivity
+  public :: ttm3_linear_gen
   public :: ttm3_eps_sig
   public :: ttm3_ninterior
   public :: ttm3_interior_cell
@@ -61,6 +62,12 @@ module ttm3
      ! the constant Ddiff/kappa_e.  Input m^2/Vs, converted to a.u. at read.
      real(8) :: mob_e0   ! electron mobility                 [a.u. = m^2/Vs*2.353e-5]
      real(8) :: mob_h0   ! hole mobility                     [a.u.]
+     ! Layer C-a (ablation): cold bound (interband) conductivity (optional 18th input line).
+     ! When >0, carrier generation is restricted to the BOUND absorption fraction
+     ! sig_bound/(sig_bound+sig_drude) with sig_bound=sig_cold*(1-Ne/N0) (band filling), so
+     ! free-carrier (Drude) absorption heats rather than ionises -> generation self-limits in
+     ! the metallisation regime.  <=0 disables the split (generation = full absorbed power).
+     real(8) :: sig_cold ! cold interband conductivity       [a.u.]         (Layer C-a)
   end type ttm3_param
 
   integer,allocatable :: ijk_media_whole(:,:)
@@ -179,6 +186,8 @@ contains
        tp3%mob_e0 = 0.0d0; tp3%mob_h0 = 0.0d0     ! optional (Set A Fermi transport)
        read(unit,*,iostat=ios) tp3%mob_e0
        read(unit,*,iostat=ios) tp3%mob_h0
+       tp3%sig_cold = 0.0d0                        ! optional (Layer C-a bound/Drude split); <=0 disables
+       read(unit,*,iostat=ios) tp3%sig_cold
        close(unit)
        write(*,*) "Egap[eV]    =",tp3%Egap
        write(*,*) "mu_e        =",tp3%mu_e
@@ -214,6 +223,7 @@ contains
     call comm_bcast(tp3%dgap_c ,comm,0)
     call comm_bcast(tp3%mob_e0 ,comm,0)
     call comm_bcast(tp3%mob_h0 ,comm,0)
+    call comm_bcast(tp3%sig_cold,comm,0)
 
 ! Convert to atomic units
     tp3%Egap = tp3%Egap / hartree_ev
@@ -885,11 +895,44 @@ contains
     implicit none
     real(8),intent(in)  :: Ne_, Nh_, omega
     real(8),intent(out) :: eps_re, sig
-    real(8) :: wp2
-    wp2    = 4.0d0*pi_*( Ne_/tp3%mu_e + Nh_/tp3%mu_h )
-    eps_re = tp3%eps_bg - wp2/(omega*omega)
-    sig    = wp2/(4.0d0*pi_)*(1.0d0/tp3%tau)/(omega*omega)
+    real(8) :: wp2, sig_d, bf
+    wp2   = 4.0d0*pi_*( Ne_/tp3%mu_e + Nh_/tp3%mu_h )
+    sig_d = wp2/(4.0d0*pi_)*(1.0d0/tp3%tau)/(omega*omega)        ! Drude (free-carrier)
+    if( tp3%sig_cold > 0.0d0 )then
+       ! Layer C-a: bound interband part scaled by band filling (1-Ne/N0), plus Drude.
+       bf     = max( 1.0d0 - Ne_/tp3%N0, 0.0d0 )
+       eps_re = tp3%eps_bg*bf - wp2/(omega*omega)
+       sig    = tp3%sig_cold*bf + sig_d
+    else
+       eps_re = tp3%eps_bg - wp2/(omega*omega)
+       sig    = sig_d
+    end if
   end subroutine ttm3_permittivity
+
+  !---------------------------------------------------------------------------
+  ! Layer C-a carrier generation: only the BOUND (interband) fraction of the absorbed
+  ! power creates electron-hole pairs.  sig_bound = sig_cold*(1-Ne/N0) depletes by band
+  ! filling; sig_drude grows with carriers.  As the material metallises the bound fraction
+  ! -> 0, so Drude absorption heats existing carriers instead of ionising -> generation
+  ! self-limits (the reference's metallisation behaviour).  sig_cold<=0 reproduces the old
+  ! "all absorbed power ionises" behaviour exactly (gen = max(power,0)/omega).
+  pure function ttm3_linear_gen( ix, iy, iz, omega, power ) result( gen )
+    implicit none
+    integer,intent(in) :: ix,iy,iz
+    real(8),intent(in) :: omega, power
+    real(8) :: gen, bf, sig_b, sig_d, wp2
+    if( power <= 0.0d0 )then
+       gen = 0.0d0; return
+    end if
+    if( tp3%sig_cold <= 0.0d0 )then
+       gen = power/omega; return                                ! old behaviour (no split)
+    end if
+    bf    = max( 1.0d0 - Ne(ix,iy,iz)/tp3%N0, 0.0d0 )
+    sig_b = tp3%sig_cold*bf
+    wp2   = 4.0d0*pi_*( Ne(ix,iy,iz)/tp3%mu_e + Nh(ix,iy,iz)/tp3%mu_h )
+    sig_d = wp2/(4.0d0*pi_)*(1.0d0/tp3%tau)/(omega*omega)
+    gen   = power/omega * sig_b/( sig_b + sig_d + 1.0d-50 )      ! bound fraction only
+  end function ttm3_linear_gen
 
   !---------------------------------------------------------------------------
   ! Stage 2 back-action: carrier-dependent permittivity/conductivity at a cell

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -341,6 +341,17 @@ contains
        end do
     end do
     f_built = .true.
+    if(DISPLAY)then
+       write(*,'(a)') " ttm3 Fermi heat-capacity self-test  Ce/N = 15/4 F3/2/F1/2 - 9/4 F1/2/F-1/2 :"
+       write(*,'(a,f9.5,a)') "   eta=-20 (non-degenerate): ", &
+            3.75d0*ttm3_fermi(3,-20.0d0)/ttm3_fermi(2,-20.0d0)-2.25d0*ttm3_fermi(2,-20.0d0)/ttm3_fermi(1,-20.0d0), &
+            "  (classical limit 1.5)"
+       write(*,'(a,f9.5)') "   eta=  0                  : ", &
+            3.75d0*ttm3_fermi(3,0.0d0)/ttm3_fermi(2,0.0d0)-2.25d0*ttm3_fermi(2,0.0d0)/ttm3_fermi(1,0.0d0)
+       write(*,'(a,f9.5,a)') "   eta=+20 (degenerate)     : ", &
+            3.75d0*ttm3_fermi(3,20.0d0)/ttm3_fermi(2,20.0d0)-2.25d0*ttm3_fermi(2,20.0d0)/ttm3_fermi(1,20.0d0), &
+            "  (Sommerfeld-suppressed)"
+    end if
   end subroutine ttm3_build_fermi_table
 
   ! F_j(eta) by linear interpolation of the table (jidx: 1=-1/2, 2=1/2, 3=3/2).

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -83,8 +83,12 @@ module ttm3
   real(8)             :: f_tab(0:f_neta,3)
   logical             :: f_built = .false.
 
-  ! density floor to keep the carrier heat capacity well defined
-  real(8),parameter :: N_floor = 1.0d-9    ! [1/bohr^3] (~7e15 cm^-3 carrier floor)
+  ! density floor to keep the carrier heat capacity well defined.  Set to the
+  ! reference's intrinsic seed density Ns ~ 5.4e-15 bohr^-3 (~3.4e10 cm^-3) so the
+  ! carrier population can reach the reference's near-transparent regime; this is
+  ! safe only because the carrier temperatures use the exponential integrator
+  ! (the old RK4 step blew up at such low Ne -- see ttm3_step_cell).
+  real(8),parameter :: N_floor = 5.4d-15   ! [1/bohr^3] (~3.4e10 cm^-3, reference seed)
   real(8),parameter :: T_clamp = 31.67d0   ! [a.u.] (~1e7 K) numerical temperature cap
   real(8),parameter :: pi_ = 3.14159265358979323846d0
 
@@ -446,32 +450,53 @@ contains
   end subroutine ttm3_rates
 
   !---------------------------------------------------------------------------
-  ! One classical Runge-Kutta (RK4) step for a single cell.  Pure scalar core
-  ! with no grid/MPI dependence, so it can be exercised standalone.
+  ! Advance a single cell by one step: an exponential integrator for the (stiff)
+  ! carrier temperatures and explicit Euler for the (non-stiff) densities/lattice.
+  ! The carrier-temperature ODE is a relaxation toward the diluted+heated target
+  !   dTe/dt = -rate_e*(Te - Te_star),   rate_e = 1/tau + geff/Ne,
+  !   Te_star = Tl + (red_e*q_heat/Ce)/rate_e
+  ! whose rate geff/Ne (dilution by cold, freshly-generated carriers) can far
+  ! exceed 1/dt at low Ne.  The exact update Te <- Te_star+(Te-Te_star)*exp(-rate_e*dt)
+  ! is unconditionally stable there (RK4 was not -- it blew up once Ne was small),
+  ! and since Te_star -> Tl + (2/3)red_e*(hw-Egap) as geff/Ne dominates, the hot-
+  ! carrier fixed point is reached without a clamp.  This removes the stiffness
+  ! limit on the carrier-density floor, so Ne can reach the reference's near-
+  ! transparent regime.
   subroutine ttm3_step_cell( Te_,Th_,Tl_,Ne_,Nh_, source_, gen_, dt_in )
     implicit none
     real(8),intent(inout) :: Te_,Th_,Tl_,Ne_,Nh_
     real(8),intent(in)    :: source_, gen_, dt_in
-    real(8) :: k1(5),k2(5),k3(5),k4(5)
-    real(8) :: y(5), yt(5)
+    real(8) :: Ce,Ch,R,geff,q_heat,red_e,red_h,inv_tau
+    real(8) :: rate_e,rate_h,Te_star,Th_star,dTl
 
-    y = (/Te_,Th_,Tl_,Ne_,Nh_/)
+    Ce = ttm3_heat_capacity( Te_, tp3%mu_e, Ne_+N_floor )
+    Ch = ttm3_heat_capacity( Th_, tp3%mu_h, Nh_+N_floor )
+    inv_tau = 1.0d0/tp3%tau
+    geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
+    R    = ( tp3%A_e*Ne_ + tp3%A_h*Nh_ )*Ne_*Nh_
+    red_e = tp3%mu_h/(tp3%mu_e+tp3%mu_h)
+    red_h = tp3%mu_e/(tp3%mu_e+tp3%mu_h)
+    q_heat = max( source_ - geff*tp3%Egap, 0.0d0 )
 
-    call ttm3_rates( y(1),y(2),y(3),y(4),y(5), source_,gen_, k1(1),k1(2),k1(3),k1(4),k1(5) )
-    yt = y + 0.5d0*dt_in*k1
-    call ttm3_rates( yt(1),yt(2),yt(3),yt(4),yt(5), source_,gen_, k2(1),k2(2),k2(3),k2(4),k2(5) )
-    yt = y + 0.5d0*dt_in*k2
-    call ttm3_rates( yt(1),yt(2),yt(3),yt(4),yt(5), source_,gen_, k3(1),k3(2),k3(3),k3(4),k3(5) )
-    yt = y + dt_in*k3
-    call ttm3_rates( yt(1),yt(2),yt(3),yt(4),yt(5), source_,gen_, k4(1),k4(2),k4(3),k4(4),k4(5) )
+    ! lattice: relaxation heating from the carriers (non-stiff, Cl large), using
+    ! the start-of-step carrier temperatures (energy-conserving relaxation channel)
+    dTl = ( Ce*(Te_-Tl_) + Ch*(Th_-Tl_) )*inv_tau / tp3%Cl
 
-    y = y + (dt_in/6.0d0)*( k1 + 2.0d0*k2 + 2.0d0*k3 + k4 )
+    ! carrier temperatures: exponential integrator (stiff relaxation + dilution)
+    rate_e = inv_tau + geff/(Ne_+N_floor)
+    rate_h = inv_tau + geff/(Nh_+N_floor)
+    Te_star = Tl_ + (red_e*q_heat/Ce)/rate_e
+    Th_star = Tl_ + (red_h*q_heat/Ch)/rate_h
+    Te_ = Te_star + (Te_-Te_star)*exp( -rate_e*dt_in )
+    Th_ = Th_star + (Th_-Th_star)*exp( -rate_h*dt_in )
 
-    ! numerical guard: clamp temperatures to a finite range so the coupled run
-    ! stays bounded where the recommended source/C heating is stiff at low Ne
-    ! (the exact Fermi heat capacity removes this stiffness; see the design notes).
-    Te_=min(max(y(1),0.0d0),T_clamp); Th_=min(max(y(2),0.0d0),T_clamp); Tl_=max(y(3),0.0d0)
-    Ne_=max(y(4),0.0d0); Nh_=max(y(5),0.0d0)
+    ! carrier densities and lattice: explicit Euler (non-stiff)
+    Ne_ = max( Ne_ + dt_in*(geff - R), 0.0d0 )
+    Nh_ = max( Nh_ + dt_in*(geff - R), 0.0d0 )
+    Tl_ = max( Tl_ + dt_in*dTl, 0.0d0 )
+
+    ! numerical guard (should not trigger now that the stiff modes are integrated exactly)
+    Te_ = min(max(Te_,0.0d0),T_clamp); Th_ = min(max(Th_,0.0d0),T_clamp)
   end subroutine ttm3_step_cell
 
   !---------------------------------------------------------------------------

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -598,11 +598,21 @@ contains
     Cl_eff = tp3%Cl*( 1.978d0 + 3.54d-4*TlK - 3.68d0/(TlK*TlK) )/2.084d0
     dTl = ( Ce*(Te_-Tl_) + Ch*(Th_-Tl_) )*inv_tau / Cl_eff
 
-    ! carrier temperatures: exponential integrator (stiff relaxation + dilution)
-    rate_e = inv_tau + geff/(Ne_+N_floor)
-    rate_h = inv_tau + geff/(Nh_+N_floor)
-    Te_star = Tl_ + (red_e*q_heat/Ce)/rate_e
-    Th_star = Tl_ + (red_h*q_heat/Ch)/rate_h
+    ! carrier temperatures: exponential integrator (stiff relaxation + dilution).
+    ! Carrier-number energy bookkeeping, matching the reference Tnt = -(dN/dt)*Cnteh
+    ! with Cnteh = (thermal energy per carrier) + red*gap:
+    !  - ALL freshly generated carriers (optical geff AND collisional Col) are born
+    !    near Tl and dilute the carrier temperature -> dilution rate (geff+Col)/N;
+    !  - impact ionization (Col) draws the carriers' share red*gap from the carrier
+    !    kinetic energy to pay for each new pair (an energy SINK).  Col ~ exp(-gap/Te)
+    !    grows with Te, so this is a negative feedback that self-limits Te -- the
+    !    physical cap, vs the unphysical free-carrier heating runaway when it is left
+    !    out (Col was previously fed into dN/dt only, not the energy balance);
+    !  - Auger recombination (R) returns red*gap to the carriers (recombination heating).
+    rate_e = inv_tau + (geff+Col)/(Ne_+N_floor)
+    rate_h = inv_tau + (geff+Col)/(Nh_+N_floor)
+    Te_star = Tl_ + ( red_e*( q_heat + gap*(R-Col) )/Ce )/rate_e
+    Th_star = Tl_ + ( red_h*( q_heat + gap*(R-Col) )/Ch )/rate_h
     Te_ = Te_star + (Te_-Te_star)*exp( -rate_e*dt_in )
     Th_ = Th_star + (Th_-Th_star)*exp( -rate_h*dt_in )
 

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -1,0 +1,302 @@
+module ttm3
+!
+! Three-temperature + carrier model (Stage 1: local rate-equation engine).
+!
+! State per cell: electron temperature Te, hole temperature Th, lattice
+! temperature Tl, electron density Ne, hole density Nh.  Transport is OFF in
+! this stage (local ODEs only); the sendrecv-grid argument of ttm3_main is
+! reserved for the transport stage.  Maxwell coupling is also a later stage:
+! here the heating source and carrier generation are inputs.
+!
+! Recommended first model (documented for review):
+!   * classical carrier heat capacity C = (3/2) N  (atomic units, kB=1),
+!   * energy-conserving carrier<->lattice relaxation with time constant tau,
+!   * standard Auger recombination R = (A_e Ne + A_h Nh) Ne Nh (removes e-h
+!     pairs, so dNe=dNh for recombination).
+! The exact reference heat capacities (from Fermi statistics) and the exact
+! relaxation/Auger split are a coefficient-level refinement for a later pass;
+! they do not change this module's structure or interfaces.
+!
+  implicit none
+  private
+  public :: init_ttm3_parameters
+  public :: init_ttm3_grid
+  public :: init_ttm3_alloc
+  public :: ttm3_main
+  public :: ttm3_step_cell
+  public :: ttm3_get_state
+
+  logical,public :: use_ttm3=.false.
+
+  ! material parameters
+  type ttm3_param
+     real(8) :: Egap     ! band gap                        [Hartree]
+     real(8) :: mu_e     ! electron effective mass ratio    [-]
+     real(8) :: mu_h     ! hole effective mass ratio        [-]
+     real(8) :: A_e      ! electron Auger coefficient        [bohr^6 / a.u.time]
+     real(8) :: A_h      ! hole Auger coefficient            [bohr^6 / a.u.time]
+     real(8) :: tau      ! carrier-lattice relaxation time   [a.u.time]
+     real(8) :: Cl       ! lattice heat capacity             [a.u. / (volume * temperature)]
+     real(8) :: Tini     ! initial temperature (Te=Th=Tl)    [a.u.]
+  end type ttm3_param
+
+  integer,allocatable :: ijk_media_whole(:,:)
+  integer,allocatable :: ijk_media_myrnk(:,:)
+  integer :: nmedia_myrnk
+  integer :: is_array(3), ie_array(3)
+  integer :: comm
+  real(8) :: hgs(3)
+  real(8) :: dt
+
+  type(ttm3_param) :: tp3
+
+  ! state and Runge-Kutta stage buffers
+  real(8),allocatable :: Te(:,:,:), Th(:,:,:), Tl(:,:,:)
+  real(8),allocatable :: Ne(:,:,:), Nh(:,:,:)
+
+  ! density floor to keep the carrier heat capacity well defined
+  real(8),parameter :: N_floor = 1.0d-24   ! [1/bohr^3]
+
+  character(12) :: ttm3_file = 'ttm3.inp_3tm'
+  logical :: DISPLAY=.false.
+
+contains
+
+  !---------------------------------------------------------------------------
+  subroutine init_ttm3_parameters( dt_em )
+    use communication, only: comm_get_globalinfo, comm_is_root, comm_bcast
+    implicit none
+    real(8), intent(in) :: dt_em
+    integer, parameter :: unit=1112
+    integer :: npid, nprocs
+    logical :: flag
+    real(8), parameter :: atomic_unit_of_length = 5.29177210903d-11 ! [m]
+    real(8), parameter :: hartree_joule_relationship = 4.3597447222071d-18 ! [J]
+    real(8), parameter :: hartree_kelvin_relationship = 3.1577502480407d5 ! [K]
+    real(8), parameter :: atomic_unit_of_time = 2.4188843265857d-17 ! [s]
+    real(8), parameter :: hartree_ev = 27.211386245988d0 ! [eV]
+
+    call comm_get_globalinfo( comm, npid, nprocs )
+    DISPLAY = comm_is_root(npid)
+
+    if ( DISPLAY ) write(*,'(a60)') repeat("-",30)//" init_ttm3_parameters(start)"
+
+    inquire( FILE=ttm3_file, EXIST=flag )
+    if( .not.flag )then
+       if( DISPLAY )then
+          write(*,*) "No three-temperature file ("//ttm3_file//")."
+          write(*,*) "Three-temperature + carrier model is not used."
+          write(*,'(a60)') repeat("-",30)//" init_ttm3_parameters(end  )"
+       end if
+       return
+    else
+       if( DISPLAY )then
+          write(*,*) "Three-temperature file ("//ttm3_file//") is found."
+          write(*,*) "Calculation uses the three-temperature + carrier model."
+       end if
+       use_ttm3 = .true.
+    end if
+
+    dt = dt_em
+
+! Input parameters (one value per line):
+!   Egap [eV], mu_e [-], mu_h [-], A_e [cm^6/s], A_h [cm^6/s],
+!   tau [fs], Cl [J/(m^3 K)], Tini [K]
+    if( comm_is_root(npid) )then
+       open(unit, file=ttm3_file, status='old')
+       read(unit,*) tp3%Egap
+       read(unit,*) tp3%mu_e
+       read(unit,*) tp3%mu_h
+       read(unit,*) tp3%A_e
+       read(unit,*) tp3%A_h
+       read(unit,*) tp3%tau
+       read(unit,*) tp3%Cl
+       read(unit,*) tp3%Tini
+       close(unit)
+       write(*,*) "Egap[eV]    =",tp3%Egap
+       write(*,*) "mu_e        =",tp3%mu_e
+       write(*,*) "mu_h        =",tp3%mu_h
+       write(*,*) "A_e[cm6/s]  =",tp3%A_e
+       write(*,*) "A_h[cm6/s]  =",tp3%A_h
+       write(*,*) "tau[fs]     =",tp3%tau
+       write(*,*) "Cl[J/m3K]   =",tp3%Cl
+       write(*,*) "Tini[K]     =",tp3%Tini
+    end if
+
+    call comm_bcast(tp3%Egap,comm,0)
+    call comm_bcast(tp3%mu_e,comm,0)
+    call comm_bcast(tp3%mu_h,comm,0)
+    call comm_bcast(tp3%A_e ,comm,0)
+    call comm_bcast(tp3%A_h ,comm,0)
+    call comm_bcast(tp3%tau ,comm,0)
+    call comm_bcast(tp3%Cl  ,comm,0)
+    call comm_bcast(tp3%Tini,comm,0)
+
+! Convert to atomic units
+    tp3%Egap = tp3%Egap / hartree_ev
+    ! Auger coefficient [cm^6/s] -> [bohr^6 / a.u.time]
+    tp3%A_e  = tp3%A_e * (1.0d-2/atomic_unit_of_length)**6 * atomic_unit_of_time
+    tp3%A_h  = tp3%A_h * (1.0d-2/atomic_unit_of_length)**6 * atomic_unit_of_time
+    tp3%tau  = tp3%tau * 1.0d-15 / atomic_unit_of_time
+    ! lattice heat capacity [J/(m^3 K)] -> a.u. (same as the two-temperature model)
+    tp3%Cl   = tp3%Cl / hartree_joule_relationship &
+                       * atomic_unit_of_length**3 &
+                       * hartree_kelvin_relationship
+    tp3%Tini = tp3%Tini / hartree_kelvin_relationship
+    ! mu_e, mu_h are dimensionless
+
+    if ( DISPLAY ) write(*,'(a60)') repeat("-",30)//" init_ttm3_parameters(end  )"
+
+  end subroutine init_ttm3_parameters
+
+  !---------------------------------------------------------------------------
+  subroutine init_ttm3_grid( hgs_in, is_a, is, ie, imedia )
+    implicit none
+    real(8),intent(in) :: hgs_in(3)
+    integer,intent(in) :: is_a(3), is(3), ie(3)
+    integer,intent(in) :: imedia(is_a(1):,is_a(2):,is_a(3):)
+    integer :: ix,iy,iz,m
+
+    hgs(:)      = hgs_in(:)
+    is_array(:) = is_a(:)
+    ie_array(:) = ie(:)
+
+    ! the temperatures/carriers live only on medium cells (imedia /= 0):
+    ! build the local medium-cell index list, mirroring the two-temperature setup
+    m = 0
+    do iz=is(3),ie(3)
+    do iy=is(2),ie(2)
+    do ix=is(1),ie(1)
+       if( imedia(ix,iy,iz) /= 0 ) m = m + 1
+    end do
+    end do
+    end do
+    nmedia_myrnk = m
+    if( allocated(ijk_media_myrnk) ) deallocate(ijk_media_myrnk)
+    allocate( ijk_media_myrnk(3,max(m,1)) )
+    m = 0
+    do iz=is(3),ie(3)
+    do iy=is(2),ie(2)
+    do ix=is(1),ie(1)
+       if( imedia(ix,iy,iz) /= 0 )then
+          m = m + 1
+          ijk_media_myrnk(1:3,m) = (/ix,iy,iz/)
+       end if
+    end do
+    end do
+    end do
+  end subroutine init_ttm3_grid
+
+  !---------------------------------------------------------------------------
+  subroutine init_ttm3_alloc( srg, rg )
+    use structures, only: s_rgrid, s_sendrecv_grid
+    implicit none
+    type(s_sendrecv_grid), intent(inout) :: srg
+    type(s_rgrid),         intent(in)    :: rg
+    integer :: i1,i2,i3,j1,j2,j3
+
+    i1=rg%is_array(1); j1=rg%ie_array(1)
+    i2=rg%is_array(2); j2=rg%ie_array(2)
+    i3=rg%is_array(3); j3=rg%ie_array(3)
+
+    allocate( Te(i1:j1,i2:j2,i3:j3), Th(i1:j1,i2:j2,i3:j3), Tl(i1:j1,i2:j2,i3:j3) )
+    allocate( Ne(i1:j1,i2:j2,i3:j3), Nh(i1:j1,i2:j2,i3:j3) )
+
+    Te = tp3%Tini ; Th = tp3%Tini ; Tl = tp3%Tini
+    Ne = N_floor  ; Nh = N_floor
+  end subroutine init_ttm3_alloc
+
+  !---------------------------------------------------------------------------
+  ! Local rates for one cell (the right-hand side of the five ODEs).
+  pure subroutine ttm3_rates( Te_,Th_,Tl_,Ne_,Nh_, source_, gen_, &
+                              dTe,dTh,dTl,dNe,dNh )
+    implicit none
+    real(8),intent(in)  :: Te_,Th_,Tl_,Ne_,Nh_, source_, gen_
+    real(8),intent(out) :: dTe,dTh,dTl,dNe,dNh
+    real(8) :: Ce,Ch,R,inv_tau
+
+    ! classical carrier heat capacities (floored to stay well defined)
+    Ce = 1.5d0*(Ne_ + N_floor)
+    Ch = 1.5d0*(Nh_ + N_floor)
+    inv_tau = 1.0d0/tp3%tau
+
+    ! standard Auger recombination (removes electron-hole pairs)
+    R = ( tp3%A_e*Ne_ + tp3%A_h*Nh_ )*Ne_*Nh_
+
+    ! carrier densities: generation - recombination (charge-neutral)
+    dNe = gen_ - R
+    dNh = gen_ - R
+
+    ! temperatures: relaxation toward the lattice + heating source (split e/h).
+    ! The lattice term is energy-conserving: the energy lost by the carriers
+    ! (Ce*(Te-Tl) + Ch*(Th-Tl))/tau is deposited into the lattice / Cl.
+    dTe = -(Te_-Tl_)*inv_tau + 0.5d0*source_/Ce
+    dTh = -(Th_-Tl_)*inv_tau + 0.5d0*source_/Ch
+    dTl = ( Ce*(Te_-Tl_) + Ch*(Th_-Tl_) )*inv_tau / tp3%Cl
+  end subroutine ttm3_rates
+
+  !---------------------------------------------------------------------------
+  ! One classical Runge-Kutta (RK4) step for a single cell.  Pure scalar core
+  ! with no grid/MPI dependence, so it can be exercised standalone.
+  subroutine ttm3_step_cell( Te_,Th_,Tl_,Ne_,Nh_, source_, gen_, dt_in )
+    implicit none
+    real(8),intent(inout) :: Te_,Th_,Tl_,Ne_,Nh_
+    real(8),intent(in)    :: source_, gen_, dt_in
+    real(8) :: k1(5),k2(5),k3(5),k4(5)
+    real(8) :: y(5), yt(5)
+
+    y = (/Te_,Th_,Tl_,Ne_,Nh_/)
+
+    call ttm3_rates( y(1),y(2),y(3),y(4),y(5), source_,gen_, k1(1),k1(2),k1(3),k1(4),k1(5) )
+    yt = y + 0.5d0*dt_in*k1
+    call ttm3_rates( yt(1),yt(2),yt(3),yt(4),yt(5), source_,gen_, k2(1),k2(2),k2(3),k2(4),k2(5) )
+    yt = y + 0.5d0*dt_in*k2
+    call ttm3_rates( yt(1),yt(2),yt(3),yt(4),yt(5), source_,gen_, k3(1),k3(2),k3(3),k3(4),k3(5) )
+    yt = y + dt_in*k3
+    call ttm3_rates( yt(1),yt(2),yt(3),yt(4),yt(5), source_,gen_, k4(1),k4(2),k4(3),k4(4),k4(5) )
+
+    y = y + (dt_in/6.0d0)*( k1 + 2.0d0*k2 + 2.0d0*k3 + k4 )
+
+    Te_=y(1); Th_=y(2); Tl_=y(3); Ne_=max(y(4),0.0d0); Nh_=max(y(5),0.0d0)
+  end subroutine ttm3_step_cell
+
+  !---------------------------------------------------------------------------
+  ! Advance every medium cell by one time step (transport OFF).
+  subroutine ttm3_main( srg, rg, source, gen )
+    use structures, only: s_rgrid, s_sendrecv_grid
+    implicit none
+    type(s_sendrecv_grid), intent(inout) :: srg     ! reserved for the transport stage
+    type(s_rgrid),         intent(in)    :: rg
+    real(8),intent(in) :: source(rg%is_array(1):,rg%is_array(2):,rg%is_array(3):)
+    real(8),intent(in) :: gen   (rg%is_array(1):,rg%is_array(2):,rg%is_array(3):)
+    integer :: m,ix,iy,iz
+
+!$omp parallel do private(m,ix,iy,iz)
+    do m=1,nmedia_myrnk
+       ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+       call ttm3_step_cell( Te(ix,iy,iz),Th(ix,iy,iz),Tl(ix,iy,iz), &
+                            Ne(ix,iy,iz),Nh(ix,iy,iz), &
+                            source(ix,iy,iz), gen(ix,iy,iz), dt )
+    end do
+!$omp end parallel do
+  end subroutine ttm3_main
+
+  !---------------------------------------------------------------------------
+  ! Return the five fields at a probe cell, converted to output units.
+  subroutine ttm3_get_state( a, Te_o, Th_o, Tl_o, Ne_o, Nh_o )
+    implicit none
+    integer,intent(in)  :: a(3)
+    real(8),intent(out) :: Te_o, Th_o, Tl_o, Ne_o, Nh_o   ! [K], [K], [K], [1/cm^3], [1/cm^3]
+    real(8), parameter :: hartree_kelvin_relationship = 3.1577502480407d5 ! [K]
+    real(8), parameter :: atomic_unit_of_length = 5.29177210903d-11 ! [m]
+    real(8) :: cm3_per_bohr3
+
+    cm3_per_bohr3 = (atomic_unit_of_length*1.0d2)**3   ! (bohr in cm)^3
+    Te_o = Te(a(1),a(2),a(3)) * hartree_kelvin_relationship
+    Th_o = Th(a(1),a(2),a(3)) * hartree_kelvin_relationship
+    Tl_o = Tl(a(1),a(2),a(3)) * hartree_kelvin_relationship
+    Ne_o = Ne(a(1),a(2),a(3)) / cm3_per_bohr3
+    Nh_o = Nh(a(1),a(2),a(3)) / cm3_per_bohr3
+  end subroutine ttm3_get_state
+
+end module ttm3

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -271,25 +271,34 @@ contains
     implicit none
     real(8),intent(in)  :: Te_,Th_,Tl_,Ne_,Nh_, source_, gen_
     real(8),intent(out) :: dTe,dTh,dTl,dNe,dNh
-    real(8) :: Ce,Ch,R,inv_tau
+    real(8) :: Ce,Ch,R,inv_tau,geff,q_heat
 
     ! classical carrier heat capacities (floored to stay well defined)
     Ce = 1.5d0*(Ne_ + N_floor)
     Ch = 1.5d0*(Nh_ + N_floor)
     inv_tau = 1.0d0/tp3%tau
 
+    ! generation, saturated at the reference/atomic density N0 (cannot exceed it)
+    geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
+
     ! standard Auger recombination (removes electron-hole pairs)
     R = ( tp3%A_e*Ne_ + tp3%A_h*Nh_ )*Ne_*Nh_
 
     ! carrier densities: generation - recombination (charge-neutral)
-    dNe = gen_ - R
-    dNh = gen_ - R
+    dNe = geff - R
+    dNh = geff - R
 
-    ! temperatures: relaxation toward the lattice + heating source (split e/h).
-    ! The lattice term is energy-conserving: the energy lost by the carriers
-    ! (Ce*(Te-Tl) + Ch*(Th-Tl))/tau is deposited into the lattice / Cl.
-    dTe = -(Te_-Tl_)*inv_tau + 0.5d0*source_/Ce
-    dTh = -(Th_-Tl_)*inv_tau + 0.5d0*source_/Ch
+    ! only the absorbed power in excess of the gap cost (Egap per generated pair)
+    ! becomes carrier kinetic energy (heating); the rest creates the pair
+    q_heat = 0.5d0*max( source_ - geff*tp3%Egap, 0.0d0 )
+
+    ! carrier temperatures: relaxation toward the lattice + bounded heating +
+    ! dilution by freshly generated carriers (born near the lattice temperature),
+    ! which caps Te near the hot-carrier value (~(hw-Egap)) instead of diverging.
+    dTe = -(Te_-Tl_)*inv_tau + (geff/(Ne_+N_floor))*(Tl_-Te_) + q_heat/Ce
+    dTh = -(Th_-Tl_)*inv_tau + (geff/(Nh_+N_floor))*(Tl_-Th_) + q_heat/Ch
+
+    ! lattice receives the energy lost by the carriers (energy-conserving coupling)
     dTl = ( Ce*(Te_-Tl_) + Ch*(Th_-Tl_) )*inv_tau / tp3%Cl
   end subroutine ttm3_rates
 
@@ -357,11 +366,14 @@ contains
     type(s_sendrecv_grid), intent(inout) :: srg
     type(s_rgrid),         intent(in)    :: rg
     integer :: m,ix,iy,iz
-    real(8) :: cx,cy,cz,Ce,Ch,lNe,lNh,lTe,lTh,lTl
+    real(8) :: cx,cy,cz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,Dmax,Dd
 
     if( tp3%Ddiff<=0.0d0 .and. tp3%kappa_e<=0.0d0 .and. tp3%kappa_l<=0.0d0 ) return
 
     cx=1.0d0/hgs(1)**2; cy=1.0d0/hgs(2)**2; cz=1.0d0/hgs(3)**2
+    ! explicit-scheme stability cap: cap every diffusivity at 0.4*h^2/dt (CFL)
+    Dmax = 0.4d0*min(hgs(1),hgs(2),hgs(3))**2/dt
+    Dd   = min(tp3%Ddiff, Dmax)
     call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
     call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)
     call update_overlap_real8(srg, rg, Tl)
@@ -385,11 +397,11 @@ contains
           +(Tl(ix,iy+1,iz)-2*Tl(ix,iy,iz)+Tl(ix,iy-1,iz))*cy &
           +(Tl(ix,iy,iz+1)-2*Tl(ix,iy,iz)+Tl(ix,iy,iz-1))*cz
        Ce=1.5d0*(Ne(ix,iy,iz)+N_floor); Ch=1.5d0*(Nh(ix,iy,iz)+N_floor)
-       rhs_ne(ix,iy,iz)=dt*tp3%Ddiff*lNe
-       rhs_nh(ix,iy,iz)=dt*tp3%Ddiff*lNh
-       rhs_te(ix,iy,iz)=dt*tp3%kappa_e/Ce*lTe
-       rhs_th(ix,iy,iz)=dt*tp3%kappa_e/Ch*lTh
-       rhs_tl(ix,iy,iz)=dt*tp3%kappa_l/tp3%Cl*lTl
+       rhs_ne(ix,iy,iz)=dt*Dd*lNe
+       rhs_nh(ix,iy,iz)=dt*Dd*lNh
+       rhs_te(ix,iy,iz)=dt*min(tp3%kappa_e/Ce,Dmax)*lTe
+       rhs_th(ix,iy,iz)=dt*min(tp3%kappa_e/Ch,Dmax)*lTh
+       rhs_tl(ix,iy,iz)=dt*min(tp3%kappa_l/tp3%Cl,Dmax)*lTl
     end do
 !$omp end parallel do
 

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -28,6 +28,7 @@ module ttm3
   public :: ttm3_get_state
   public :: ttm3_get_max
   public :: ttm3_get_front
+  public :: ttm3_front_ijk
   public :: ttm3_permittivity
   public :: ttm3_linear_gen
   public :: ttm3_eps_sig
@@ -892,6 +893,38 @@ contains
     Tl_o=Tl(a(1),a(2),a(3))*hartree_kelvin_relationship
     Ne_o=Ne(a(1),a(2),a(3))/cm3_per_bohr3; Nh_o=Nh(a(1),a(2),a(3))/cm3_per_bohr3
   end subroutine ttm3_get_front
+
+  ! Index of the illuminated front-face medium cell (same selection as ttm3_get_front).
+  ! Diagnostic: lets the caller read the field envelope there to compare the surface
+  ! intensity against the reference's out_all(6).
+  subroutine ttm3_front_ijk( jx, jy, jz )
+    implicit none
+    integer,intent(out) :: jx,jy,jz
+    integer :: m,iy,iz,ixmin,nmin,a(3),dbest,d
+    real(8) :: cy,cz
+    jx=is_inner(1); jy=is_inner(2); jz=is_inner(3)
+    if( nmedia_myrnk<=0 ) return
+    ixmin = ijk_media_myrnk(1,1)
+    do m=2,nmedia_myrnk
+       if( ijk_media_myrnk(1,m) < ixmin ) ixmin = ijk_media_myrnk(1,m)
+    end do
+    cy=0d0; cz=0d0; nmin=0
+    do m=1,nmedia_myrnk
+       if( ijk_media_myrnk(1,m)==ixmin )then
+          cy=cy+ijk_media_myrnk(2,m); cz=cz+ijk_media_myrnk(3,m); nmin=nmin+1
+       end if
+    end do
+    cy=cy/max(nmin,1); cz=cz/max(nmin,1)
+    a = ijk_media_myrnk(1:3,1); dbest=huge(0)
+    do m=1,nmedia_myrnk
+       if( ijk_media_myrnk(1,m)==ixmin )then
+          iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+          d = (iy-nint(cy))**2 + (iz-nint(cz))**2
+          if( d<dbest )then; dbest=d; a=ijk_media_myrnk(1:3,m); end if
+       end if
+    end do
+    jx=a(1); jy=a(2); jz=a(3)
+  end subroutine ttm3_front_ijk
 
   !---------------------------------------------------------------------------
   ! Stage 2: carrier-dependent permittivity (recommended Drude model).

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -55,6 +55,12 @@ module ttm3
      real(8) :: kappa_e  ! carrier thermal conductivity      [a.u.]         (Stage 4)
      real(8) :: kappa_l  ! lattice thermal conductivity      [a.u.]         (Stage 4)
      real(8) :: dgap_c   ! gap-renormalisation coefficient   [a.u.]         (Stage 5)
+     ! Set A (Fermi transport): carrier mobilities (optional 16th,17th input lines).
+     ! When >0 the diffusion/conductivity are computed from the Fermi-Dirac integrals
+     ! (mu=mob0*F0/F12, D=mob0*Te*F0/Fm, K=(6 F2/F0-4(F1/F0)^2) N Te mu), superseding
+     ! the constant Ddiff/kappa_e.  Input m^2/Vs, converted to a.u. at read.
+     real(8) :: mob_e0   ! electron mobility                 [a.u. = m^2/Vs*2.353e-5]
+     real(8) :: mob_h0   ! hole mobility                     [a.u.]
   end type ttm3_param
 
   integer,allocatable :: ijk_media_whole(:,:)
@@ -75,6 +81,8 @@ module ttm3
   ! transport increment buffers (Stage 4)
   real(8),allocatable :: rhs_te(:,:,:), rhs_th(:,:,:), rhs_tl(:,:,:)
   real(8),allocatable :: rhs_ne(:,:,:), rhs_nh(:,:,:)
+  ! Set A (Fermi transport): per-cell thermal conductivity (electron/hole)
+  real(8),allocatable :: Kc_e(:,:,:), Kc_h(:,:,:)
 
   ! Fermi-Dirac integral table F_j(eta).  Indices 1,2,3 = j = -1/2,1/2,3/2 (heat
   ! capacity / chemical potential); indices 4,5 = j = 1,2 (transport: mobility,
@@ -107,6 +115,7 @@ contains
     implicit none
     real(8), intent(in) :: dt_em
     integer, parameter :: unit=1112
+    integer :: ios
     integer :: npid, nprocs
     logical :: flag
     real(8), parameter :: atomic_unit_of_length = 5.29177210903d-11 ! [m]
@@ -158,6 +167,9 @@ contains
        read(unit,*) tp3%kappa_e
        read(unit,*) tp3%kappa_l
        read(unit,*) tp3%dgap_c
+       tp3%mob_e0 = 0.0d0; tp3%mob_h0 = 0.0d0     ! optional (Set A Fermi transport)
+       read(unit,*,iostat=ios) tp3%mob_e0
+       read(unit,*,iostat=ios) tp3%mob_h0
        close(unit)
        write(*,*) "Egap[eV]    =",tp3%Egap
        write(*,*) "mu_e        =",tp3%mu_e
@@ -191,9 +203,15 @@ contains
     call comm_bcast(tp3%kappa_e,comm,0)
     call comm_bcast(tp3%kappa_l,comm,0)
     call comm_bcast(tp3%dgap_c ,comm,0)
+    call comm_bcast(tp3%mob_e0 ,comm,0)
+    call comm_bcast(tp3%mob_h0 ,comm,0)
 
 ! Convert to atomic units
     tp3%Egap = tp3%Egap / hartree_ev
+    ! mobility [m^2/Vs] -> a.u.  (mob_au = mob_SI * E_h * a_t * 1e-5 / a_B^2, the reference's
+    ! conversion: 8.5e-3 -> 2.0e-7).  Kept in SI-derived form via the atomic-unit constants.
+    tp3%mob_e0 = tp3%mob_e0 * hartree_ev*(atomic_unit_of_time*1.0d15)*1.0d-5/(atomic_unit_of_length*1.0d10)**2
+    tp3%mob_h0 = tp3%mob_h0 * hartree_ev*(atomic_unit_of_time*1.0d15)*1.0d-5/(atomic_unit_of_length*1.0d10)**2
     ! Auger coefficient [cm^6/s] -> [bohr^6 / a.u.time]
     tp3%A_e  = tp3%A_e * (1.0d-2/atomic_unit_of_length)**6 * atomic_unit_of_time
     tp3%A_h  = tp3%A_h * (1.0d-2/atomic_unit_of_length)**6 * atomic_unit_of_time
@@ -315,9 +333,11 @@ contains
     allocate( Ne(i1:j1,i2:j2,i3:j3), Nh(i1:j1,i2:j2,i3:j3) )
     allocate( rhs_te(i1:j1,i2:j2,i3:j3), rhs_th(i1:j1,i2:j2,i3:j3), rhs_tl(i1:j1,i2:j2,i3:j3) )
     allocate( rhs_ne(i1:j1,i2:j2,i3:j3), rhs_nh(i1:j1,i2:j2,i3:j3) )
+    allocate( Kc_e(i1:j1,i2:j2,i3:j3), Kc_h(i1:j1,i2:j2,i3:j3) )
 
     Te = tp3%Tini ; Th = tp3%Tini ; Tl = tp3%Tini
     Ne = N_floor  ; Nh = N_floor
+    Kc_e = 0.0d0  ; Kc_h = 0.0d0
   end subroutine init_ttm3_alloc
 
   !---------------------------------------------------------------------------
@@ -417,6 +437,22 @@ contains
     Fm = ttm3_fermi(1,eta); F0 = ttm3_fermi(2,eta); Fp = ttm3_fermi(3,eta)
     Ce = N*( 3.75d0*Fp/F0 - 2.25d0*F0/Fm )
   end function ttm3_heat_capacity
+
+  ! Set A: Fermi-Dirac carrier thermal conductivity (Wiedemann-Franz with degeneracy
+  ! corrections), reference Coef_Nc NTc(3)/(10).  K = (6 F_2/F_0 - 4 (F_1/F_0)^2) N Te mu,
+  ! mu = mob0 F_0/F_{1/2}.  (T is in energy units, so the reference's extra kbT is absorbed.)
+  pure function ttm3_thermal_cond( T, mc, N, mob0 ) result( K )
+    implicit none
+    real(8),intent(in) :: T,mc,N,mob0
+    real(8) :: K,eta,F0,F12,F1,F2,mu
+    eta = ttm3_chem_pot(T,mc,N)
+    F0  = ttm3_F0(eta)                       ! F_0 = ln(1+exp(eta))
+    F12 = ttm3_fermi(2,eta)                  ! F_{1/2}
+    F1  = ttm3_fermi(4,eta)                  ! F_1
+    F2  = ttm3_fermi(5,eta)                  ! F_2
+    mu  = mob0*F0/F12
+    K   = ( 6.0d0*F2/F0 - 4.0d0*(F1/F0)**2 )*N*T*mu
+  end function ttm3_thermal_cond
 
   !---------------------------------------------------------------------------
   ! Local rates for one cell (the right-hand side of the five ODEs).
@@ -551,21 +587,41 @@ contains
     type(s_rgrid),         intent(in)    :: rg
     integer :: m,ix,iy,iz
     real(8) :: cx,cy,cz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,Dmax,Dd
+    real(8) :: gx,gy,gz,gKe,gKh
+    logical :: use_fermi
 
-    if( tp3%Ddiff<=0.0d0 .and. tp3%kappa_e<=0.0d0 .and. tp3%kappa_l<=0.0d0 ) return
+    use_fermi = ( tp3%mob_e0>0.0d0 .or. tp3%mob_h0>0.0d0 )
+    if( tp3%Ddiff<=0.0d0 .and. tp3%kappa_e<=0.0d0 .and. tp3%kappa_l<=0.0d0 &
+        .and. .not.use_fermi ) return
 
     cx=1.0d0/hgs(1)**2; cy=1.0d0/hgs(2)**2; cz=1.0d0/hgs(3)**2
+    gx=0.5d0/hgs(1); gy=0.5d0/hgs(2); gz=0.5d0/hgs(3)   ! central first-difference
     ! explicit FTCS diffusion stability: the update u += dt*D*lap with the 7-point
     ! Laplacian amplifies unless dt*D*2*(cx+cy+cz) <= 1.  Cap every diffusivity so
     ! this factor stays at 0.5 (safety).  [The previous 0.4*min(h)^2/dt cap was the
     ! 1-D form; in 3-D it gives dt*D*6/h^2 = 2.4 > 1, i.e. unstable -> Te blow-up.]
     Dmax = 0.5d0/( 2.0d0*dt*(cx+cy+cz) )
     Dd   = min(tp3%Ddiff, Dmax)
+
+    ! Set A: per-cell Fermi-Dirac thermal conductivity (electron/hole), replacing the
+    ! constant kappa_e in the conduction term.  Density-dependent (K ~ N*mu), so the
+    ! conductivity shrinks with the carrier population, as in the reference.
+    if( use_fermi )then
+!$omp parallel do private(m,ix,iy,iz)
+       do m=1,nmedia_myrnk
+          ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+          Kc_e(ix,iy,iz)=ttm3_thermal_cond( Te(ix,iy,iz),tp3%mu_e,Ne(ix,iy,iz)+N_floor,tp3%mob_e0 )
+          Kc_h(ix,iy,iz)=ttm3_thermal_cond( Th(ix,iy,iz),tp3%mu_h,Nh(ix,iy,iz)+N_floor,tp3%mob_h0 )
+       end do
+!$omp end parallel do
+       call update_overlap_real8(srg, rg, Kc_e); call update_overlap_real8(srg, rg, Kc_h)
+    end if
+
     call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
     call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)
     call update_overlap_real8(srg, rg, Tl)
 
-!$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl)
+!$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,gKe,gKh)
     do m=1,nmedia_myrnk
        ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
        lNe=(Ne(ix+1,iy,iz)-2*Ne(ix,iy,iz)+Ne(ix-1,iy,iz))*cx &
@@ -583,11 +639,26 @@ contains
        lTl=(Tl(ix+1,iy,iz)-2*Tl(ix,iy,iz)+Tl(ix-1,iy,iz))*cx &
           +(Tl(ix,iy+1,iz)-2*Tl(ix,iy,iz)+Tl(ix,iy-1,iz))*cy &
           +(Tl(ix,iy,iz+1)-2*Tl(ix,iy,iz)+Tl(ix,iy,iz-1))*cz
-       Ce=1.5d0*(Ne(ix,iy,iz)+N_floor); Ch=1.5d0*(Nh(ix,iy,iz)+N_floor)
+       Ce=ttm3_heat_capacity(Te(ix,iy,iz),tp3%mu_e,Ne(ix,iy,iz)+N_floor)
+       Ch=ttm3_heat_capacity(Th(ix,iy,iz),tp3%mu_h,Nh(ix,iy,iz)+N_floor)
        rhs_ne(ix,iy,iz)=dt*Dd*lNe
        rhs_nh(ix,iy,iz)=dt*Dd*lNh
-       rhs_te(ix,iy,iz)=dt*min(tp3%kappa_e/Ce,Dmax)*lTe
-       rhs_th(ix,iy,iz)=dt*min(tp3%kappa_e/Ch,Dmax)*lTh
+       if( use_fermi )then
+          ! heat conduction nab.(K nabT) = nabK.nabT + K lap(T), divided by the heat
+          ! capacity; the K lap(T) diffusivity K/Ce is CFL-capped, the nabK.nabT term
+          ! is a bounded first-order correction.
+          gKe=(Kc_e(ix+1,iy,iz)-Kc_e(ix-1,iy,iz))*gx*(Te(ix+1,iy,iz)-Te(ix-1,iy,iz))*gx &
+             +(Kc_e(ix,iy+1,iz)-Kc_e(ix,iy-1,iz))*gy*(Te(ix,iy+1,iz)-Te(ix,iy-1,iz))*gy &
+             +(Kc_e(ix,iy,iz+1)-Kc_e(ix,iy,iz-1))*gz*(Te(ix,iy,iz+1)-Te(ix,iy,iz-1))*gz
+          gKh=(Kc_h(ix+1,iy,iz)-Kc_h(ix-1,iy,iz))*gx*(Th(ix+1,iy,iz)-Th(ix-1,iy,iz))*gx &
+             +(Kc_h(ix,iy+1,iz)-Kc_h(ix,iy-1,iz))*gy*(Th(ix,iy+1,iz)-Th(ix,iy-1,iz))*gy &
+             +(Kc_h(ix,iy,iz+1)-Kc_h(ix,iy,iz-1))*gz*(Th(ix,iy,iz+1)-Th(ix,iy,iz-1))*gz
+          rhs_te(ix,iy,iz)=dt*( min(Kc_e(ix,iy,iz)/Ce,Dmax)*lTe + gKe/Ce )
+          rhs_th(ix,iy,iz)=dt*( min(Kc_h(ix,iy,iz)/Ch,Dmax)*lTh + gKh/Ch )
+       else
+          rhs_te(ix,iy,iz)=dt*min(tp3%kappa_e/Ce,Dmax)*lTe
+          rhs_th(ix,iy,iz)=dt*min(tp3%kappa_e/Ch,Dmax)*lTh
+       end if
        rhs_tl(ix,iy,iz)=dt*min(tp3%kappa_l/tp3%Cl,Dmax)*lTl
     end do
 !$omp end parallel do

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -102,7 +102,9 @@ module ttm3
   ! medium mask over the full (halo) box: the space-charge sum must skip vacuum cells,
   ! whose Ne/Nh now hold mirrored (nonzero) values from the reflecting boundary.
   logical,allocatable :: med_mask(:,:,:)
-  real(8) :: dcap_worst = 1.0d0                      ! worst D/Dmax seen (CFL-cap diagnostic)
+  real(8) :: dcap_worst = 1.0d0                      ! worst D/Dmax seen (const path CFL-cap diagnostic)
+  integer :: nsub_worst = 8                          ! worst transport sub-step count reported so far
+  logical :: ktw_warned = .false.                    ! one-shot: coefficient kT floor engaged
   real(8) :: hgs(3)
   real(8) :: dt
 
@@ -114,13 +116,18 @@ module ttm3
   ! transport increment buffers (Stage 4)
   real(8),allocatable :: rhs_te(:,:,:), rhs_th(:,:,:), rhs_tl(:,:,:)
   real(8),allocatable :: rhs_ne(:,:,:), rhs_nh(:,:,:)
-  ! Set A (Fermi transport): per-cell thermal conductivity (electron/hole)
+  ! Set A (Fermi transport) per-cell coefficient fields, frozen over the sub-steps of one
+  ! FDTD step: thermal conductivity Kc, diffusion Dc, mobility Mc, heat capacity Cf,
+  ! heat-per-carrier Cj (cJeh), and the N-normalized cross-advection velocities
+  ! bE = Dc*cjE/N (band-edge force) and bT = Dc*cjT/N (thermodiffusion) -- these are
+  ! bounded ~Dc/kT, so no N_neighbor/N_local amplification survives at density shoulders
+  ! (the 2026-07-06 s2 blow-up mechanism).  Fluxes are built at faces (flux form).
   real(8),allocatable :: Kc_e(:,:,:), Kc_h(:,:,:)
-  ! Set A layer 2 (carrier transport): diffusion Dc, mobility Mc, current components
-  ! Jc(species,dir)=grad N + coefjE grad gap + coefjT grad T, band gap, space-charge field.
   real(8),allocatable :: Dc_e(:,:,:), Dc_h(:,:,:), Mc_e(:,:,:), Mc_h(:,:,:)
-  real(8),allocatable :: Jc_e(:,:,:,:), Jc_h(:,:,:,:)   ! (i,j,k,dir) -- dir last for contiguous halo
-  real(8),allocatable :: rgap(:,:,:), Efld(:,:,:)       ! local gap, space-charge field (x)
+  real(8),allocatable :: Cf_e(:,:,:), Cf_h(:,:,:)
+  real(8),allocatable :: bE_e(:,:,:), bT_e(:,:,:), bE_h(:,:,:), bT_h(:,:,:)
+  real(8),allocatable :: rgap(:,:,:), Efld(:,:,:)       ! local gap, space-charge field (x, cell centre)
+  real(8),allocatable :: Efc(:,:,:)                     ! space-charge field at x-faces (i+1/2, exact prefix)
   real(8),allocatable :: Cj_e(:,:,:), Cj_h(:,:,:)       ! Set A layer 3: heat per carrier (cJeh)
 
   ! Fermi-Dirac integral table F_j(eta).  Indices 1,2,3 = j = -1/2,1/2,3/2 (heat
@@ -443,12 +450,16 @@ contains
        allocate( Kc_e(i1:j1,i2:j2,i3:j3), Kc_h(i1:j1,i2:j2,i3:j3) )
        allocate( Dc_e(i1:j1,i2:j2,i3:j3), Dc_h(i1:j1,i2:j2,i3:j3) )
        allocate( Mc_e(i1:j1,i2:j2,i3:j3), Mc_h(i1:j1,i2:j2,i3:j3) )
-       allocate( Jc_e(i1:j1,i2:j2,i3:j3,3), Jc_h(i1:j1,i2:j2,i3:j3,3) )
-       allocate( rgap(i1:j1,i2:j2,i3:j3), Efld(i1:j1,i2:j2,i3:j3) )
+       allocate( Cf_e(i1:j1,i2:j2,i3:j3), Cf_h(i1:j1,i2:j2,i3:j3) )
+       allocate( bE_e(i1:j1,i2:j2,i3:j3), bT_e(i1:j1,i2:j2,i3:j3) )
+       allocate( bE_h(i1:j1,i2:j2,i3:j3), bT_h(i1:j1,i2:j2,i3:j3) )
+       allocate( rgap(i1:j1,i2:j2,i3:j3), Efld(i1:j1,i2:j2,i3:j3), Efc(i1:j1,i2:j2,i3:j3) )
        allocate( Cj_e(i1:j1,i2:j2,i3:j3), Cj_h(i1:j1,i2:j2,i3:j3) )
        Kc_e = 0.0d0  ; Kc_h = 0.0d0
        Dc_e = 0.0d0  ; Dc_h = 0.0d0 ; Mc_e = 0.0d0 ; Mc_h = 0.0d0
-       Jc_e = 0.0d0  ; Jc_h = 0.0d0 ; rgap = tp3%Egap ; Efld = 0.0d0
+       Cf_e = 0.0d0  ; Cf_h = 0.0d0
+       bE_e = 0.0d0  ; bT_e = 0.0d0 ; bE_h = 0.0d0 ; bT_h = 0.0d0
+       rgap = tp3%Egap ; Efld = 0.0d0 ; Efc = 0.0d0
        Cj_e = 0.0d0  ; Cj_h = 0.0d0
     end if
   end subroutine init_ttm3_alloc
@@ -749,10 +760,41 @@ contains
   end subroutine ttm3_main
 
   !---------------------------------------------------------------------------
-  ! Stage 4: carrier diffusion + heat conduction (recommended explicit scheme,
-  ! operator-split from the local step).  Skipped when all coefficients are zero
-  ! (then ttm3_main reproduces the verified Stage-1 local engine exactly).
+  ! Stage 4: spatial transport (operator-split from the local step).  Two paths:
+  !  * constant-coefficient path (Ddiff/kappa inputs, mobility=0): the original
+  !    capped explicit Laplacians -- unchanged, regression-stable;
+  !  * Set A Fermi path (mobility>0): conservative FLUX-FORM finite volumes with
+  !    harmonic interface diffusivities, donor-cell (upwind) cross advection and
+  !    drift, compensated convective carrier heat, and adaptive sub-stepping.
+  !    The former point-local splitting (K_loc*lapT + gradK.gradT, D_loc*divJ +
+  !    gradD.J, Cj*(...)) net-created energy at carrier-density shoulders where
+  !    N jumps 20-400x per cell: neighbour-sized fluxes divided by the LOCAL
+  !    Ce ~ N_loc amplified the update by N_nb/N_loc (10^2..10^3) -- a
+  !    dt-INDEPENDENT blow-up (s2 smoke forensics, 2026-07-06).
   subroutine ttm3_transport( srg, rg )
+    use structures,    only: s_rgrid, s_sendrecv_grid
+    implicit none
+    type(s_sendrecv_grid), intent(inout) :: srg
+    type(s_rgrid),         intent(in)    :: rg
+    if( tp3%mob_e0>0.0d0 .or. tp3%mob_h0>0.0d0 )then
+       call ttm3_transport_fermi( srg, rg )
+    else if( tp3%Ddiff>0.0d0 .or. tp3%kappa_e>0.0d0 .or. tp3%kappa_l>0.0d0 )then
+       call ttm3_transport_const( srg, rg )
+    end if
+  end subroutine ttm3_transport
+
+  ! harmonic interface mean: bounded by twice the SMALLER argument, so a huge
+  ! neighbour coefficient can never drive a small cell (maximum-principle helper).
+  pure function harm( a, b ) result( c )
+    implicit none
+    real(8),intent(in) :: a,b
+    real(8) :: c
+    c = 2.0d0*a*b/max( a+b, 1.0d-300 )
+  end function harm
+
+  !---------------------------------------------------------------------------
+  ! Constant-coefficient explicit diffusion (the pre-Set-A path, unchanged).
+  subroutine ttm3_transport_const( srg, rg )
     use structures,    only: s_rgrid, s_sendrecv_grid
     use sendrecv_grid, only: update_overlap_real8
     implicit none
@@ -760,90 +802,22 @@ contains
     type(s_rgrid),         intent(in)    :: rg
     integer :: m,ix,iy,iz
     real(8) :: cx,cy,cz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,Dmax,Dd
-    real(8) :: gx,gy,gz,gKe,gKh
-    real(8) :: eta,F0,Fm,F12,F1,F2,kT,cjE,cjT,fp4i
-    real(8) :: dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh,gCJe,gCJh
     real(8) :: TlK_t,Cl_t,dcap
-    logical :: use_fermi
-
-    use_fermi = ( tp3%mob_e0>0.0d0 .or. tp3%mob_h0>0.0d0 )
-    if( tp3%Ddiff<=0.0d0 .and. tp3%kappa_e<=0.0d0 .and. tp3%kappa_l<=0.0d0 &
-        .and. .not.use_fermi ) return
 
     cx=1.0d0/hgs(1)**2; cy=1.0d0/hgs(2)**2; cz=1.0d0/hgs(3)**2
-    gx=0.5d0/hgs(1); gy=0.5d0/hgs(2); gz=0.5d0/hgs(3)   ! central first-difference
     ! explicit FTCS diffusion stability: cap every diffusivity so dt*D*2*(cx+cy+cz)<=0.5.
     Dmax = 0.5d0/( 2.0d0*dt*(cx+cy+cz) )
     Dd   = min(tp3%Ddiff, Dmax)
-    fp4i = 4.0d0*pi_/tp3%eps_bg                ! 4*pi*inveps (local Gauss term, dEf)
-
-    ! Set A: per-cell Fermi-Dirac transport coefficients + carrier current components.
-    if( use_fermi )then
-!$omp parallel do private(m,ix,iy,iz)
-       do m=1,nmedia_myrnk
-          ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
-          rgap(ix,iy,iz)=ttm3_gap( Ne(ix,iy,iz), Tl(ix,iy,iz) )    ! carrier + thermal renormalised gap
-       end do
-!$omp end parallel do
-       call update_overlap_real8(srg, rg, rgap)
-    end if
 
     call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
     call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)
     call update_overlap_real8(srg, rg, Tl)
     ! reflecting (zero-flux) slab boundary: mirror the state into the vacuum face
     ! neighbours (after the halo exchange, so the exchange cannot overwrite it).
-    ! Without this the never-evolved vacuum cells act as an infinite Dirichlet sink.
-    call ttm3_mirror_state( use_fermi )
-
-    if( use_fermi )then
-       ! pass 1: Fermi coefficients (mobility Mc, diffusion Dc, conductivity Kc) and the
-       ! current components Jc(dir)=grad N + coefjE grad gap + coefjT grad T (per species).
-!$omp parallel do private(m,ix,iy,iz,eta,F0,Fm,F12,F1,F2,kT,cjE,cjT)
-       do m=1,nmedia_myrnk
-          ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
-          ! electrons
-          kT=max(Te(ix,iy,iz),T_floor); eta=ttm3_chem_pot(kT,tp3%mu_e,Ne(ix,iy,iz)+N_floor)
-          F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
-          F1=ttm3_fermi(4,eta); F2=ttm3_fermi(5,eta)
-          Mc_e(ix,iy,iz)=tp3%mob_e0*F0/F12
-          Dc_e(ix,iy,iz)=tp3%mob_e0*kT*F0/Fm
-          Kc_e(ix,iy,iz)=(6.0d0*F2/F0-4.0d0*(F1/F0)**2)*Ne(ix,iy,iz)*kT*Mc_e(ix,iy,iz)
-          cjE=(tp3%mu_h/(tp3%mu_e+tp3%mu_h))*(Ne(ix,iy,iz)+N_floor)*Fm/F12/kT
-          cjT=(Ne(ix,iy,iz)+N_floor)*(2.0d0*Fm*F1/(F12*F0)-1.5d0)/kT
-          Jc_e(ix,iy,iz,1)=(Ne(ix+1,iy,iz)-Ne(ix-1,iy,iz))*gx + cjE*(rgap(ix+1,iy,iz)-rgap(ix-1,iy,iz))*gx + cjT*(Te(ix+1,iy,iz)-Te(ix-1,iy,iz))*gx
-          Jc_e(ix,iy,iz,2)=(Ne(ix,iy+1,iz)-Ne(ix,iy-1,iz))*gy + cjE*(rgap(ix,iy+1,iz)-rgap(ix,iy-1,iz))*gy + cjT*(Te(ix,iy+1,iz)-Te(ix,iy-1,iz))*gy
-          Jc_e(ix,iy,iz,3)=(Ne(ix,iy,iz+1)-Ne(ix,iy,iz-1))*gz + cjE*(rgap(ix,iy,iz+1)-rgap(ix,iy,iz-1))*gz + cjT*(Te(ix,iy,iz+1)-Te(ix,iy,iz-1))*gz
-          Cj_e(ix,iy,iz)=2.0d0*kT*F1/F0 + (tp3%mu_h/(tp3%mu_e+tp3%mu_h))*rgap(ix,iy,iz)   ! heat per carrier
-          ! holes
-          kT=max(Th(ix,iy,iz),T_floor); eta=ttm3_chem_pot(kT,tp3%mu_h,Nh(ix,iy,iz)+N_floor)
-          F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
-          F1=ttm3_fermi(4,eta); F2=ttm3_fermi(5,eta)
-          Mc_h(ix,iy,iz)=tp3%mob_h0*F0/F12
-          Dc_h(ix,iy,iz)=tp3%mob_h0*kT*F0/Fm
-          Kc_h(ix,iy,iz)=(6.0d0*F2/F0-4.0d0*(F1/F0)**2)*Nh(ix,iy,iz)*kT*Mc_h(ix,iy,iz)
-          cjE=(tp3%mu_e/(tp3%mu_e+tp3%mu_h))*(Nh(ix,iy,iz)+N_floor)*Fm/F12/kT
-          cjT=(Nh(ix,iy,iz)+N_floor)*(2.0d0*Fm*F1/(F12*F0)-1.5d0)/kT
-          Jc_h(ix,iy,iz,1)=(Nh(ix+1,iy,iz)-Nh(ix-1,iy,iz))*gx + cjE*(rgap(ix+1,iy,iz)-rgap(ix-1,iy,iz))*gx + cjT*(Th(ix+1,iy,iz)-Th(ix-1,iy,iz))*gx
-          Jc_h(ix,iy,iz,2)=(Nh(ix,iy+1,iz)-Nh(ix,iy-1,iz))*gy + cjE*(rgap(ix,iy+1,iz)-rgap(ix,iy-1,iz))*gy + cjT*(Th(ix,iy+1,iz)-Th(ix,iy-1,iz))*gy
-          Jc_h(ix,iy,iz,3)=(Nh(ix,iy,iz+1)-Nh(ix,iy,iz-1))*gz + cjE*(rgap(ix,iy,iz+1)-rgap(ix,iy,iz-1))*gz + cjT*(Th(ix,iy,iz+1)-Th(ix,iy,iz-1))*gz
-          Cj_h(ix,iy,iz)=2.0d0*kT*F1/F0 + (tp3%mu_e/(tp3%mu_e+tp3%mu_h))*rgap(ix,iy,iz)   ! heat per carrier
-       end do
-!$omp end parallel do
-       call update_overlap_real8(srg, rg, Dc_e); call update_overlap_real8(srg, rg, Dc_h)
-       call update_overlap_real8(srg, rg, Mc_e); call update_overlap_real8(srg, rg, Mc_h)
-       call update_overlap_real8(srg, rg, Kc_e); call update_overlap_real8(srg, rg, Kc_h)
-       call update_overlap_real8(srg, rg, Cj_e); call update_overlap_real8(srg, rg, Cj_h)
-       call update_overlap_real8(srg, rg, Jc_e(:,:,:,1)); call update_overlap_real8(srg, rg, Jc_e(:,:,:,2)); call update_overlap_real8(srg, rg, Jc_e(:,:,:,3))
-       call update_overlap_real8(srg, rg, Jc_h(:,:,:,1)); call update_overlap_real8(srg, rg, Jc_h(:,:,:,2)); call update_overlap_real8(srg, rg, Jc_h(:,:,:,3))
-       call ttm3_mirror_coefs()                 ! reflecting BC for the derived fields (J.n=0)
-       call ttm3_space_charge()                 ! Efld = space-charge field (prefix sum along x)
-    end if
+    call ttm3_mirror_state( .false. )
 
     dcap = 0.0d0
-!$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,gKe,gKh, &
-!$omp&                    dJe,dJh,gDJe,gDJh,gMxe,gMxh,gNxe,gNxh,dEf,nabNe,nabNh,gCJe,gCJh, &
-!$omp&                    TlK_t,Cl_t) reduction(max:dcap)
+!$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl,TlK_t,Cl_t) reduction(max:dcap)
     do m=1,nmedia_myrnk
        ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
        lTe=(Te(ix+1,iy,iz)-2*Te(ix,iy,iz)+Te(ix-1,iy,iz))*cx+(Te(ix,iy+1,iz)-2*Te(ix,iy,iz)+Te(ix,iy-1,iz))*cy+(Te(ix,iy,iz+1)-2*Te(ix,iy,iz)+Te(ix,iy,iz-1))*cz
@@ -851,53 +825,12 @@ contains
        lTl=(Tl(ix+1,iy,iz)-2*Tl(ix,iy,iz)+Tl(ix-1,iy,iz))*cx+(Tl(ix,iy+1,iz)-2*Tl(ix,iy,iz)+Tl(ix,iy-1,iz))*cy+(Tl(ix,iy,iz+1)-2*Tl(ix,iy,iz)+Tl(ix,iy,iz-1))*cz
        Ce=ttm3_heat_capacity(Te(ix,iy,iz),tp3%mu_e,Ne(ix,iy,iz)+N_floor)
        Ch=ttm3_heat_capacity(Th(ix,iy,iz),tp3%mu_h,Nh(ix,iy,iz)+N_floor)
-       if( use_fermi )then
-          ! heat conduction nab.(K nabT) = nabK.nabT + K lap(T), /Ce (K/Ce CFL-capped)
-          gKe=(Kc_e(ix+1,iy,iz)-Kc_e(ix-1,iy,iz))*gx*(Te(ix+1,iy,iz)-Te(ix-1,iy,iz))*gx &
-             +(Kc_e(ix,iy+1,iz)-Kc_e(ix,iy-1,iz))*gy*(Te(ix,iy+1,iz)-Te(ix,iy-1,iz))*gy &
-             +(Kc_e(ix,iy,iz+1)-Kc_e(ix,iy,iz-1))*gz*(Te(ix,iy,iz+1)-Te(ix,iy,iz-1))*gz
-          gKh=(Kc_h(ix+1,iy,iz)-Kc_h(ix-1,iy,iz))*gx*(Th(ix+1,iy,iz)-Th(ix-1,iy,iz))*gx &
-             +(Kc_h(ix,iy+1,iz)-Kc_h(ix,iy-1,iz))*gy*(Th(ix,iy+1,iz)-Th(ix,iy-1,iz))*gy &
-             +(Kc_h(ix,iy,iz+1)-Kc_h(ix,iy,iz-1))*gz*(Th(ix,iy,iz+1)-Th(ix,iy,iz-1))*gz
-          ! CFL-cap diagnostic: when a diffusivity exceeds Dmax the min() silently reduces
-          ! the physics -- track the worst ratio so ttm3_transport can warn (see loop end).
-          dcap = max( dcap, Kc_e(ix,iy,iz)/Ce/Dmax, Kc_h(ix,iy,iz)/Ch/Dmax, &
-                            Dc_e(ix,iy,iz)/Dmax,    Dc_h(ix,iy,iz)/Dmax )
-          rhs_te(ix,iy,iz)=dt*( min(Kc_e(ix,iy,iz)/Ce,Dmax)*lTe + gKe/Ce )
-          rhs_th(ix,iy,iz)=dt*( min(Kc_h(ix,iy,iz)/Ch,Dmax)*lTh + gKh/Ch )
-          ! carrier transport: nab.(Dc Jc) - drift(space charge).  reference Evolve_N_T.
-          dJe=(Jc_e(ix+1,iy,iz,1)-Jc_e(ix-1,iy,iz,1))*gx+(Jc_e(ix,iy+1,iz,2)-Jc_e(ix,iy-1,iz,2))*gy+(Jc_e(ix,iy,iz+1,3)-Jc_e(ix,iy,iz-1,3))*gz
-          dJh=(Jc_h(ix+1,iy,iz,1)-Jc_h(ix-1,iy,iz,1))*gx+(Jc_h(ix,iy+1,iz,2)-Jc_h(ix,iy-1,iz,2))*gy+(Jc_h(ix,iy,iz+1,3)-Jc_h(ix,iy,iz-1,3))*gz
-          gDJe=(Dc_e(ix+1,iy,iz)-Dc_e(ix-1,iy,iz))*gx*Jc_e(ix,iy,iz,1)+(Dc_e(ix,iy+1,iz)-Dc_e(ix,iy-1,iz))*gy*Jc_e(ix,iy,iz,2)+(Dc_e(ix,iy,iz+1)-Dc_e(ix,iy,iz-1))*gz*Jc_e(ix,iy,iz,3)
-          gDJh=(Dc_h(ix+1,iy,iz)-Dc_h(ix-1,iy,iz))*gx*Jc_h(ix,iy,iz,1)+(Dc_h(ix,iy+1,iz)-Dc_h(ix,iy-1,iz))*gy*Jc_h(ix,iy,iz,2)+(Dc_h(ix,iy,iz+1)-Dc_h(ix,iy,iz-1))*gz*Jc_h(ix,iy,iz,3)
-          ! Layer 3: convective heat -- the carrier current carries energy cJeh per carrier:
-          ! nabW += cJeh*(Dc div Jc + grad Dc . Jc) + Dc*(grad cJeh . Jc).  Added to the heat RHS.
-          gCJe=(Cj_e(ix+1,iy,iz)-Cj_e(ix-1,iy,iz))*gx*Jc_e(ix,iy,iz,1)+(Cj_e(ix,iy+1,iz)-Cj_e(ix,iy-1,iz))*gy*Jc_e(ix,iy,iz,2)+(Cj_e(ix,iy,iz+1)-Cj_e(ix,iy,iz-1))*gz*Jc_e(ix,iy,iz,3)
-          gCJh=(Cj_h(ix+1,iy,iz)-Cj_h(ix-1,iy,iz))*gx*Jc_h(ix,iy,iz,1)+(Cj_h(ix,iy+1,iz)-Cj_h(ix,iy-1,iz))*gy*Jc_h(ix,iy,iz,2)+(Cj_h(ix,iy,iz+1)-Cj_h(ix,iy,iz-1))*gz*Jc_h(ix,iy,iz,3)
-          rhs_te(ix,iy,iz)=rhs_te(ix,iy,iz)+dt*( Cj_e(ix,iy,iz)*(Dc_e(ix,iy,iz)*dJe+gDJe) + Dc_e(ix,iy,iz)*gCJe )/Ce
-          rhs_th(ix,iy,iz)=rhs_th(ix,iy,iz)+dt*( Cj_h(ix,iy,iz)*(Dc_h(ix,iy,iz)*dJh+gDJh) + Dc_h(ix,iy,iz)*gCJh )/Ch
-          gMxe=(Mc_e(ix+1,iy,iz)-Mc_e(ix-1,iy,iz))*gx; gNxe=(Ne(ix+1,iy,iz)-Ne(ix-1,iy,iz))*gx
-          gMxh=(Mc_h(ix+1,iy,iz)-Mc_h(ix-1,iy,iz))*gx; gNxh=(Nh(ix+1,iy,iz)-Nh(ix-1,iy,iz))*gx
-          dEf=fp4i*(Ne(ix,iy,iz)-Nh(ix,iy,iz))               ! 4*pi*inveps*(Ne-Nh) = -dE/dx
-          ! drift (Efld = physical E from the sheet prefix sum, pointing away from net + charge):
-          !   electrons (v=-mu*E):  dNe/dt|drift = +div(mu_e Ne E) = +grad(mu_e Ne).E + mu_e Ne divE
-          !   holes     (v=+mu*E):  dNh/dt|drift = -div(mu_h Nh E) = -grad(mu_h Nh).E - mu_h Nh divE
-          ! with divE = -dEf; the gradient and divergence terms must carry CONSISTENT signs or
-          ! the drift is not a conservative flux (the old code had the gradient terms flipped).
-          nabNe=min(Dc_e(ix,iy,iz),Dmax)*dJe + gDJe &
-                + (gMxe*Ne(ix,iy,iz)+Mc_e(ix,iy,iz)*gNxe)*Efld(ix,iy,iz) - Mc_e(ix,iy,iz)*Ne(ix,iy,iz)*dEf
-          nabNh=min(Dc_h(ix,iy,iz),Dmax)*dJh + gDJh &
-                - (gMxh*Nh(ix,iy,iz)+Mc_h(ix,iy,iz)*gNxh)*Efld(ix,iy,iz) + Mc_h(ix,iy,iz)*Nh(ix,iy,iz)*dEf
-          rhs_ne(ix,iy,iz)=dt*nabNe
-          rhs_nh(ix,iy,iz)=dt*nabNh
-       else
-          lNe=(Ne(ix+1,iy,iz)-2*Ne(ix,iy,iz)+Ne(ix-1,iy,iz))*cx+(Ne(ix,iy+1,iz)-2*Ne(ix,iy,iz)+Ne(ix,iy-1,iz))*cy+(Ne(ix,iy,iz+1)-2*Ne(ix,iy,iz)+Ne(ix,iy,iz-1))*cz
-          lNh=(Nh(ix+1,iy,iz)-2*Nh(ix,iy,iz)+Nh(ix-1,iy,iz))*cx+(Nh(ix,iy+1,iz)-2*Nh(ix,iy,iz)+Nh(ix,iy-1,iz))*cy+(Nh(ix,iy,iz+1)-2*Nh(ix,iy,iz)+Nh(ix,iy,iz-1))*cz
-          rhs_ne(ix,iy,iz)=dt*Dd*lNe
-          rhs_nh(ix,iy,iz)=dt*Dd*lNh
-          rhs_te(ix,iy,iz)=dt*min(tp3%kappa_e/Ce,Dmax)*lTe
-          rhs_th(ix,iy,iz)=dt*min(tp3%kappa_e/Ch,Dmax)*lTh
-       end if
+       lNe=(Ne(ix+1,iy,iz)-2*Ne(ix,iy,iz)+Ne(ix-1,iy,iz))*cx+(Ne(ix,iy+1,iz)-2*Ne(ix,iy,iz)+Ne(ix,iy-1,iz))*cy+(Ne(ix,iy,iz+1)-2*Ne(ix,iy,iz)+Ne(ix,iy,iz-1))*cz
+       lNh=(Nh(ix+1,iy,iz)-2*Nh(ix,iy,iz)+Nh(ix-1,iy,iz))*cx+(Nh(ix,iy+1,iz)-2*Nh(ix,iy,iz)+Nh(ix,iy-1,iz))*cy+(Nh(ix,iy,iz+1)-2*Nh(ix,iy,iz)+Nh(ix,iy,iz-1))*cz
+       rhs_ne(ix,iy,iz)=dt*Dd*lNe
+       rhs_nh(ix,iy,iz)=dt*Dd*lNh
+       rhs_te(ix,iy,iz)=dt*min(tp3%kappa_e/Ce,Dmax)*lTe
+       rhs_th(ix,iy,iz)=dt*min(tp3%kappa_e/Ch,Dmax)*lTh
        ! lattice conduction Kl(Tl)/Cl(Tl): both temperature-dependent, Tl floored before
        ! the power/polynomial (a zero/negative Tl would give inf/NaN before any commit floor)
        TlK_t = max(Tl(ix,iy,iz),T_floor)*hk_kelvin
@@ -910,7 +843,7 @@ contains
     ! warn (rank-local, log-cadence) when the CFL cap is actually rewriting the physics
     if( dcap > 1.0d0 .and. dcap > 1.999d0*dcap_worst )then
        write(*,'(A,ES10.2,A)') " ttm3 WARNING: transport diffusivity CFL-capped (worst D/Dmax =", dcap, &
-                               " ) -- conduction/diffusion locally reduced; consider sub-stepping."
+                               " ) -- conduction/diffusion locally reduced."
     end if
     dcap_worst = max( dcap_worst, dcap )
 
@@ -926,7 +859,254 @@ contains
        Tl(ix,iy,iz)=max(Tl(ix,iy,iz)+rhs_tl(ix,iy,iz),T_floor)
     end do
 !$omp end parallel do
-  end subroutine ttm3_transport
+  end subroutine ttm3_transport_const
+
+  !---------------------------------------------------------------------------
+  ! Set A Fermi transport: conservative flux-form finite volumes + adaptive
+  ! sub-stepping.  Per FDTD step: (1) freeze the per-cell coefficient fields
+  ! (Kc, Dc, Mc, Cf=Ce, Cj, bE, bT, rgap, space-charge Efld/Efc; the lattice
+  ! Kl(Tl)/Cl(Tl) are deliberately LIVE per sub-step -- cheap state functions,
+  ! better for the nonlinear lattice diffusion), (2) advance the
+  ! state by sub-steps dt_s chosen from an ALL-TERM stability estimate (diffusive
+  ! interface CFL + advective CFL + a relative-change guard, re-evaluated every
+  ! sub-step; rates are linear in dt_s so no retry pass is needed).
+  ! Faces to non-medium cells carry exactly zero flux (reflecting slab boundary),
+  ! so no vacuum value is ever read.  Fail-loud: the sub-step count is bounded;
+  ! exceeding it stops the run (never freeze-and-continue).
+  subroutine ttm3_transport_fermi( srg, rg )
+    use structures,    only: s_rgrid, s_sendrecv_grid
+    use sendrecv_grid, only: update_overlap_real8
+    use communication, only: comm_get_min
+    implicit none
+    type(s_sendrecv_grid), intent(inout) :: srg
+    type(s_rgrid),         intent(in)    :: rg
+    integer,parameter :: nit_max = 1000
+    real(8),parameter :: cfl_saf = 0.5d0, rel_cap = 0.1d0
+    integer :: m,ix,iy,iz,jx,jy,jz,d,sg,nit,nktf
+    real(8) :: kT,eta,F0,Fm,F12,F1,F2
+    real(8) :: h,hi,TlK_t,Cl_i,Kl_i,Kl_j,Ce,Ch
+    real(8) :: khe,khh,khl,dhe,dhh,ue,uh,gte,gth,gtl,gne,gnh,ggp,efc_f
+    real(8) :: phn_e,phn_h,cjfe,cjfh,rr
+    real(8) :: rte,rth,rtl,rne,rnh,rwe,rwh,rmax,relmax,tau,dts,tsc
+
+    ! ---- per-FDTD-step coefficient pass (frozen over the sub-steps) ----------
+!$omp parallel do private(m,ix,iy,iz)
+    do m=1,nmedia_myrnk
+       ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+       rgap(ix,iy,iz)=ttm3_gap( Ne(ix,iy,iz), Tl(ix,iy,iz) )    ! carrier + thermal renormalised gap
+    end do
+!$omp end parallel do
+    call update_overlap_real8(srg, rg, rgap)
+
+    nktf = 0
+!$omp parallel do private(m,ix,iy,iz,kT,eta,F0,Fm,F12,F1,F2) reduction(+:nktf)
+    do m=1,nmedia_myrnk
+       ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+       ! electrons.  The coefficient kT is floored at a PHYSICAL scale: the state floor
+       ! (~1 K) would let the 1/kT thermodiffusion coefficient amplify ~300x (s2 crash).
+       kT = max( Te(ix,iy,iz), 0.5d0*max(Tl(ix,iy,iz),tp3%Tini) )
+       if( kT > Te(ix,iy,iz) ) nktf = nktf + 1
+       eta=ttm3_chem_pot(kT,tp3%mu_e,Ne(ix,iy,iz)+N_floor)
+       F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
+       F1=ttm3_fermi(4,eta); F2=ttm3_fermi(5,eta)
+       Mc_e(ix,iy,iz)=tp3%mob_e0*F0/F12
+       Dc_e(ix,iy,iz)=tp3%mob_e0*kT*F0/Fm
+       Kc_e(ix,iy,iz)=(6.0d0*F2/F0-4.0d0*(F1/F0)**2)*Ne(ix,iy,iz)*kT*Mc_e(ix,iy,iz)
+       ! thermodynamic divisor (Ce*dT = dW - Cj*dN): LIVE temperature, not the transport
+       ! kT floor -- flooring the EOS would misconvert energy whenever the floor engages
+       Cf_e(ix,iy,iz)=ttm3_heat_capacity(max(Te(ix,iy,iz),T_floor),tp3%mu_e,Ne(ix,iy,iz)+N_floor)
+       ! N-normalized cross-advection velocities per unit gradient (bounded ~Dc/kT;
+       ! the N_neighbour/N_local amplification cancels exactly):
+       !   bE = Dc*cjE/(Ne+floor) ;  bT = Dc*cjT/(Ne+floor)
+       bE_e(ix,iy,iz)=Dc_e(ix,iy,iz)*(tp3%mu_h/(tp3%mu_e+tp3%mu_h))*Fm/F12/kT
+       bT_e(ix,iy,iz)=Dc_e(ix,iy,iz)*(2.0d0*Fm*F1/(F12*F0)-1.5d0)/kT
+       Cj_e(ix,iy,iz)=2.0d0*kT*F1/F0 + (tp3%mu_h/(tp3%mu_e+tp3%mu_h))*rgap(ix,iy,iz)   ! heat per carrier
+       ! holes
+       kT = max( Th(ix,iy,iz), 0.5d0*max(Tl(ix,iy,iz),tp3%Tini) )
+       if( kT > Th(ix,iy,iz) ) nktf = nktf + 1
+       eta=ttm3_chem_pot(kT,tp3%mu_h,Nh(ix,iy,iz)+N_floor)
+       F0=ttm3_F0(eta); Fm=ttm3_fermi(1,eta); F12=ttm3_fermi(2,eta)
+       F1=ttm3_fermi(4,eta); F2=ttm3_fermi(5,eta)
+       Mc_h(ix,iy,iz)=tp3%mob_h0*F0/F12
+       Dc_h(ix,iy,iz)=tp3%mob_h0*kT*F0/Fm
+       Kc_h(ix,iy,iz)=(6.0d0*F2/F0-4.0d0*(F1/F0)**2)*Nh(ix,iy,iz)*kT*Mc_h(ix,iy,iz)
+       Cf_h(ix,iy,iz)=ttm3_heat_capacity(max(Th(ix,iy,iz),T_floor),tp3%mu_h,Nh(ix,iy,iz)+N_floor)
+       bE_h(ix,iy,iz)=Dc_h(ix,iy,iz)*(tp3%mu_e/(tp3%mu_e+tp3%mu_h))*Fm/F12/kT
+       bT_h(ix,iy,iz)=Dc_h(ix,iy,iz)*(2.0d0*Fm*F1/(F12*F0)-1.5d0)/kT
+       Cj_h(ix,iy,iz)=2.0d0*kT*F1/F0 + (tp3%mu_e/(tp3%mu_e+tp3%mu_h))*rgap(ix,iy,iz)   ! heat per carrier
+    end do
+!$omp end parallel do
+    if( nktf > 0 .and. .not.ktw_warned )then
+       write(*,'(A)') " ttm3 NOTE: transport-coefficient kT floored at 0.5*max(Tl,Tini) on this rank."
+       ktw_warned = .true.
+    end if
+
+    call update_overlap_real8(srg, rg, Kc_e); call update_overlap_real8(srg, rg, Kc_h)
+    call update_overlap_real8(srg, rg, Dc_e); call update_overlap_real8(srg, rg, Dc_h)
+    call update_overlap_real8(srg, rg, Mc_e); call update_overlap_real8(srg, rg, Mc_h)
+    call update_overlap_real8(srg, rg, Cf_e); call update_overlap_real8(srg, rg, Cf_h)
+    call update_overlap_real8(srg, rg, bE_e); call update_overlap_real8(srg, rg, bT_e)
+    call update_overlap_real8(srg, rg, bE_h); call update_overlap_real8(srg, rg, bT_h)
+    call update_overlap_real8(srg, rg, Cj_e); call update_overlap_real8(srg, rg, Cj_h)
+    call ttm3_space_charge()   ! Efld (cell centres) + Efc (x-faces, exact prefix); frozen over sub-steps
+    ! make rank-boundary faces bit-identical on both owners: the halo copy of Efc
+    ! replaces the locally-recomputed offset value with the owning rank's exact one
+    call update_overlap_real8(srg, rg, Efc)
+
+    call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
+    call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)
+    call update_overlap_real8(srg, rg, Tl)
+
+    ! ---- adaptive sub-step loop ----------------------------------------------
+    tau = dt ; nit = 0
+    do while( tau > 0.0d0 )
+       nit = nit + 1
+       if( nit > nit_max )then
+          write(*,'(A,I8,A)') " ttm3 ERROR: transport sub-stepping exceeded", nit_max, &
+                              " iterations in one FDTD step (unresolvable stiffness)."
+          error stop 'ttm3_transport_fermi: sub-step limit'
+       end if
+
+       ! one flux pass: per-cell RATES (per unit time) + stability measures.
+       ! Gather form: each cell evaluates its own faces; the face formulas are
+       ! symmetric under (i,j) swap, so both owners compute bit-identical fluxes
+       ! (conservative to machine precision, incl. across MPI ranks via halos).
+       rmax = 0.0d0 ; relmax = 0.0d0
+!$omp parallel do private(m,ix,iy,iz,jx,jy,jz,d,sg,h,hi,kT,TlK_t,Cl_i,Kl_i,Kl_j,Ce,Ch, &
+!$omp&                    khe,khh,khl,dhe,dhh,ue,uh,gte,gth,gtl,gne,gnh,ggp,efc_f, &
+!$omp&                    phn_e,phn_h,cjfe,cjfh,rr,rte,rth,rtl,rne,rnh,rwe,rwh,tsc) &
+!$omp&         reduction(max:rmax,relmax)
+       do m=1,nmedia_myrnk
+          ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+          Ce = Cf_e(ix,iy,iz) ; Ch = Cf_h(ix,iy,iz)
+          TlK_t = max(Tl(ix,iy,iz),T_floor)*hk_kelvin
+          Cl_i  = tp3%Cl*max( 1.978d0 + 3.54d-4*TlK_t - 3.68d0/(TlK_t*TlK_t), 0.2d0 )/2.084d0
+          Kl_i  = tp3%kappa_l*(TlK_t/300.0d0)**(-1.23d0)
+          rte=0.0d0; rth=0.0d0; rtl=0.0d0; rne=0.0d0; rnh=0.0d0
+          rwe=0.0d0; rwh=0.0d0; rr=0.0d0
+          do d=1,3
+             h = hgs(d) ; hi = 1.0d0/h
+             do sg=-1,1,2
+                jx=ix; jy=iy; jz=iz
+                select case(d)
+                case(1); jx=ix+sg
+                case(2); jy=iy+sg
+                case(3); jz=iz+sg
+                end select
+                if( .not.med_mask(jx,jy,jz) ) cycle      ! reflecting boundary: zero face flux
+                ! +d-oriented face gradients (sg folds the orientation)
+                gte=dble(sg)*(Te(jx,jy,jz)-Te(ix,iy,iz))*hi
+                gth=dble(sg)*(Th(jx,jy,jz)-Th(ix,iy,iz))*hi
+                gtl=dble(sg)*(Tl(jx,jy,jz)-Tl(ix,iy,iz))*hi
+                gne=dble(sg)*(Ne(jx,jy,jz)-Ne(ix,iy,iz))*hi
+                gnh=dble(sg)*(Nh(jx,jy,jz)-Nh(ix,iy,iz))*hi
+                ggp=dble(sg)*(rgap(jx,jy,jz)-rgap(ix,iy,iz))*hi
+                ! interface diffusivities: harmonic mean (bounded by the small side)
+                khe = harm( Kc_e(ix,iy,iz), Kc_e(jx,jy,jz) )
+                khh = harm( Kc_h(ix,iy,iz), Kc_h(jx,jy,jz) )
+                TlK_t = max(Tl(jx,jy,jz),T_floor)*hk_kelvin
+                Kl_j  = tp3%kappa_l*(TlK_t/300.0d0)**(-1.23d0)
+                khl   = harm( Kl_i, Kl_j )
+                dhe = harm( Dc_e(ix,iy,iz), Dc_e(jx,jy,jz) )
+                dhh = harm( Dc_h(ix,iy,iz), Dc_h(jx,jy,jz) )
+                ! cross advection (band-edge force + thermodiffusion) + x drift = face velocity
+                ue = -0.5d0*(bE_e(ix,iy,iz)+bE_e(jx,jy,jz))*ggp - 0.5d0*(bT_e(ix,iy,iz)+bT_e(jx,jy,jz))*gte
+                uh = -0.5d0*(bE_h(ix,iy,iz)+bE_h(jx,jy,jz))*ggp - 0.5d0*(bT_h(ix,iy,iz)+bT_h(jx,jy,jz))*gth
+                if( d==1 )then
+                   efc_f = Efc( min(ix,jx), iy, iz )     ! exact prefix face field (x only)
+                   ue = ue - harm(Mc_e(ix,iy,iz),Mc_e(jx,jy,jz))*efc_f   ! electrons: v = -mu E
+                   uh = uh + harm(Mc_h(ix,iy,iz),Mc_h(jx,jy,jz))*efc_f   ! holes:     v = +mu E
+                end if
+                ! +d-oriented carrier fluxes: Fickian diffusion + donor-cell advection
+                if( sg==1 )then
+                   phn_e = -dhe*gne + ue*merge( Ne(ix,iy,iz), Ne(jx,jy,jz), ue>0.0d0 )
+                   phn_h = -dhh*gnh + uh*merge( Nh(ix,iy,iz), Nh(jx,jy,jz), uh>0.0d0 )
+                   cjfe  = merge( Cj_e(ix,iy,iz), Cj_e(jx,jy,jz), phn_e>0.0d0 )
+                   cjfh  = merge( Cj_h(ix,iy,iz), Cj_h(jx,jy,jz), phn_h>0.0d0 )
+                else
+                   phn_e = -dhe*gne + ue*merge( Ne(jx,jy,jz), Ne(ix,iy,iz), ue>0.0d0 )
+                   phn_h = -dhh*gnh + uh*merge( Nh(jx,jy,jz), Nh(ix,iy,iz), uh>0.0d0 )
+                   cjfe  = merge( Cj_e(jx,jy,jz), Cj_e(ix,iy,iz), phn_e>0.0d0 )
+                   cjfh  = merge( Cj_h(jx,jy,jz), Cj_h(ix,iy,iz), phn_h>0.0d0 )
+                end if
+                ! cell-i contribution of a +d-oriented face flux is -sg*PHI/h
+                rne = rne - dble(sg)*phn_e*hi
+                rnh = rnh - dble(sg)*phn_h*hi
+                rwe = rwe - dble(sg)*cjfe*phn_e*hi       ! advected carrier heat (donor Cj)
+                rwh = rwh - dble(sg)*cjfh*phn_h*hi
+                rte = rte + dble(sg)*khe*gte*hi          ! conduction: -sg*(-K dT)/h
+                rth = rth + dble(sg)*khh*gth*hi
+                rtl = rtl + dble(sg)*khl*gtl*hi
+                ! all-term stability accumulator (diffusive + advective)
+                rr  = rr + max( khe/Ce, khh/Ch, khl/Cl_i, dhe, dhh )*hi*hi &
+                         + max( abs(ue), abs(uh) )*hi
+             end do
+          end do
+          ! temperature rates: conduction + COMPENSATED convective heat.  Continuous
+          ! identity div(Cj*F) - Cj*div(F) = F.grad(Cj): advection alone must not
+          ! change T (exactly zero for uniform Cj since rwe and rne use the SAME fluxes).
+          rhs_te(ix,iy,iz) = ( rte + rwe - Cj_e(ix,iy,iz)*rne )/Ce
+          rhs_th(ix,iy,iz) = ( rth + rwh - Cj_h(ix,iy,iz)*rnh )/Ch
+          rhs_tl(ix,iy,iz) = rtl/Cl_i
+          rhs_ne(ix,iy,iz) = rne
+          rhs_nh(ix,iy,iz) = rnh
+          rmax = max( rmax, rr )
+          tsc = max( Te(ix,iy,iz), 0.05d0*tp3%Tini )
+          relmax = max( relmax, abs(rhs_te(ix,iy,iz))/tsc )
+          tsc = max( Th(ix,iy,iz), 0.05d0*tp3%Tini )
+          relmax = max( relmax, abs(rhs_th(ix,iy,iz))/tsc )
+          tsc = max( Tl(ix,iy,iz), 0.05d0*tp3%Tini )
+          relmax = max( relmax, abs(rhs_tl(ix,iy,iz))/tsc )
+          relmax = max( relmax, abs(rhs_ne(ix,iy,iz))/(Ne(ix,iy,iz)+N_floor) )
+          relmax = max( relmax, abs(rhs_nh(ix,iy,iz))/(Nh(ix,iy,iz)+N_floor) )
+       end do
+!$omp end parallel do
+
+       ! sub-step size: interface CFL + relative-change cap; rates are linear in
+       ! dt_s so no retry pass is needed.  Global min keeps all ranks in lockstep
+       ! (identical sub-step count => matched halo exchanges).
+       dts = tau
+       if( rmax   > 0.0d0 ) dts = min( dts, cfl_saf/rmax )
+       if( relmax > 0.0d0 ) dts = min( dts, rel_cap/relmax )
+       if( nprocs_g > 1 ) call comm_get_min( dts, comm )
+       ! underflow guard: only when the STABILITY caps (not a small final remainder tau)
+       ! forced the collapse
+       if( dts < dt/dble(nit_max) .and. tau > dt/dble(nit_max) )then
+          write(*,'(A,ES10.2)') " ttm3 ERROR: transport sub-step collapsed, dt_s/dt =", dts/dt
+          error stop 'ttm3_transport_fermi: sub-step underflow'
+       end if
+
+!$omp parallel do private(m,ix,iy,iz)
+       do m=1,nmedia_myrnk
+          ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+          Ne(ix,iy,iz)=max(Ne(ix,iy,iz)+dts*rhs_ne(ix,iy,iz),0.0d0)
+          Nh(ix,iy,iz)=max(Nh(ix,iy,iz)+dts*rhs_nh(ix,iy,iz),0.0d0)
+          ! positivity floors: last-resort guards (the sub-step control should keep
+          ! the update far from them; see the rel_cap bound above)
+          Te(ix,iy,iz)=max(Te(ix,iy,iz)+dts*rhs_te(ix,iy,iz),T_floor)
+          Th(ix,iy,iz)=max(Th(ix,iy,iz)+dts*rhs_th(ix,iy,iz),T_floor)
+          Tl(ix,iy,iz)=max(Tl(ix,iy,iz)+dts*rhs_tl(ix,iy,iz),T_floor)
+       end do
+!$omp end parallel do
+
+       tau = tau - dts
+       if( tau > 0.0d0 )then
+          if( tau < 1.0d-12*dt )then                    ! FP crumbs: fold into done
+             tau = 0.0d0
+          else                                          ! state changed: refresh halos
+             call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
+             call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)
+             call update_overlap_real8(srg, rg, Tl)
+          end if
+       end if
+    end do
+
+    ! rank-local, log-cadence sub-step report (visibility without spam)
+    if( nit > nsub_worst )then
+       write(*,'(A,I6,A)') " ttm3 NOTE: transport used", nit, " sub-steps in one FDTD step."
+       nsub_worst = max( 2*nsub_worst, nit )
+    end if
+  end subroutine ttm3_transport_fermi
 
   !---------------------------------------------------------------------------
   ! Reflecting (zero-flux) closure at the medium surface: copy each surface cell's
@@ -951,29 +1131,6 @@ contains
     end do
   end subroutine ttm3_mirror_state
 
-  ! Same closure for the pass-1 derived fields: transport coefficients mirror
-  ! symmetrically; the carrier-current NORMAL component mirrors antisymmetrically
-  ! (J.n = 0 at the surface).  Only the normal component of the neighbour's Jc is
-  ! ever read by the divergence stencil.
-  subroutine ttm3_mirror_coefs()
-    implicit none
-    integer :: m,ix,iy,iz,id,jx,jy,jz,d
-    do m=1,nsurf
-       ix=ijk_surf(1,m); iy=ijk_surf(2,m); iz=ijk_surf(3,m); id=ijk_surf(4,m)
-       jx=ix; jy=iy; jz=iz; d=abs(id)
-       select case( d )
-       case(1); jx = ix + sign(1,id)
-       case(2); jy = iy + sign(1,id)
-       case(3); jz = iz + sign(1,id)
-       end select
-       Dc_e(jx,jy,jz)=Dc_e(ix,iy,iz); Dc_h(jx,jy,jz)=Dc_h(ix,iy,iz)
-       Mc_e(jx,jy,jz)=Mc_e(ix,iy,iz); Mc_h(jx,jy,jz)=Mc_h(ix,iy,iz)
-       Kc_e(jx,jy,jz)=Kc_e(ix,iy,iz); Kc_h(jx,jy,jz)=Kc_h(ix,iy,iz)
-       Cj_e(jx,jy,jz)=Cj_e(ix,iy,iz); Cj_h(jx,jy,jz)=Cj_h(ix,iy,iz)
-       Jc_e(jx,jy,jz,d)=-Jc_e(ix,iy,iz,d)
-       Jc_h(jx,jy,jz,d)=-Jc_h(ix,iy,iz,d)
-    end do
-  end subroutine ttm3_mirror_coefs
 
   !---------------------------------------------------------------------------
   ! Space-charge field Efld along x: Ef(ix)=2*pi*inveps*[sum_{i<ix} - sum_{i>ix}] rho*dx.
@@ -1000,11 +1157,14 @@ contains
              if( med_mask(ix,iy,iz) ) total=total+(Nh(ix,iy,iz)-Ne(ix,iy,iz))
           end do
           pre=0.0d0                                  ! exclusive prefix sum (i<ix)
+          Efc(is_inner(1)-1,iy,iz)=c2*dx*( -total )  ! face left of the first inner cell
           do ix=is_inner(1),ie_inner(1)
              rho=merge( Nh(ix,iy,iz)-Ne(ix,iy,iz), 0.0d0, med_mask(ix,iy,iz) )
              ! Ef = (left - right)*dx*c2 ;  right = total - pre - rho
              Efld(ix,iy,iz)=c2*dx*( 2.0d0*pre + rho - total )
              pre=pre+rho
+             ! exact field at face ix+1/2: all charge through ix is now to the left
+             Efc(ix,iy,iz)=c2*dx*( 2.0d0*pre - total )
           end do
        end do
        end do
@@ -1033,10 +1193,12 @@ contains
              total=total+aout(p,iy,iz)
              if( p<xc_id ) pre=pre+aout(p,iy,iz)   ! charge in x-domains left of this one
           end do
+          Efc(is_inner(1)-1,iy,iz)=c2*dx*( 2.0d0*pre - total )   ! face into this x-domain
           do ix=is_inner(1),ie_inner(1)
              rho=merge( Nh(ix,iy,iz)-Ne(ix,iy,iz), 0.0d0, med_mask(ix,iy,iz) )
              Efld(ix,iy,iz)=c2*dx*( 2.0d0*pre + rho - total )
              pre=pre+rho
+             Efc(ix,iy,iz)=c2*dx*( 2.0d0*pre - total )           ! exact face ix+1/2
           end do
        end do
        end do

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -405,7 +405,7 @@ contains
     implicit none
     real(8),intent(in)  :: Te_,Th_,Tl_,Ne_,Nh_, source_, gen_
     real(8),intent(out) :: dTe,dTh,dTl,dNe,dNh
-    real(8) :: Ce,Ch,R,inv_tau,geff,q_heat
+    real(8) :: Ce,Ch,R,inv_tau,geff,q_heat,red_e,red_h
 
     ! Fermi-Dirac carrier heat capacities (reduce to the classical 3/2 N when
     ! non-degenerate; suppressed when degenerate)
@@ -416,22 +416,30 @@ contains
     ! generation, saturated at the reference/atomic density N0 (cannot exceed it)
     geff = gen_ * max( 0.0d0, 1.0d0 - Ne_/tp3%N0 )
 
-    ! standard Auger recombination (removes electron-hole pairs)
+    ! standard Auger recombination (removes electron-hole pairs).  This is the
+    ! unsaturated limit of the reference R = N*A*N*Ne*Nh/(1+T_au*A*Ne*Nh): at the
+    ! carrier densities reached here (T_au*A*Ne*Nh << 1) the two coincide.
     R = ( tp3%A_e*Ne_ + tp3%A_h*Nh_ )*Ne_*Nh_
 
     ! carrier densities: generation - recombination (charge-neutral)
     dNe = geff - R
     dNh = geff - R
 
+    ! Reference energy partition between the electron and hole subsystems:
+    ! red_e = mu_h/(mu_e+mu_h), red_h = mu_e/(mu_e+mu_h) (lighter carrier takes
+    ! the larger share).  For Si this is 0.692/0.308, setting the Te:Th ratio.
+    red_e = tp3%mu_h/(tp3%mu_e+tp3%mu_h)
+    red_h = tp3%mu_e/(tp3%mu_e+tp3%mu_h)
+
     ! only the absorbed power in excess of the gap cost (Egap per generated pair)
     ! becomes carrier kinetic energy (heating); the rest creates the pair
-    q_heat = 0.5d0*max( source_ - geff*tp3%Egap, 0.0d0 )
+    q_heat = max( source_ - geff*tp3%Egap, 0.0d0 )
 
-    ! carrier temperatures: relaxation toward the lattice + bounded heating +
+    ! carrier temperatures: relaxation toward the lattice + partitioned heating +
     ! dilution by freshly generated carriers (born near the lattice temperature),
     ! which caps Te near the hot-carrier value (~(hw-Egap)) instead of diverging.
-    dTe = -(Te_-Tl_)*inv_tau + (geff/(Ne_+N_floor))*(Tl_-Te_) + q_heat/Ce
-    dTh = -(Th_-Tl_)*inv_tau + (geff/(Nh_+N_floor))*(Tl_-Th_) + q_heat/Ch
+    dTe = -(Te_-Tl_)*inv_tau + (geff/(Ne_+N_floor))*(Tl_-Te_) + red_e*q_heat/Ce
+    dTh = -(Th_-Tl_)*inv_tau + (geff/(Nh_+N_floor))*(Tl_-Th_) + red_h*q_heat/Ch
 
     ! lattice receives the energy lost by the carriers (energy-conserving coupling)
     dTl = ( Ce*(Te_-Tl_) + Ch*(Th_-Tl_) )*inv_tau / tp3%Cl

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -273,6 +273,12 @@ contains
     integer,intent(in) :: is_a(3), is(3), ie(3)
     integer,intent(in) :: imedia(is_a(1):,is_a(2):,is_a(3):)
     integer :: ix,iy,iz,m
+    logical :: allmed
+
+    ! Ablation mode (sig_cold>0): the surface metallizes, so the carrier-dependent optics
+    ! back-action must reach the illuminated face cell too -> include ALL medium cells, not
+    ! only the 6-neighbour interior.  Layer B / regression (sig_cold<=0) keeps interior-only.
+    allmed = ( tp3%sig_cold > 0.0d0 )
 
     hgs(:)      = hgs_in(:)
     is_array(:) = is_a(:)
@@ -312,10 +318,10 @@ contains
     do iz=is(3),ie(3)
     do iy=is(2),ie(2)
     do ix=is(1),ie(1)
-       if( imedia(ix,iy,iz)/=0 .and. &
+       if( imedia(ix,iy,iz)/=0 .and. ( allmed .or. ( &
            imedia(ix+1,iy,iz)==imedia(ix,iy,iz) .and. imedia(ix-1,iy,iz)==imedia(ix,iy,iz) .and. &
            imedia(ix,iy+1,iz)==imedia(ix,iy,iz) .and. imedia(ix,iy-1,iz)==imedia(ix,iy,iz) .and. &
-           imedia(ix,iy,iz+1)==imedia(ix,iy,iz) .and. imedia(ix,iy,iz-1)==imedia(ix,iy,iz) ) m = m + 1
+           imedia(ix,iy,iz+1)==imedia(ix,iy,iz) .and. imedia(ix,iy,iz-1)==imedia(ix,iy,iz) ) ) ) m = m + 1
     end do
     end do
     end do
@@ -326,10 +332,10 @@ contains
     do iz=is(3),ie(3)
     do iy=is(2),ie(2)
     do ix=is(1),ie(1)
-       if( imedia(ix,iy,iz)/=0 .and. &
+       if( imedia(ix,iy,iz)/=0 .and. ( allmed .or. ( &
            imedia(ix+1,iy,iz)==imedia(ix,iy,iz) .and. imedia(ix-1,iy,iz)==imedia(ix,iy,iz) .and. &
            imedia(ix,iy+1,iz)==imedia(ix,iy,iz) .and. imedia(ix,iy-1,iz)==imedia(ix,iy,iz) .and. &
-           imedia(ix,iy,iz+1)==imedia(ix,iy,iz) .and. imedia(ix,iy,iz-1)==imedia(ix,iy,iz) )then
+           imedia(ix,iy,iz+1)==imedia(ix,iy,iz) .and. imedia(ix,iy,iz-1)==imedia(ix,iy,iz) ) ) )then
           m = m + 1
           ijk_interior(1:3,m) = (/ix,iy,iz/)
        end if

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -35,6 +35,7 @@ module ttm3
   public :: ttm3_drude_coef
   public :: ttm3_drude_coef_cell
   public :: ttm3_eps_sig
+  public :: ttm3_coupling_mode
   public :: ttm3_ninterior
   public :: ttm3_interior_cell
   public :: ttm3_generation
@@ -72,6 +73,9 @@ module ttm3
      ! free-carrier (Drude) absorption heats rather than ionises -> generation self-limits in
      ! the metallisation regime.  <=0 disables the split (generation = full absorbed power).
      real(8) :: sig_cold ! cold interband conductivity       [a.u.]         (Layer C-a)
+     integer :: coupling_mode ! 0=J-update (current-source ADE, default), 1=eps-update
+                              ! (carrier eps/sigma folded into the FDTD media coefficients).
+                              ! For isolating the Maxwell-coupling METHOD on an identical run.
   end type ttm3_param
 
   integer,allocatable :: ijk_media_whole(:,:)
@@ -192,6 +196,8 @@ contains
        read(unit,*,iostat=ios) tp3%mob_h0
        tp3%sig_cold = 0.0d0                        ! optional (Layer C-a bound/Drude split); <=0 disables
        read(unit,*,iostat=ios) tp3%sig_cold
+       tp3%coupling_mode = 0                       ! optional: 0=J-update (default), 1=eps-update
+       read(unit,*,iostat=ios) tp3%coupling_mode
        close(unit)
        write(*,*) "Egap[eV]    =",tp3%Egap
        write(*,*) "mu_e        =",tp3%mu_e
@@ -228,6 +234,7 @@ contains
     call comm_bcast(tp3%mob_e0 ,comm,0)
     call comm_bcast(tp3%mob_h0 ,comm,0)
     call comm_bcast(tp3%sig_cold,comm,0)
+    call comm_bcast(tp3%coupling_mode,comm,0)
 
 ! Convert to atomic units
     tp3%Egap = tp3%Egap / hartree_ev
@@ -1105,6 +1112,12 @@ contains
     real(8),intent(out) :: eps_re, sig
     call ttm3_permittivity( Ne(ix,iy,iz), Nh(ix,iy,iz), Te(ix,iy,iz), Th(ix,iy,iz), Tl(ix,iy,iz), omega, eps_re, sig )
   end subroutine ttm3_eps_sig
+
+  pure function ttm3_coupling_mode() result( m )
+    implicit none
+    integer :: m
+    m = tp3%coupling_mode
+  end function ttm3_coupling_mode
 
   integer function ttm3_ninterior()
     implicit none

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -32,6 +32,8 @@ module ttm3
   public :: ttm3_write_profile
   public :: ttm3_permittivity
   public :: ttm3_linear_gen
+  public :: ttm3_drude_coef
+  public :: ttm3_drude_coef_cell
   public :: ttm3_eps_sig
   public :: ttm3_ninterior
   public :: ttm3_interior_cell
@@ -995,6 +997,50 @@ contains
     eps_re = -wpe/w2/(1.0d0+xE*xE) - wph/w2/(1.0d0+xH*xH)          ! Re(eps_Drude), e+h
     sig    = ( wpe/w2*xE/(1.0d0+xE*xE) + wph/w2*xH/(1.0d0+xH*xH) )*omega/(4.0d0*pi_)
   end subroutine ttm3_drude
+
+  ! ADE-FDTD coefficients for the carrier Drude polarization current J (the STABLE,
+  ! SALMON-native current-source coupling): J_new = c1*J + c2*E, with the current injected
+  ! via eh_add_curr.  Same gamma_eh as ttm3_drude; combined e+h plasma frequency
+  ! wp^2 = 4*pi*Ne*(1/mu_eo+1/mu_ho).  c1=(1-g dt/2)/(1+g dt/2), c2=wp^2 dt/(8 pi (1+g dt/2))
+  ! (the same form as the validated Lorentz-Drude pole, c2_jx_ld).  This replaces the
+  ! eps/sigma back-action (which is unstable in the real-field FDTD as sigma grows fast).
+  pure subroutine ttm3_drude_coef( Ne_, Te_, Tl_, omega, dt, c1, c2 )
+    implicit none
+    real(8),intent(in)  :: Ne_, Te_, Tl_, omega, dt
+    real(8),intent(out) :: c1, c2
+    real(8),parameter :: mu_eo=0.26d0, mu_ho=0.37d0, kbT_r=3.1668d-6, a_t_=2.419d-2, E_h_=27.2114d0
+    real(8) :: red,red2,Cg,Tryd,Pe,Tf,aa,gsp,gph,g1e,ge,TeK,TlK,argl,wp2,c0
+    TeK=max(Te_,1.0d-12)/kbT_r; TlK=Tl_/kbT_r
+    red  = 1.0d0/(1.0d0/mu_eo+1.0d0/mu_ho)
+    red2 = 1.0d0/(1.0d0/tp3%mu_e+1.0d0/tp3%mu_h)
+    Cg   = 16.0d0/9.0d0*pi_**(-1.5d0)
+    Tryd = red*0.5d0/(11.7d0**2)*(16.0d0*pi_*pi_)
+    Pe   = (3.0d0*pi_*pi_*max(Ne_,1.0d-30))**(2.0d0/3.0d0)
+    Tf   = 0.5d0*Pe/(red2*kbT_r)
+    argl = sqrt(Tryd*Tf)*Tf
+    aa   = 1.0d0/sqrt( sqrt(kbT_r)/argl )*exp(2.0d0/3.0d0)
+    if( TeK > aa )then
+       gsp = abs( Cg*Tryd*(Tf/TeK)**1.5d0 * log( TeK*TeK*sqrt(kbT_r)/argl ) )
+    else
+       gsp = Cg*Tryd*(Tf/aa)**1.5d0 * log( aa*aa*sqrt(kbT_r)/argl )
+    end if
+    gph = 4.0d-4*TlK*a_t_
+    g1e = a_t_/( 0.98d0 + 0.2d0*(kbT_r*TeK*E_h_)**(-3.5d0) )
+    ge  = max( gsp+gph+g1e, 1.0d-30 )                              ! collision rate
+    wp2 = 4.0d0*pi_*Ne_*( 1.0d0/mu_eo + 1.0d0/mu_ho )             ! combined e+h plasma freq^2
+    c0  = 1.0d0 + ge*dt/2.0d0
+    c1  = ( 1.0d0 - ge*dt/2.0d0 )/c0
+    c2  = wp2*dt/( 8.0d0*pi_*c0 )
+  end subroutine ttm3_drude_coef
+
+  ! Cell wrapper: ADE Drude coefficients from the cell's carrier state (for the FDTD coupling).
+  subroutine ttm3_drude_coef_cell( ix, iy, iz, omega, dt, c1, c2 )
+    implicit none
+    integer,intent(in)  :: ix,iy,iz
+    real(8),intent(in)  :: omega, dt
+    real(8),intent(out) :: c1, c2
+    call ttm3_drude_coef( Ne(ix,iy,iz)+N_floor, Te(ix,iy,iz), Tl(ix,iy,iz), omega, dt, c1, c2 )
+  end subroutine ttm3_drude_coef_cell
 
   pure subroutine ttm3_permittivity( Ne_, Nh_, Te_, Th_, Tl_, omega, eps_re, sig )
     implicit none

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -1030,7 +1030,7 @@ contains
     wp2 = 4.0d0*pi_*Ne_*( 1.0d0/mu_eo + 1.0d0/mu_ho )             ! combined e+h plasma freq^2
     c0  = 1.0d0 + ge*dt/2.0d0
     c1  = ( 1.0d0 - ge*dt/2.0d0 )/c0
-    c2  = wp2*dt/( 8.0d0*pi_*c0 )
+    c2  = wp2*dt/( 4.0d0*pi_*c0 )                 ! drive with ex (=ex_y+ex_z); 4pi gives correct Drude sigma
   end subroutine ttm3_drude_coef
 
   ! Cell wrapper: ADE Drude coefficients from the cell's carrier state (for the FDTD coupling).

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -25,6 +25,7 @@ module ttm3
   public :: ttm3_main
   public :: ttm3_step_cell
   public :: ttm3_get_state
+  public :: ttm3_get_max
   public :: ttm3_permittivity
   public :: ttm3_generation
   public :: ttm3_gap
@@ -405,6 +406,27 @@ contains
     Ne_o = Ne(a(1),a(2),a(3)) / cm3_per_bohr3
     Nh_o = Nh(a(1),a(2),a(3)) / cm3_per_bohr3
   end subroutine ttm3_get_state
+
+  !---------------------------------------------------------------------------
+  ! Peak values over this rank's medium cells (output units), for diagnostics.
+  subroutine ttm3_get_max( Te_o, Th_o, Tl_o, Ne_o, Nh_o )
+    implicit none
+    real(8),intent(out) :: Te_o, Th_o, Tl_o, Ne_o, Nh_o   ! [K],[K],[K],[1/cm^3],[1/cm^3]
+    real(8), parameter :: hartree_kelvin_relationship = 3.1577502480407d5
+    real(8), parameter :: atomic_unit_of_length = 5.29177210903d-11
+    real(8) :: cm3_per_bohr3
+    integer :: m,ix,iy,iz
+    Te_o=0d0; Th_o=0d0; Tl_o=0d0; Ne_o=0d0; Nh_o=0d0
+    cm3_per_bohr3 = (atomic_unit_of_length*1.0d2)**3
+    do m=1,nmedia_myrnk
+       ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+       Te_o=max(Te_o,Te(ix,iy,iz)); Th_o=max(Th_o,Th(ix,iy,iz)); Tl_o=max(Tl_o,Tl(ix,iy,iz))
+       Ne_o=max(Ne_o,Ne(ix,iy,iz)); Nh_o=max(Nh_o,Nh(ix,iy,iz))
+    end do
+    Te_o=Te_o*hartree_kelvin_relationship; Th_o=Th_o*hartree_kelvin_relationship
+    Tl_o=Tl_o*hartree_kelvin_relationship
+    Ne_o=Ne_o/cm3_per_bohr3; Nh_o=Nh_o/cm3_per_bohr3
+  end subroutine ttm3_get_max
 
   !---------------------------------------------------------------------------
   ! Stage 2: carrier-dependent permittivity (recommended Drude model).

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -514,8 +514,11 @@ contains
     if( tp3%Ddiff<=0.0d0 .and. tp3%kappa_e<=0.0d0 .and. tp3%kappa_l<=0.0d0 ) return
 
     cx=1.0d0/hgs(1)**2; cy=1.0d0/hgs(2)**2; cz=1.0d0/hgs(3)**2
-    ! explicit-scheme stability cap: cap every diffusivity at 0.4*h^2/dt (CFL)
-    Dmax = 0.4d0*min(hgs(1),hgs(2),hgs(3))**2/dt
+    ! explicit FTCS diffusion stability: the update u += dt*D*lap with the 7-point
+    ! Laplacian amplifies unless dt*D*2*(cx+cy+cz) <= 1.  Cap every diffusivity so
+    ! this factor stays at 0.5 (safety).  [The previous 0.4*min(h)^2/dt cap was the
+    ! 1-D form; in 3-D it gives dt*D*6/h^2 = 2.4 > 1, i.e. unstable -> Te blow-up.]
+    Dmax = 0.5d0/( 2.0d0*dt*(cx+cy+cz) )
     Dd   = min(tp3%Ddiff, Dmax)
     call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
     call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -929,11 +929,12 @@ contains
 
   ! Depth profile along x at the transverse centre line (front cell's iy,iz): writes
   ! one block per call (time, ix, Te[K], Ne[cm^-3], Tl[K]) for spatial-distribution diagnostics.
-  subroutine ttm3_write_profile( fname, t_fs, u )
+  subroutine ttm3_write_profile( fname, t_fs, u, field )
     implicit none
     character(*),intent(in) :: fname
     real(8),     intent(in) :: t_fs
     integer,     intent(in) :: u
+    real(8),     intent(in) :: field(is_array(1):,is_array(2):,is_array(3):)  ! |E|^2 envelope [a.u.]
     real(8),parameter :: hk = 3.1577502480407d5, aul = 5.29177210903d-11
     real(8) :: cm3
     integer :: m,ix,iy,iz,fx,fy,fz
@@ -945,8 +946,8 @@ contains
        do m=1,nmedia_myrnk
           if( ijk_media_myrnk(1,m)==ix .and. ijk_media_myrnk(2,m)==fy .and. ijk_media_myrnk(3,m)==fz )then
              iy=fy; iz=fz
-             write(u,'(F12.4,1X,I6,3(1X,E16.8))') t_fs, ix, &
-                  Te(ix,iy,iz)*hk, Ne(ix,iy,iz)/cm3, Tl(ix,iy,iz)*hk
+             write(u,'(F12.4,1X,I6,4(1X,E16.8))') t_fs, ix, &
+                  Te(ix,iy,iz)*hk, Ne(ix,iy,iz)/cm3, Tl(ix,iy,iz)*hk, field(ix,iy,iz)
           end if
        end do
     end do

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -29,6 +29,7 @@ module ttm3
   public :: ttm3_get_max
   public :: ttm3_get_front
   public :: ttm3_front_ijk
+  public :: ttm3_write_profile
   public :: ttm3_permittivity
   public :: ttm3_linear_gen
   public :: ttm3_eps_sig
@@ -925,6 +926,33 @@ contains
     end do
     jx=a(1); jy=a(2); jz=a(3)
   end subroutine ttm3_front_ijk
+
+  ! Depth profile along x at the transverse centre line (front cell's iy,iz): writes
+  ! one block per call (time, ix, Te[K], Ne[cm^-3], Tl[K]) for spatial-distribution diagnostics.
+  subroutine ttm3_write_profile( fname, t_fs, u )
+    implicit none
+    character(*),intent(in) :: fname
+    real(8),     intent(in) :: t_fs
+    integer,     intent(in) :: u
+    real(8),parameter :: hk = 3.1577502480407d5, aul = 5.29177210903d-11
+    real(8) :: cm3
+    integer :: m,ix,iy,iz,fx,fy,fz
+    if( nmedia_myrnk<=0 ) return
+    call ttm3_front_ijk( fx, fy, fz )                 ! transverse centre = front cell line
+    cm3 = (aul*1.0d2)**3
+    open(u, file=fname, status='unknown', position='append')
+    do ix=is_inner(1),ie_inner(1)                     ! sorted by depth
+       do m=1,nmedia_myrnk
+          if( ijk_media_myrnk(1,m)==ix .and. ijk_media_myrnk(2,m)==fy .and. ijk_media_myrnk(3,m)==fz )then
+             iy=fy; iz=fz
+             write(u,'(F12.4,1X,I6,3(1X,E16.8))') t_fs, ix, &
+                  Te(ix,iy,iz)*hk, Ne(ix,iy,iz)/cm3, Tl(ix,iy,iz)*hk
+          end if
+       end do
+    end do
+    write(u,*) ' '                                    ! blank line separates time blocks
+    close(u)
+  end subroutine ttm3_write_profile
 
   !---------------------------------------------------------------------------
   ! Stage 2: carrier-dependent permittivity (recommended Drude model).

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -25,12 +25,15 @@ module ttm3
   public :: ttm3_main
   public :: ttm3_step_cell
   public :: ttm3_get_state
+  public :: ttm3_permittivity
+  public :: ttm3_generation
+  public :: ttm3_gap
 
   logical,public :: use_ttm3=.false.
 
   ! material parameters
   type ttm3_param
-     real(8) :: Egap     ! band gap                        [Hartree]
+     real(8) :: Egap     ! band gap (cold)                 [Hartree]
      real(8) :: mu_e     ! electron effective mass ratio    [-]
      real(8) :: mu_h     ! hole effective mass ratio        [-]
      real(8) :: A_e      ! electron Auger coefficient        [bohr^6 / a.u.time]
@@ -38,6 +41,14 @@ module ttm3
      real(8) :: tau      ! carrier-lattice relaxation time   [a.u.time]
      real(8) :: Cl       ! lattice heat capacity             [a.u. / (volume * temperature)]
      real(8) :: Tini     ! initial temperature (Te=Th=Tl)    [a.u.]
+     ! stage 2-5 (recommended models)
+     real(8) :: eps_bg   ! background relative permittivity  [-]            (Stage 2)
+     real(8) :: N0       ! saturation/reference density      [1/bohr^3]     (Stage 2,5)
+     real(8) :: beta2    ! two-photon generation coefficient [a.u.]         (Stage 3)
+     real(8) :: Ddiff    ! ambipolar carrier diffusivity     [bohr^2/a.u.t] (Stage 4)
+     real(8) :: kappa_e  ! carrier thermal conductivity      [a.u.]         (Stage 4)
+     real(8) :: kappa_l  ! lattice thermal conductivity      [a.u.]         (Stage 4)
+     real(8) :: dgap_c   ! gap-renormalisation coefficient   [a.u.]         (Stage 5)
   end type ttm3_param
 
   integer,allocatable :: ijk_media_whole(:,:)
@@ -53,9 +64,13 @@ module ttm3
   ! state and Runge-Kutta stage buffers
   real(8),allocatable :: Te(:,:,:), Th(:,:,:), Tl(:,:,:)
   real(8),allocatable :: Ne(:,:,:), Nh(:,:,:)
+  ! transport increment buffers (Stage 4)
+  real(8),allocatable :: rhs_te(:,:,:), rhs_th(:,:,:), rhs_tl(:,:,:)
+  real(8),allocatable :: rhs_ne(:,:,:), rhs_nh(:,:,:)
 
   ! density floor to keep the carrier heat capacity well defined
   real(8),parameter :: N_floor = 1.0d-24   ! [1/bohr^3]
+  real(8),parameter :: pi_ = 3.14159265358979323846d0
 
   character(12) :: ttm3_file = 'ttm3.inp_3tm'
   logical :: DISPLAY=.false.
@@ -112,6 +127,13 @@ contains
        read(unit,*) tp3%tau
        read(unit,*) tp3%Cl
        read(unit,*) tp3%Tini
+       read(unit,*) tp3%eps_bg
+       read(unit,*) tp3%N0
+       read(unit,*) tp3%beta2
+       read(unit,*) tp3%Ddiff
+       read(unit,*) tp3%kappa_e
+       read(unit,*) tp3%kappa_l
+       read(unit,*) tp3%dgap_c
        close(unit)
        write(*,*) "Egap[eV]    =",tp3%Egap
        write(*,*) "mu_e        =",tp3%mu_e
@@ -121,6 +143,13 @@ contains
        write(*,*) "tau[fs]     =",tp3%tau
        write(*,*) "Cl[J/m3K]   =",tp3%Cl
        write(*,*) "Tini[K]     =",tp3%Tini
+       write(*,*) "eps_bg      =",tp3%eps_bg
+       write(*,*) "N0[cm-3]    =",tp3%N0
+       write(*,*) "beta2[a.u.] =",tp3%beta2
+       write(*,*) "Ddiff[cm2/s]=",tp3%Ddiff
+       write(*,*) "kappa_e[W/mK]=",tp3%kappa_e
+       write(*,*) "kappa_l[W/mK]=",tp3%kappa_l
+       write(*,*) "dgap_c[a.u.]=",tp3%dgap_c
     end if
 
     call comm_bcast(tp3%Egap,comm,0)
@@ -131,6 +160,13 @@ contains
     call comm_bcast(tp3%tau ,comm,0)
     call comm_bcast(tp3%Cl  ,comm,0)
     call comm_bcast(tp3%Tini,comm,0)
+    call comm_bcast(tp3%eps_bg ,comm,0)
+    call comm_bcast(tp3%N0     ,comm,0)
+    call comm_bcast(tp3%beta2  ,comm,0)
+    call comm_bcast(tp3%Ddiff  ,comm,0)
+    call comm_bcast(tp3%kappa_e,comm,0)
+    call comm_bcast(tp3%kappa_l,comm,0)
+    call comm_bcast(tp3%dgap_c ,comm,0)
 
 ! Convert to atomic units
     tp3%Egap = tp3%Egap / hartree_ev
@@ -143,7 +179,14 @@ contains
                        * atomic_unit_of_length**3 &
                        * hartree_kelvin_relationship
     tp3%Tini = tp3%Tini / hartree_kelvin_relationship
-    ! mu_e, mu_h are dimensionless
+    ! mu_e, mu_h, eps_bg, beta2, dgap_c are taken as given (eps_bg,mu dimensionless; beta2,dgap_c in a.u.)
+    tp3%N0    = tp3%N0 * (atomic_unit_of_length*1.0d2)**3                 ! [cm^-3] -> [bohr^-3]
+    tp3%Ddiff = tp3%Ddiff * (1.0d-2/atomic_unit_of_length)**2 * atomic_unit_of_time   ! [cm^2/s] -> a.u.
+    ! thermal conductivity [W/(m K)] -> a.u. (same form as the two-temperature model)
+    tp3%kappa_e = tp3%kappa_e / hartree_joule_relationship*atomic_unit_of_length &
+                              * hartree_kelvin_relationship*atomic_unit_of_time
+    tp3%kappa_l = tp3%kappa_l / hartree_joule_relationship*atomic_unit_of_length &
+                              * hartree_kelvin_relationship*atomic_unit_of_time
 
     if ( DISPLAY ) write(*,'(a60)') repeat("-",30)//" init_ttm3_parameters(end  )"
 
@@ -201,6 +244,8 @@ contains
 
     allocate( Te(i1:j1,i2:j2,i3:j3), Th(i1:j1,i2:j2,i3:j3), Tl(i1:j1,i2:j2,i3:j3) )
     allocate( Ne(i1:j1,i2:j2,i3:j3), Nh(i1:j1,i2:j2,i3:j3) )
+    allocate( rhs_te(i1:j1,i2:j2,i3:j3), rhs_th(i1:j1,i2:j2,i3:j3), rhs_tl(i1:j1,i2:j2,i3:j3) )
+    allocate( rhs_ne(i1:j1,i2:j2,i3:j3), rhs_nh(i1:j1,i2:j2,i3:j3) )
 
     Te = tp3%Tini ; Th = tp3%Tini ; Tl = tp3%Tini
     Ne = N_floor  ; Nh = N_floor
@@ -279,7 +324,69 @@ contains
                             source(ix,iy,iz), gen(ix,iy,iz), dt )
     end do
 !$omp end parallel do
+
+    ! Stage 4: spatial transport (operator-split explicit diffusion + heat conduction)
+    call ttm3_transport( srg, rg )
   end subroutine ttm3_main
+
+  !---------------------------------------------------------------------------
+  ! Stage 4: carrier diffusion + heat conduction (recommended explicit scheme,
+  ! operator-split from the local step).  Skipped when all coefficients are zero
+  ! (then ttm3_main reproduces the verified Stage-1 local engine exactly).
+  subroutine ttm3_transport( srg, rg )
+    use structures,    only: s_rgrid, s_sendrecv_grid
+    use sendrecv_grid, only: update_overlap_real8
+    implicit none
+    type(s_sendrecv_grid), intent(inout) :: srg
+    type(s_rgrid),         intent(in)    :: rg
+    integer :: m,ix,iy,iz
+    real(8) :: cx,cy,cz,Ce,Ch,lNe,lNh,lTe,lTh,lTl
+
+    if( tp3%Ddiff<=0.0d0 .and. tp3%kappa_e<=0.0d0 .and. tp3%kappa_l<=0.0d0 ) return
+
+    cx=1.0d0/hgs(1)**2; cy=1.0d0/hgs(2)**2; cz=1.0d0/hgs(3)**2
+    call update_overlap_real8(srg, rg, Ne); call update_overlap_real8(srg, rg, Nh)
+    call update_overlap_real8(srg, rg, Te); call update_overlap_real8(srg, rg, Th)
+    call update_overlap_real8(srg, rg, Tl)
+
+!$omp parallel do private(m,ix,iy,iz,Ce,Ch,lNe,lNh,lTe,lTh,lTl)
+    do m=1,nmedia_myrnk
+       ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+       lNe=(Ne(ix+1,iy,iz)-2*Ne(ix,iy,iz)+Ne(ix-1,iy,iz))*cx &
+          +(Ne(ix,iy+1,iz)-2*Ne(ix,iy,iz)+Ne(ix,iy-1,iz))*cy &
+          +(Ne(ix,iy,iz+1)-2*Ne(ix,iy,iz)+Ne(ix,iy,iz-1))*cz
+       lNh=(Nh(ix+1,iy,iz)-2*Nh(ix,iy,iz)+Nh(ix-1,iy,iz))*cx &
+          +(Nh(ix,iy+1,iz)-2*Nh(ix,iy,iz)+Nh(ix,iy-1,iz))*cy &
+          +(Nh(ix,iy,iz+1)-2*Nh(ix,iy,iz)+Nh(ix,iy,iz-1))*cz
+       lTe=(Te(ix+1,iy,iz)-2*Te(ix,iy,iz)+Te(ix-1,iy,iz))*cx &
+          +(Te(ix,iy+1,iz)-2*Te(ix,iy,iz)+Te(ix,iy-1,iz))*cy &
+          +(Te(ix,iy,iz+1)-2*Te(ix,iy,iz)+Te(ix,iy,iz-1))*cz
+       lTh=(Th(ix+1,iy,iz)-2*Th(ix,iy,iz)+Th(ix-1,iy,iz))*cx &
+          +(Th(ix,iy+1,iz)-2*Th(ix,iy,iz)+Th(ix,iy-1,iz))*cy &
+          +(Th(ix,iy,iz+1)-2*Th(ix,iy,iz)+Th(ix,iy,iz-1))*cz
+       lTl=(Tl(ix+1,iy,iz)-2*Tl(ix,iy,iz)+Tl(ix-1,iy,iz))*cx &
+          +(Tl(ix,iy+1,iz)-2*Tl(ix,iy,iz)+Tl(ix,iy-1,iz))*cy &
+          +(Tl(ix,iy,iz+1)-2*Tl(ix,iy,iz)+Tl(ix,iy,iz-1))*cz
+       Ce=1.5d0*(Ne(ix,iy,iz)+N_floor); Ch=1.5d0*(Nh(ix,iy,iz)+N_floor)
+       rhs_ne(ix,iy,iz)=dt*tp3%Ddiff*lNe
+       rhs_nh(ix,iy,iz)=dt*tp3%Ddiff*lNh
+       rhs_te(ix,iy,iz)=dt*tp3%kappa_e/Ce*lTe
+       rhs_th(ix,iy,iz)=dt*tp3%kappa_e/Ch*lTh
+       rhs_tl(ix,iy,iz)=dt*tp3%kappa_l/tp3%Cl*lTl
+    end do
+!$omp end parallel do
+
+!$omp parallel do private(m,ix,iy,iz)
+    do m=1,nmedia_myrnk
+       ix=ijk_media_myrnk(1,m); iy=ijk_media_myrnk(2,m); iz=ijk_media_myrnk(3,m)
+       Ne(ix,iy,iz)=max(Ne(ix,iy,iz)+rhs_ne(ix,iy,iz),0.0d0)
+       Nh(ix,iy,iz)=max(Nh(ix,iy,iz)+rhs_nh(ix,iy,iz),0.0d0)
+       Te(ix,iy,iz)=Te(ix,iy,iz)+rhs_te(ix,iy,iz)
+       Th(ix,iy,iz)=Th(ix,iy,iz)+rhs_th(ix,iy,iz)
+       Tl(ix,iy,iz)=Tl(ix,iy,iz)+rhs_tl(ix,iy,iz)
+    end do
+!$omp end parallel do
+  end subroutine ttm3_transport
 
   !---------------------------------------------------------------------------
   ! Return the five fields at a probe cell, converted to output units.
@@ -298,5 +405,40 @@ contains
     Ne_o = Ne(a(1),a(2),a(3)) / cm3_per_bohr3
     Nh_o = Nh(a(1),a(2),a(3)) / cm3_per_bohr3
   end subroutine ttm3_get_state
+
+  !---------------------------------------------------------------------------
+  ! Stage 2: carrier-dependent permittivity (recommended Drude model).
+  ! eps(omega) = eps_bg - omega_p^2/omega^2,  omega_p^2 = 4*pi*(Ne/m_e + Nh/m_h);
+  ! the Drude damping (rate 1/tau) gives the conductivity sigma. All atomic units.
+  pure subroutine ttm3_permittivity( Ne_, Nh_, omega, eps_re, sig )
+    implicit none
+    real(8),intent(in)  :: Ne_, Nh_, omega
+    real(8),intent(out) :: eps_re, sig
+    real(8) :: wp2
+    wp2    = 4.0d0*pi_*( Ne_/tp3%mu_e + Nh_/tp3%mu_h )
+    eps_re = tp3%eps_bg - wp2/(omega*omega)
+    sig    = wp2/(4.0d0*pi_)*(1.0d0/tp3%tau)/(omega*omega)
+  end subroutine ttm3_permittivity
+
+  !---------------------------------------------------------------------------
+  ! Stage 3: carrier generation rate from the field-intensity envelope.
+  ! Recommended two-photon form gen = beta2 * I^2, with I = |E|^2 + |E_g|^2
+  ! (the cycle-averaged intensity from eh_get_field_envelope), atomic units.
+  pure function ttm3_generation( intensity ) result( gen )
+    implicit none
+    real(8),intent(in) :: intensity
+    real(8) :: gen
+    gen = tp3%beta2 * intensity*intensity
+  end function ttm3_generation
+
+  !---------------------------------------------------------------------------
+  ! Stage 5: band-gap renormalisation (recommended form).
+  ! Eg(Ne) = Egap - dgap_c * Ne^(1/3)  (band-gap shrinkage with carrier density).
+  pure function ttm3_gap( Ne_ ) result( Eg )
+    implicit none
+    real(8),intent(in) :: Ne_
+    real(8) :: Eg
+    Eg = tp3%Egap - tp3%dgap_c*( max(Ne_,0.0d0) )**(1.0d0/3.0d0)
+  end function ttm3_gap
 
 end module ttm3

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -28,6 +28,9 @@ module ttm3
   public :: ttm3_get_state
   public :: ttm3_get_max
   public :: ttm3_permittivity
+  public :: ttm3_eps_sig
+  public :: ttm3_ninterior
+  public :: ttm3_interior_cell
   public :: ttm3_generation
   public :: ttm3_gap
 
@@ -55,7 +58,9 @@ module ttm3
 
   integer,allocatable :: ijk_media_whole(:,:)
   integer,allocatable :: ijk_media_myrnk(:,:)
+  integer,allocatable :: ijk_interior(:,:)   ! interior medium cells (all 6 neighbours same medium)
   integer :: nmedia_myrnk
+  integer :: ninterior
   integer :: is_array(3), ie_array(3)
   integer :: comm
   real(8) :: hgs(3)
@@ -237,6 +242,38 @@ contains
        if( imedia(ix,iy,iz) /= 0 )then
           m = m + 1
           ijk_media_myrnk(1:3,m) = (/ix,iy,iz/)
+       end if
+    end do
+    end do
+    end do
+
+    ! interior medium cells (all 6 neighbours the same medium): used by the
+    ! permittivity back-action so it never touches fs%imedia (which the FDTD
+    ! setup deallocates) and keeps the interface cells' init coefficients.
+    m = 0
+    do iz=is(3),ie(3)
+    do iy=is(2),ie(2)
+    do ix=is(1),ie(1)
+       if( imedia(ix,iy,iz)/=0 .and. &
+           imedia(ix+1,iy,iz)==imedia(ix,iy,iz) .and. imedia(ix-1,iy,iz)==imedia(ix,iy,iz) .and. &
+           imedia(ix,iy+1,iz)==imedia(ix,iy,iz) .and. imedia(ix,iy-1,iz)==imedia(ix,iy,iz) .and. &
+           imedia(ix,iy,iz+1)==imedia(ix,iy,iz) .and. imedia(ix,iy,iz-1)==imedia(ix,iy,iz) ) m = m + 1
+    end do
+    end do
+    end do
+    ninterior = m
+    if( allocated(ijk_interior) ) deallocate(ijk_interior)
+    allocate( ijk_interior(3,max(m,1)) )
+    m = 0
+    do iz=is(3),ie(3)
+    do iy=is(2),ie(2)
+    do ix=is(1),ie(1)
+       if( imedia(ix,iy,iz)/=0 .and. &
+           imedia(ix+1,iy,iz)==imedia(ix,iy,iz) .and. imedia(ix-1,iy,iz)==imedia(ix,iy,iz) .and. &
+           imedia(ix,iy+1,iz)==imedia(ix,iy,iz) .and. imedia(ix,iy-1,iz)==imedia(ix,iy,iz) .and. &
+           imedia(ix,iy,iz+1)==imedia(ix,iy,iz) .and. imedia(ix,iy,iz-1)==imedia(ix,iy,iz) )then
+          m = m + 1
+          ijk_interior(1:3,m) = (/ix,iy,iz/)
        end if
     end do
     end do
@@ -469,6 +506,30 @@ contains
     eps_re = tp3%eps_bg - wp2/(omega*omega)
     sig    = wp2/(4.0d0*pi_)*(1.0d0/tp3%tau)/(omega*omega)
   end subroutine ttm3_permittivity
+
+  !---------------------------------------------------------------------------
+  ! Stage 2 back-action: carrier-dependent permittivity/conductivity at a cell
+  ! (drives the FDTD media coefficients; single-frequency static eps at omega,
+  ! the same approximation the reference uses).
+  subroutine ttm3_eps_sig( ix, iy, iz, omega, eps_re, sig )
+    implicit none
+    integer,intent(in)  :: ix,iy,iz
+    real(8),intent(in)  :: omega
+    real(8),intent(out) :: eps_re, sig
+    call ttm3_permittivity( Ne(ix,iy,iz), Nh(ix,iy,iz), omega, eps_re, sig )
+  end subroutine ttm3_eps_sig
+
+  integer function ttm3_ninterior()
+    implicit none
+    ttm3_ninterior = ninterior
+  end function ttm3_ninterior
+
+  subroutine ttm3_interior_cell( m, ix, iy, iz )
+    implicit none
+    integer,intent(in)  :: m
+    integer,intent(out) :: ix,iy,iz
+    ix=ijk_interior(1,m); iy=ijk_interior(2,m); iz=ijk_interior(3,m)
+  end subroutine ttm3_interior_cell
 
   !---------------------------------------------------------------------------
   ! Stage 3: carrier generation rate from the field-intensity envelope.

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -34,6 +34,7 @@ module ttm3
   public :: ttm3_linear_gen
   public :: ttm3_drude_coef
   public :: ttm3_drude_coef_cell
+  public :: ttm3_drude_osc_cell
   public :: ttm3_eps_sig
   public :: ttm3_coupling_mode
   public :: ttm3_ninterior
@@ -624,8 +625,8 @@ contains
     Th_ = Th_star + (Th_-Th_star)*exp( -rate_h*dt_in )
 
     ! carrier densities and lattice: explicit Euler (non-stiff); +Col thermal generation
-    Ne_ = max( Ne_ + dt_in*(geff - R + Col), 0.0d0 )
-    Nh_ = max( Nh_ + dt_in*(geff - R + Col), 0.0d0 )
+    Ne_ = min( max( Ne_ + dt_in*(geff - R + Col), 0.0d0 ), tp3%N0 )   ! cap at valence density
+    Nh_ = min( max( Nh_ + dt_in*(geff - R + Col), 0.0d0 ), tp3%N0 )
     Tl_ = max( Tl_ + dt_in*dTl, 0.0d0 )
 
     ! numerical guard (should not trigger now that the stiff modes are integrated exactly)
@@ -1021,12 +1022,12 @@ contains
   ! wp^2 = 4*pi*Ne*(1/mu_eo+1/mu_ho).  c1=(1-g dt/2)/(1+g dt/2), c2=wp^2 dt/(8 pi (1+g dt/2))
   ! (the same form as the validated Lorentz-Drude pole, c2_jx_ld).  This replaces the
   ! eps/sigma back-action (which is unstable in the real-field FDTD as sigma grows fast).
-  pure subroutine ttm3_drude_coef( Ne_, Te_, Tl_, omega, dt, c1, c2 )
+  pure subroutine ttm3_gamma_wp2( Ne_, Te_, Tl_, ge, wp2 )
     implicit none
-    real(8),intent(in)  :: Ne_, Te_, Tl_, omega, dt
-    real(8),intent(out) :: c1, c2
+    real(8),intent(in)  :: Ne_, Te_, Tl_
+    real(8),intent(out) :: ge, wp2
     real(8),parameter :: mu_eo=0.26d0, mu_ho=0.37d0, kbT_r=3.1668d-6, a_t_=2.419d-2, E_h_=27.2114d0
-    real(8) :: red,red2,Cg,Tryd,Pe,Tf,aa,gsp,gph,g1e,ge,TeK,TlK,argl,wp2,c0
+    real(8) :: red,red2,Cg,Tryd,Pe,Tf,aa,gsp,gph,g1e,TeK,TlK,argl
     TeK=max(Te_,1.0d-12)/kbT_r; TlK=Tl_/kbT_r
     red  = 1.0d0/(1.0d0/mu_eo+1.0d0/mu_ho)
     red2 = 1.0d0/(1.0d0/tp3%mu_e+1.0d0/tp3%mu_h)
@@ -1043,11 +1044,24 @@ contains
     end if
     gph = 4.0d-4*TlK*a_t_
     g1e = a_t_/( 0.98d0 + 0.2d0*(kbT_r*TeK*E_h_)**(-3.5d0) )
-    ge  = max( gsp+gph+g1e, 1.0d-30 )                              ! collision rate
-    wp2 = 4.0d0*pi_*Ne_*( 1.0d0/mu_eo + 1.0d0/mu_ho )             ! combined e+h plasma freq^2
-    c0  = 1.0d0 + ge*dt/2.0d0
-    c1  = ( 1.0d0 - ge*dt/2.0d0 )/c0
-    c2  = wp2*dt/( 4.0d0*pi_*c0 )                 ! drive with ex (=ex_y+ex_z); 4pi gives correct Drude sigma
+    ge  = max( gsp+gph+g1e, 1.0d-30 )
+    wp2 = 4.0d0*pi_*Ne_*( 1.0d0/mu_eo + 1.0d0/mu_ho )
+  end subroutine ttm3_gamma_wp2
+
+  pure subroutine ttm3_drude_coef( Ne_, Te_, Tl_, omega, dt, c1, c2 )
+    implicit none
+    real(8),intent(in)  :: Ne_, Te_, Tl_, omega, dt
+    real(8),intent(out) :: c1, c2
+    real(8) :: ge, wp2, c0
+    call ttm3_gamma_wp2( Ne_, Te_, Tl_, ge, wp2 )
+    if( tp3%coupling_mode == 2 )then              ! ETD (exponential) Drude current integrator
+       c1  = exp( -ge*dt )
+       c2  = ( 1.0d0 - c1 )/ge * wp2/( 4.0d0*pi_ )
+    else                                          ! bilinear (Crank-Nicolson), mode 0
+       c0  = 1.0d0 + ge*dt/2.0d0
+       c1  = ( 1.0d0 - ge*dt/2.0d0 )/c0
+       c2  = wp2*dt/( 4.0d0*pi_*c0 )
+    end if
   end subroutine ttm3_drude_coef
 
   ! Cell wrapper: ADE Drude coefficients from the cell's carrier state (for the FDTD coupling).
@@ -1058,6 +1072,16 @@ contains
     real(8),intent(out) :: c1, c2
     call ttm3_drude_coef( Ne(ix,iy,iz)+N_floor, Te(ix,iy,iz), Tl(ix,iy,iz), omega, dt, c1, c2 )
   end subroutine ttm3_drude_coef_cell
+
+  ! Cell wrapper: raw Drude-oscillator parameters (eps_bg, gamma, wp^2) for the exact
+  ! exponential sub-step (coupling_mode=3).
+  subroutine ttm3_drude_osc_cell( ix, iy, iz, eps_bg, gamma, wp2 )
+    implicit none
+    integer,intent(in)  :: ix,iy,iz
+    real(8),intent(out) :: eps_bg, gamma, wp2
+    call ttm3_gamma_wp2( Ne(ix,iy,iz)+N_floor, Te(ix,iy,iz), Tl(ix,iy,iz), gamma, wp2 )
+    eps_bg = tp3%eps_bg
+  end subroutine ttm3_drude_osc_cell
 
   pure subroutine ttm3_permittivity( Ne_, Nh_, Te_, Th_, Tl_, omega, eps_re, sig )
     implicit none
@@ -1152,6 +1176,7 @@ contains
     TlK = Tl_*hk_kelvin
     Eg = tp3%Egap - tp3%dgap_c*( max(Ne_,0.0d0) )**(1.0d0/3.0d0) &
                   - 7.02d-4*TlK*TlK/(TlK+1108.0d0)/27.2114d0
+    Eg = max( Eg, 0.0d0 )   ! gap collapse: clamp at 0 (Mott handoff), matches standalone
   end function ttm3_gap
 
 end module ttm3

--- a/src/ttm/ttm3.f90
+++ b/src/ttm/ttm3.f90
@@ -891,21 +891,58 @@ contains
   ! Stage 2: carrier-dependent permittivity (recommended Drude model).
   ! eps(omega) = eps_bg - omega_p^2/omega^2,  omega_p^2 = 4*pi*(Ne/m_e + Nh/m_h);
   ! the Drude damping (rate 1/tau) gives the conductivity sigma. All atomic units.
-  pure subroutine ttm3_permittivity( Ne_, Nh_, omega, eps_re, sig )
+  ! Layer C-b1: strong carrier-temperature-dependent Drude (reference TOTAL_DIELE + Diel_Func).
+  ! The electron-hole scattering rate gamma_eh rises with carrier density and temperature, so
+  ! the free-carrier absorption climbs sharply as the material metallizes -- the T_e "second
+  ! rise" that the fixed-tau Drude misses.  Ported verbatim with the reference constants
+  ! (kbT, a_t, E_h, optical masses mu_eo/mu_ho); ttm3 stores T_e = k_B T [Ha] so the reference's
+  ! Kelvin temperature is T/kbT.  Ne in bohr^-3 matches the reference.
+  pure subroutine ttm3_drude( Ne_, Te_, Th_, Tl_, omega, eps_re, sig )
     implicit none
-    real(8),intent(in)  :: Ne_, Nh_, omega
+    real(8),intent(in)  :: Ne_, Te_, Th_, Tl_, omega
     real(8),intent(out) :: eps_re, sig
-    real(8) :: wp2, sig_d, bf
-    wp2   = 4.0d0*pi_*( Ne_/tp3%mu_e + Nh_/tp3%mu_h )
-    sig_d = wp2/(4.0d0*pi_)*(1.0d0/tp3%tau)/(omega*omega)        ! Drude (free-carrier)
+    real(8),parameter :: mu_eo=0.26d0, mu_ho=0.37d0                 ! Drude optical masses
+    real(8),parameter :: kbT_r=3.1668d-6, a_t_=2.419d-2, E_h_=27.2114d0
+    real(8) :: red,red2,Cg,Tryd,Pe,Tf,aa,gsp,gph,g1e,g1h,ge,gh,TeK,ThK,TlK,xE,xH,w2,wpe,wph,argl
+    TeK=max(Te_,1.0d-12)/kbT_r; ThK=max(Th_,1.0d-12)/kbT_r; TlK=Tl_/kbT_r
+    red  = 1.0d0/(1.0d0/mu_eo+1.0d0/mu_ho)
+    red2 = 1.0d0/(1.0d0/tp3%mu_e+1.0d0/tp3%mu_h)                    ! band masses
+    Cg   = 16.0d0/9.0d0*pi_**(-1.5d0)
+    Tryd = red*0.5d0/(11.7d0**2)*(16.0d0*pi_*pi_)
+    Pe   = (3.0d0*pi_*pi_*max(Ne_,1.0d-30))**(2.0d0/3.0d0)
+    Tf   = 0.5d0*Pe/(red2*kbT_r)                                   ! Fermi temperature [K]
+    argl = sqrt(Tryd*Tf)*Tf
+    aa   = 1.0d0/sqrt( sqrt(kbT_r)/argl )*exp(2.0d0/3.0d0)
+    if( TeK > aa )then                                             ! Spitzer e-h scattering
+       gsp = abs( Cg*Tryd*(Tf/TeK)**1.5d0 * log( TeK*TeK*sqrt(kbT_r)/argl ) )
+    else
+       gsp = Cg*Tryd*(Tf/aa)**1.5d0 * log( aa*aa*sqrt(kbT_r)/argl )
+    end if
+    gph = 4.0d-4*TlK*a_t_                                          ! phonon
+    g1e = a_t_/( 0.98d0 + 0.2d0*(kbT_r*TeK*E_h_)**(-3.5d0) )       ! correction (electron temp)
+    g1h = a_t_/( 0.98d0 + 0.2d0*(kbT_r*ThK*E_h_)**(-3.5d0) )       ! correction (hole temp)
+    ge  = max( gsp+gph+g1e, 1.0d-30 ); gh = max( gsp+gph+g1h, 1.0d-30 )
+    w2  = omega*omega; xE = ge/omega; xH = gh/omega
+    wpe = 4.0d0*pi_*Ne_/mu_eo; wph = 4.0d0*pi_*Ne_/mu_ho           ! ambipolar: Nh=Ne
+    eps_re = -wpe/w2/(1.0d0+xE*xE) - wph/w2/(1.0d0+xH*xH)          ! Re(eps_Drude), e+h
+    sig    = ( wpe/w2*xE/(1.0d0+xE*xE) + wph/w2*xH/(1.0d0+xH*xH) )*omega/(4.0d0*pi_)
+  end subroutine ttm3_drude
+
+  pure subroutine ttm3_permittivity( Ne_, Nh_, Te_, Th_, Tl_, omega, eps_re, sig )
+    implicit none
+    real(8),intent(in)  :: Ne_, Nh_, Te_, Th_, Tl_, omega
+    real(8),intent(out) :: eps_re, sig
+    real(8) :: wp2, bf, eps_d, sig_d
     if( tp3%sig_cold > 0.0d0 )then
-       ! Layer C-a: bound interband part scaled by band filling (1-Ne/N0), plus Drude.
+       ! Layer C-a/b: band-filled bound interband part + strong carrier-T Drude.
+       call ttm3_drude( Ne_, Te_, Th_, Tl_, omega, eps_d, sig_d )
        bf     = max( 1.0d0 - Ne_/tp3%N0, 0.0d0 )
-       eps_re = tp3%eps_bg*bf - wp2/(omega*omega)
+       eps_re = tp3%eps_bg*bf + eps_d
        sig    = tp3%sig_cold*bf + sig_d
     else
+       wp2    = 4.0d0*pi_*( Ne_/tp3%mu_e + Nh_/tp3%mu_h )          ! legacy simple Drude
        eps_re = tp3%eps_bg - wp2/(omega*omega)
-       sig    = sig_d
+       sig    = wp2/(4.0d0*pi_)*(1.0d0/tp3%tau)/(omega*omega)
     end if
   end subroutine ttm3_permittivity
 
@@ -920,7 +957,7 @@ contains
     implicit none
     integer,intent(in) :: ix,iy,iz
     real(8),intent(in) :: omega, power
-    real(8) :: gen, bf, sig_b, sig_d, wp2
+    real(8) :: gen, bf, sig_b, sig_d, eps_d
     if( power <= 0.0d0 )then
        gen = 0.0d0; return
     end if
@@ -929,8 +966,7 @@ contains
     end if
     bf    = max( 1.0d0 - Ne(ix,iy,iz)/tp3%N0, 0.0d0 )
     sig_b = tp3%sig_cold*bf
-    wp2   = 4.0d0*pi_*( Ne(ix,iy,iz)/tp3%mu_e + Nh(ix,iy,iz)/tp3%mu_h )
-    sig_d = wp2/(4.0d0*pi_)*(1.0d0/tp3%tau)/(omega*omega)
+    call ttm3_drude( Ne(ix,iy,iz), Te(ix,iy,iz), Th(ix,iy,iz), Tl(ix,iy,iz), omega, eps_d, sig_d )
     gen   = power/omega * sig_b/( sig_b + sig_d + 1.0d-50 )      ! bound fraction only
   end function ttm3_linear_gen
 
@@ -943,7 +979,7 @@ contains
     integer,intent(in)  :: ix,iy,iz
     real(8),intent(in)  :: omega
     real(8),intent(out) :: eps_re, sig
-    call ttm3_permittivity( Ne(ix,iy,iz), Nh(ix,iy,iz), omega, eps_re, sig )
+    call ttm3_permittivity( Ne(ix,iy,iz), Nh(ix,iy,iz), Te(ix,iy,iz), Th(ix,iy,iz), Tl(ix,iy,iz), omega, eps_re, sig )
   end subroutine ttm3_eps_sig
 
   integer function ttm3_ninterior()


### PR DESCRIPTION
**Draft / WIP** — opening for early review and to track the three-temperature (3TM) carrier model port. Validation is ongoing (see Status).

## What this adds
A **three-temperature model** (separate electron, hole, and lattice quasi-temperatures + electron/hole carrier densities) coupled to the Maxwell-FDTD field solver, in a new `ttm3` module. Ported from the standalone reference 3TM implementation (*Appl. Phys. Express* **15**, 041008 (2022)) for laser-excitation / damage-threshold studies in silicon.

## Key pieces
- **Maxwell–carrier coupling**: exact 2×2 matrix-exponential of the Drude J–E oscillator (`ttm_coupling=3`) — unconditionally stable and energy-conserving in the metallic (ε<0) regime. Modes 0/1/2/3 are selectable to isolate the discretization (mode 1 = the eps-update back-action, which diverges at metallization).
- **Heating source**: cycle-averaged absorbed power `½(−∇·S − ∇·S_g)` via the envelope ghost field (builds on #1266).
- **Local physics**: single- + two-photon generation with bound/free(Drude) split, Auger recombination, impact ionization, Fermi–Dirac carrier heat capacity, `red_e/red_h` mass partition, Fermi–Dirac transport set (mobility/diffusion/conductivity/current), and the ambipolar space-charge field.
- **Parallelism**: transverse **and** x-domain MPI decomposition — the space-charge prefix-sum and the front/max diagnostics use a parallel prefix-sum + global reductions, giving results **bit-identical** to a single rank. NUMA-safe 4 MPI × 12 OMP on A64FX.
- **Input interface**: select via `theory='maxwell-3tm'` (normalized to `maxwell` + `yn_use_ttm3` after `read_input`) and an `&ttm` namelist for all parameters.

## Status / remaining
- Core dynamics validated against the standalone reference (intensity/seed-independent dilution-plateau `Te`).
- Quantitative reproduction of the reference's published Fig. 1 is in progress.
- Optics is currently table/Drude; a fully dispersive dielectric (gap-dependent interband absorption, T-dependent n,k) for quantitative ablation-threshold work is future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
