### PR TITLE
fix(rt): pass ofl to init_dft so RT writes a non-empty data_for_restart_rt

### DIFF
--- a/src/rt/initialization_rt.f90
+++ b/src/rt/initialization_rt.f90
@@ -89,8 +89,7 @@ subroutine initialization_rt( Mit, system, energy, ewald, rt, md, &
   type(s_pp_grid) :: ppg
   type(s_pp_nlcc) :: ppn
   type(s_singlescale) :: singlescale
-  type(s_ofile) :: ofile
-  
+
   integer :: iob, i1,iik,jspin, Mit, m, n
   integer :: idensity, idiffDensity
   integer :: jj, ix,iy,iz
@@ -194,7 +193,7 @@ subroutine initialization_rt( Mit, system, energy, ewald, rt, md, &
   call timer_begin(LOG_READ_GS_DATA)
   call nvtxStartRange('READ_GS_DATA', __LINE__)
   
-  call init_dft(nproc_group_global,info,lg,mg,system,stencil,fg,poisson,srg,srg_scalar,ofile)
+  call init_dft(nproc_group_global,info,lg,mg,system,stencil,fg,poisson,srg,srg_scalar,ofl)
   
   call init_code_optimization
   


### PR DESCRIPTION
## Summary

`initialization_rt` passed a **fresh, uninitialized local** `type(s_ofile) :: ofile` to
`init_dft` instead of the subroutine's own `ofl` argument. `init_dft` is what populates
`ofl%dir_out_restart` (the directory RT later writes its restart set into). Because the
real `ofl` never received that initialization, `ofl%dir_out_restart` was left as
uninitialized memory (a garbage path), so when RT wrote its restart data at the end of
propagation it went nowhere usable — `data_for_restart_rt/` came out **empty**.

The fix passes the actual `ofl` argument to `init_dft` and drops the throwaway local
`ofile` declaration.

```
-  call init_dft(...,srg_scalar,ofile)
+  call init_dft(...,srg_scalar,ofl)
```

`src/rt/initialization_rt.f90` (the `READ_GS_DATA` region).

This is a **different bug** from the `i6`/`dirname` filename-index issue — that one does not
fix this; the RT restart directory stays empty until `ofl` is threaded through here.

## Verification (Fugaku / A64FX, Si, GS→RT restart smoke)

Built at this branch HEAD and ran a GS→RT restart chain:

- **GS** — converged cleanly (residual 6.7e-8 < 1e-7, gap 2.077 eV, Ne=8), wrote a
  populated flat `data_for_restart/`.
- **RT** — restart-chained off that GS dir with `write_rt_wfn_k='y'`; propagated to the full
  `nt`, `end SALMON`, Ne conserved exactly, energy smooth (no blow-up).
- **The gate** — after the fix, `data_for_restart_rt/` is written **non-empty at the correct
  resolved path** (not a garbage path): `wfn.bin` (21.2 MB), `Vh_stock.bin`,
  `occupation.bin`, `info.bin`, `atomic_coor.txt`, `atomic_vel.txt`. Before the fix this
  directory was empty.

## Scope

One-line behavioral change plus removal of the now-unused local declaration. No interface,
namelist, or output-format changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
