### PR TITLE
Fix I6 filename/index overflow in multiscale Ac, field-snapshot, restart-dir and k-expand naming

### DIFF
--- a/src/io/checkpoint_restart.f90
+++ b/src/io/checkpoint_restart.f90
@@ -66,8 +66,8 @@ subroutine generate_checkpoint_directory_name(header,iter,gdir,pdir)
   character(256),intent(out) :: gdir
   character(256),intent(out) :: pdir
 
-  ! global directory
-  write(gdir,'(A,A,A,I6.6,A)') trim(base_directory)//"checkpoint_",trim(header),"_",iter,"/"
+  ! global directory (i0.6: keep 6-digit zero-padding but widen automatically for iter >= 1e6)
+  write(gdir,'(A,A,A,i0.6,A)') trim(base_directory)//"checkpoint_",trim(header),"_",iter,"/"
   ! process private directory
   write(pdir,'(A,A,I6.6,A)')   trim(gdir),'rank_',nproc_id_global,'/'
 end subroutine generate_checkpoint_directory_name
@@ -79,8 +79,9 @@ subroutine generate_restart_directory_name(basedir,gdir,pdir)
   character(256),intent(out) :: gdir
   character(256),intent(out) :: pdir
 
-  ! global directory
-  write(gdir,'(A,I6.6,A)')   trim(basedir)
+  ! global directory (gdir = basedir; the old '(A,I6.6,A)' had no integer arg for I6.6,
+  !  a format/output-list mismatch that aborts under the Fujitsu runtime on the final RT-restart write)
+  write(gdir,'(A)')          trim(basedir)
   ! process private directory
   write(pdir,'(A,A,I6.6,A)') trim(gdir),'rank_',nproc_id_global,'/'
 end subroutine generate_restart_directory_name

--- a/src/io/main_dft_k_expand.f90
+++ b/src/io/main_dft_k_expand.f90
@@ -342,8 +342,9 @@ subroutine get_print_rank_numbers(kex,info)
     character(256),intent(out) :: pdir(kex%nk)
     integer :: ik, nproc_id_kex
 
-    ! global directory
-    write(gdir,'(A,I6.6,A)')   trim(basedir)
+    ! global directory (gdir = basedir; the old '(A,I6.6,A)' had no integer arg for I6.6,
+    !  a format/output-list mismatch that aborts under the Fujitsu runtime, same as generate_restart_directory_name)
+    write(gdir,'(A)')          trim(basedir)
 
     ! process private directory for k-expand
     do ik=1,kex%nk

--- a/src/io/main_dft_k_expand_slice.f90
+++ b/src/io/main_dft_k_expand_slice.f90
@@ -317,7 +317,8 @@ subroutine assign_rank_mumber_to_read_write_files(kex,system,info)
     character(256),intent(out) :: pdir(:)
     integer :: ik,io,nblock, i
 
-    write(gdir,'(A,I6.6,A)')   trim(directory_read_data)
+    ! gdir = directory_read_data; '(A,I6.6,A)' had no integer arg for I6.6 (format/output-list mismatch, aborts on Fujitsu runtime)
+    write(gdir,'(A)')          trim(directory_read_data)
 
     i=0
     do ik=1,system%nk 
@@ -337,7 +338,8 @@ subroutine assign_rank_mumber_to_read_write_files(kex,system,info)
     character(256),intent(out) :: pdir(:)
     integer :: icnt, i,ik_new,io_new, nblock
 
-    write(gdir,'(A,I6.6,A)')   trim(odir)
+    ! gdir = odir; '(A,I6.6,A)' had no integer arg for I6.6 (format/output-list mismatch, aborts on Fujitsu runtime)
+    write(gdir,'(A)')          trim(odir)
 
     ik_new=1
     i=0

--- a/src/io/write_field.f90
+++ b/src/io/write_field.f90
@@ -53,7 +53,7 @@ subroutine write_dns(lg,mg,system,info,rho_s,rho0_s,itt)
     suffix_u = trim(base_directory)//trim(sysname)//"_dns_u"
     suffix_d = trim(base_directory)//trim(sysname)//"_dns_d"
   case('dft_md','tddft_response','tddft_pulse','single_scale_maxwell_tddft','multi_scale_maxwell_tddft')
-    write(filenum, '(i6.6)') itt
+    write(filenum, '(i0.6)') itt
     suffix =   trim(base_directory)//trim(sysname)//"_dns_"//adjustl(filenum)
     suffix_u = trim(base_directory)//trim(sysname)//"_dns_u_"//adjustl(filenum)
     suffix_d = trim(base_directory)//trim(sysname)//"_dns_d_"//adjustl(filenum)
@@ -87,7 +87,7 @@ subroutine write_dns(lg,mg,system,info,rho_s,rho0_s,itt)
     dns = dns - wrk2
     !$omp end workshare
 
-    write(filenum, '(i6.6)') itt
+    write(filenum, '(i0.6)') itt
     suffix   = trim(base_directory)//trim(sysname)//"_dnsdiff_"//adjustl(filenum)
     suffix_u = trim(base_directory)//trim(sysname)//"_dnsdiff_u_"//adjustl(filenum)
     suffix_d = trim(base_directory)//trim(sysname)//"_dnsdiff_d_"//adjustl(filenum)
@@ -204,7 +204,7 @@ subroutine write_dns_ac_je(info,mg,system,rho,fw,itt,action)
      if(comm_is_root(nproc_id_global)) then
 
         fp = 299
-        write(filenum1,'(i6.6)') itt
+        write(filenum1,'(i0.6)') itt
         filenum1=adjustl(filenum1)
         ofile =trim(wdir1)//"it"//trim(filenum1)//"_ion.bin"
         open(fp,file=trim(ofile),form='unformatted',access='stream')
@@ -218,7 +218,7 @@ subroutine write_dns_ac_je(info,mg,system,rho,fw,itt,action)
      if(comm_is_root(info%id_ko)) then
 
         fp = 300 + info%id_r
-        write(filenum1,'(i6.6)') itt
+        write(filenum1,'(i0.6)') itt
         write(filenum2,'(i6.6)') info%id_r
         filenum1=adjustl(filenum1)
         filenum2=adjustl(filenum2)
@@ -606,7 +606,7 @@ subroutine write_elf(itt,lg,mg,system,info,stencil,rho,srg,srg_scalar,tpsi)
   case('dft','dft_band','dft_md') 
     suffix = trim(base_directory)//trim(sysname)//"_elf"
   case('tddft_response','tddft_pulse','single_scale_maxwell_tddft','multi_scale_maxwell_tddft')
-    write(filenum, '(i6.6)') itt
+    write(filenum, '(i0.6)') itt
     suffix = trim(base_directory)//trim(sysname)//"_elf_"//adjustl(filenum)
   case default
     stop 'invalid theory'
@@ -680,7 +680,7 @@ subroutine write_estatic(lg,mg,system,stencil,info,Vh,srg_scalar,itt)
  
     call comm_summation(rmat,rmat2,lg%num(1)*lg%num(2)*lg%num(3),info%icomm_r)
   
-    write(filenum, '(i6.6)') itt
+    write(filenum, '(i0.6)') itt
     if(jj==1)then
       suffix = trim(base_directory)//trim(sysname)//"_Exsta_"//adjustl(filenum)
       phys_quantity = "exsta"

--- a/src/ms/main_ms.f90
+++ b/src/ms/main_ms.f90
@@ -568,7 +568,9 @@ subroutine write_RT_Ac_file()
     
     if (comm_is_root(ms%id_ms_world)) then
         fh_ac_data = get_filehandle()
-        write(file_ac_data, '(a,a,"_Ac_",i6.6,".data")') trim(ms%base_directory_RT_Ac), trim(sysname), itt
+        ! i0.6: keep 6-digit zero-padding but widen automatically for itt >= 1e6
+        ! (old i6.6 overflowed to "******", colliding/overwriting frames for step >= 1,000,000)
+        write(file_ac_data, '(a,a,"_Ac_",i0.6,".data")') trim(ms%base_directory_RT_Ac), trim(sysname), itt
         open(fh_ac_data, file=trim(file_ac_data))
         write(fh_ac_data, '(a)') "# Multiscale TDDFT calculation"
         write(fh_ac_data, '(a)') "# IX, IY, IZ: FDTD Grid index"


### PR DESCRIPTION
## Summary

Fixed-width integer edit descriptors used to build filenames and restart/checkpoint directory names in `src/io` and `src/ms`. Two classes:

1. **`i6.6` filename/index overflow** — a 6-digit zero-padded step/iteration counter overflows to `******` once the counter reaches `1,000,000`, silently colliding every subsequent frame onto one filename. Real functional bug for long runs (`nt >= 1e6`).
2. **Format / output-list mismatches** — `write(x,'(A,I6.6,A)') trim(...)` : a format with an `I6.6` (and trailing `A`) edit descriptor but only one character output item, i.e. no integer argument for the `I6.6`. This is nonconforming Fortran; today it happens to produce the intended `x = trim(...)` via format reversion (format control terminates at the first data-edit descriptor with no matching item), so it is not currently observed to fail, but it is fragile and should be corrected.

### 1. Multiscale `Ac` field-snapshot filename overflow (`src/ms/main_ms.f90`) — class 1

```fortran
write(file_ac_data, '(a,a,"_Ac_",i6.6,".data")') ..., itt
```

For `itt >= 1,000,000` the field overflows to `Ac_******.data`, so every frame for steps `1e6 ... nt` collides on the same filename and overwrites the previous one — the late-time field snapshots of long-pulse multiscale runs are silently lost. Fixed by widening to `i0.6` (identical 6-digit zero-padding below `1e6`, grows automatically past it). Logic/compile-verified (no `nt >= 1e6` live run in this PR).

### 2. Real-space snapshot filenames in `write_field.f90` — class 1

The RT step counter `itt` is formatted with `i6.6` in nine snapshot filename builders (`_dns_`, `_dnsdiff_`, microscopic current / magnetization / spin-current, `_elf_`, `_Exsta_`, and the per-step ion / field `.bin`). Same `itt >= 1e6` overflow as (1). Widened to `i0.6`. The MPI-rank `id_r` writes are intentionally left at `i6.6` (bounded by `nproc`, not a growing step counter).

### 3. Checkpoint-directory iteration index (`src/io/checkpoint_restart.f90`) — class 1

`generate_checkpoint_directory_name` formatted the checkpoint `iter` with `i6.6`; widened to `i0.6` (same overflow class; would bite `nt >= 1e6` runs with periodic checkpointing).

### 4. Format / output-list mismatches — class 2

`generate_restart_directory_name` (`src/io/checkpoint_restart.f90`) and three copies in the k-expand restart helpers (`src/io/main_dft_k_expand.f90:346`, `src/io/main_dft_k_expand_slice.f90:320,340`) all built a directory string with `write(gdir,'(A,I6.6,A)') trim(...)` — three edit descriptors, one output item, no integer for the `I6.6`. Replaced with the conforming `write(gdir,'(A)') trim(...)` (identical result, `gdir = trim(basedir/odir/directory_read_data)`).

## Scope note (what this PR does NOT fix)

An earlier draft of this PR attributed the production RT restart-write abort (`data_for_restart_rt/` left empty, `MPI_File_open` / `CODE=1907` at the RT end-of-run checkpoint) to the `generate_restart_directory_name` mismatch in (4). A real-hardware GS→RT validation on the fixed binary showed that is **not** the cause: GS restart succeeds and the RT restart write still aborts identically with the (4) fix in place. That abort is a **separate, independent bug** — an uninitialized `ofl%dir_out_restart` passed to the RT checkpoint because `initialization_rt` calls `init_dft` with a throwaway local instead of the returned `ofl` — and is addressed in a separate PR. The changes here are I6-overflow fixes (real for `nt >= 1e6`) and format-conformance cleanups; they are not tied to that RT-restart abort.

## Verification

- `i0.6` behavior: `12345 -> 012345`, `999999 -> 999999`, `1000000 -> 1000000`, `1234567 -> 1234567` (no overflow, sortable).
- `(4)` result unchanged: `gdir = trim(basedir)`; callers consume `gdir` directly (`wdir = gdir`, then `pdir = trim(gdir)//'rank_'...`), no caller expects an appended index; no reader parses these filenames for the step index, so the widened `i0.6` does not break globbing.
- Compiles cleanly on Fugaku (A64FX, `mpifrtpx`, `--arch=fujitsu-a64fx-ea`).
- GS restart write exercised successfully on the fixed binary in the validation run above (`data_for_restart/` fully populated).
