### PR TITLE
Draft: OpenACC tuning + nvhpc/26.5 fixes (device-side loop tripcounts, MPI_Init CUDA-context hang)

### DIFF
--- a/platforms/nvhpc-openacc-gemm.cmake
+++ b/platforms/nvhpc-openacc-gemm.cmake
@@ -1,0 +1,24 @@
+set(CMAKE_Fortran_COMPILER      "mpif90")
+set(CMAKE_C_COMPILER            "mpicc")
+set(OPENMP_FLAGS                "-Mnoopenmp")
+
+set(General_Fortran_FLAGS       "-Wall -fstrict-aliasing")
+set(General_C_FLAGS             "-Wall -alias=ansi")
+
+# OpenACC + cuBLAS batched-GEMM path for pseudo-pt (USE_GEMM), not the hand-written CUDA kernels (USE_CUDA).
+set(OpenACC_FLAGS               "-acc=strict -gpu=cc80,cc90,cc100,cc120,managed,ptxinfo -cudalib=cublas,cusolver -cuda -Minfo=accel -DUSE_OPENACC -DUSE_GEMM")
+
+set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g -traceback ${General_Fortran_FLAGS} ${OpenACC_FLAGS}")
+set(CMAKE_C_FLAGS_DEBUG         "-O2 -g -traceback ${General_C_FLAGS} ${OpenACC_FLAGS}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${General_Fortran_FLAGS} ${OpenACC_FLAGS}")
+set(CMAKE_C_FLAGS_RELEASE       "-O3 ${General_C_FLAGS} ${OpenACC_FLAGS}")
+
+set(USE_MPI_DEFAULT             ON)
+set(USE_OPENACC                 ON)
+set(USE_CUDA                    OFF)
+
+########
+# CMake Platform-specific variables
+########
+set(CMAKE_SYSTEM_NAME "Linux" CACHE STRING "Compiling for x86_64 + Nvidia GPU")
+set(CMAKE_SYSTEM_PROCESSOR "openacc")

--- a/platforms/nvhpc-openacc-nccl.cmake
+++ b/platforms/nvhpc-openacc-nccl.cmake
@@ -1,0 +1,24 @@
+set(CMAKE_Fortran_COMPILER      "mpif90")
+set(CMAKE_C_COMPILER            "mpicc")
+set(OPENMP_FLAGS                "-Mnoopenmp")
+
+set(General_Fortran_FLAGS       "-Wall -fstrict-aliasing")
+set(General_C_FLAGS             "-Wall -alias=ansi")
+
+# As nvhpc-openacc-gemm.cmake, plus NCCL for the pseudo-pt domain-decomposition allreduce (USE_NCCL).
+set(OpenACC_FLAGS               "-acc=strict -gpu=cc80,cc90,cc100,cc120,managed,ptxinfo -cudalib=cublas,cusolver,nccl -cuda -Minfo=accel -DUSE_OPENACC -DUSE_GEMM -DUSE_NCCL")
+
+set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g -traceback ${General_Fortran_FLAGS} ${OpenACC_FLAGS}")
+set(CMAKE_C_FLAGS_DEBUG         "-O2 -g -traceback ${General_C_FLAGS} ${OpenACC_FLAGS}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${General_Fortran_FLAGS} ${OpenACC_FLAGS}")
+set(CMAKE_C_FLAGS_RELEASE       "-O3 ${General_C_FLAGS} ${OpenACC_FLAGS}")
+
+set(USE_MPI_DEFAULT             ON)
+set(USE_OPENACC                 ON)
+set(USE_CUDA                    OFF)
+
+########
+# CMake Platform-specific variables
+########
+set(CMAKE_SYSTEM_NAME "Linux" CACHE STRING "Compiling for x86_64 + Nvidia GPU")
+set(CMAKE_SYSTEM_PROCESSOR "openacc")

--- a/src/atom/pp/prep_pp.f90
+++ b/src/atom/pp/prep_pp.f90
@@ -170,15 +170,12 @@ subroutine init_ps(lg,mg,system,info,fg,poisson,pp,ppg,Vpsl)
   call timer_end(LOG_INIT_PS_UVPSI)
 
 #ifdef USE_OPENACC
-  if(info%if_divide_rspace) then
-  else
-    allocate(ppg%uVpsibox(ppg%nlma, &
-                          system%nspin, &
-                          info%io_s:info%io_e, &
-                          info%ik_s:info%ik_e, &
-                          info%im_s:info%im_e))
-    call init_uvpsi_blocking(ppg,mg)
-  end if
+  allocate(ppg%uVpsibox(ppg%nlma, &
+                        system%nspin, &
+                        info%io_s:info%io_e, &
+                        info%ik_s:info%ik_e, &
+                        info%im_s:info%im_e))
+  call init_uvpsi_blocking(ppg,mg)
 #endif
 
   if(iperiodic==3) then

--- a/src/common/density_matrix.f90
+++ b/src/common/density_matrix.f90
@@ -221,6 +221,10 @@ contains
     use timer
     use iso_c_binding
     use nvtx_wrapper
+#if defined(USE_OPENACC) && defined(USE_GEMM)
+    use cublas
+    use openacc
+#endif
     implicit none
 #if defined(USE_OPENACC)
     interface
@@ -277,6 +281,21 @@ contains
     integer    :: ix,iy,iz
     real(8)    :: rtmp
     complex(8) :: cpsi,xtmp,ytmp,ztmp
+#if defined(USE_OPENACC) && defined(USE_GEMM)
+    ! Batched-GEMM nonlocal current: zpseudo's phase-1 contraction, but four
+    ! projections per (ilma,io) -- zekr_uV plus x/y/z-weighted copies, stacked
+    ! into one packed matrix (4x zpseudo's) so a single GEMM returns all four.
+    integer, parameter :: cur_io_block = 64
+    integer,                     save :: cur_max_nproj = -1
+    integer,    allocatable,     save :: cur_nproj_atom(:), cur_l2g(:,:)
+    complex(8), allocatable,     save :: cur_zekr4(:,:,:), cur_wf(:,:,:), cur_out(:,:,:)
+    real(8),    allocatable,     save :: cur_rinv(:,:)
+    type(cublasHandle),          save :: cur_handle
+    integer    :: cur_ia,cur_p,cur_j,cur_b,cur_natom,cur_ilma,cur_stat
+    integer    :: cur_blk_s,cur_nb,cur_np4
+    complex(8) :: cur_uv,cur_z
+    real(8)    :: cur_w
+#endif
     call nvtxStartRange('calc_current', __LINE__)
     call timer_begin(LOG_CURRENT_CALC)
 #ifdef FORTRAN_COMPILER_HAS_2MB_ALIGNED_ALLOCATION
@@ -393,6 +412,101 @@ contains
 !$acc exit data copyout(jx,jy,jz)
           call timer_end(LOG_CURRENT_SO_NONLOCAL)
         else ! yn_spinorbit=='y'
+#if defined(USE_GEMM)
+          cur_natom = size(ppg%mps)
+          if (cur_max_nproj < 0) then
+            allocate(cur_nproj_atom(cur_natom))
+            cur_nproj_atom = 0
+            do cur_ilma=1,ppg%Nlma
+              cur_ia = ppg%ia_tbl(cur_ilma)
+              cur_nproj_atom(cur_ia) = cur_nproj_atom(cur_ia) + 1
+            end do
+            cur_max_nproj = maxval(cur_nproj_atom)
+            allocate(cur_l2g(cur_max_nproj, cur_natom))
+            allocate(cur_rinv(cur_max_nproj, cur_natom))
+            cur_l2g  = 0
+            cur_rinv = 0d0
+            cur_nproj_atom = 0   ! reused as a per-atom fill cursor
+            do cur_ilma=1,ppg%Nlma
+              cur_ia = ppg%ia_tbl(cur_ilma)
+              cur_nproj_atom(cur_ia) = cur_nproj_atom(cur_ia) + 1
+              cur_l2g (cur_nproj_atom(cur_ia), cur_ia) = cur_ilma
+              cur_rinv(cur_nproj_atom(cur_ia), cur_ia) = ppg%rinv_uvu(cur_ilma)
+            end do
+            allocate(cur_zekr4(ppg%nps, 4*cur_max_nproj, cur_natom))
+            allocate(cur_wf   (ppg%nps, cur_io_block,    cur_natom))
+            allocate(cur_out  (4*cur_max_nproj, cur_io_block, cur_natom))
+            cur_zekr4 = (0d0,0d0)
+            cur_wf    = (0d0,0d0)
+!$acc enter data copyin(cur_zekr4,cur_wf,cur_l2g,cur_nproj_atom,cur_rinv) create(cur_out)
+            cur_stat = cublasCreate(cur_handle)
+          end if
+          cur_np4 = 4*cur_max_nproj
+          ! cublas must share OpenACC's stream, or the reduction reads the GEMM early.
+          cur_stat = cublasSetStream(cur_handle, acc_get_cuda_stream(acc_async_sync))
+
+          do ik=info%ik_s,info%ik_e
+            ! Refresh per (call, k-point): zekr_uV carries the time-dependent A(t).
+!$acc parallel loop collapse(3) present(ppg,cur_zekr4,cur_l2g,cur_nproj_atom) private(cur_z)
+            do cur_ia=1,cur_natom
+            do cur_p=1,cur_max_nproj
+            do cur_j=1,ppg%nps
+              if (cur_p <= cur_nproj_atom(cur_ia) .and. cur_j <= ppg%mps(cur_ia)) then
+                cur_z = ppg%zekr_uV(cur_j, cur_l2g(cur_p,cur_ia), ik)
+                cur_zekr4(cur_j, cur_p,                   cur_ia) = cur_z
+                cur_zekr4(cur_j, cur_p +   cur_max_nproj, cur_ia) = cur_z * ppg%Rxyz(1,cur_j,cur_ia)
+                cur_zekr4(cur_j, cur_p + 2*cur_max_nproj, cur_ia) = cur_z * ppg%Rxyz(2,cur_j,cur_ia)
+                cur_zekr4(cur_j, cur_p + 3*cur_max_nproj, cur_ia) = cur_z * ppg%Rxyz(3,cur_j,cur_ia)
+              end if
+            end do
+            end do
+            end do
+
+            cur_blk_s = info%io_s
+            do while (cur_blk_s <= info%io_e)
+              cur_nb = min(cur_io_block, info%io_e - cur_blk_s + 1)
+!$acc parallel loop collapse(3) present(psi,ppg,cur_wf)
+              do cur_ia=1,cur_natom
+              do cur_b=1,cur_nb
+              do cur_j=1,ppg%nps
+                if (cur_j <= ppg%mps(cur_ia)) then
+                  cur_wf(cur_j,cur_b,cur_ia) = psi%zwf( &
+                      ppg%jxyz(1,cur_j,cur_ia), ppg%jxyz(2,cur_j,cur_ia), ppg%jxyz(3,cur_j,cur_ia), &
+                      ispin, cur_blk_s+cur_b-1, ik, im)
+                end if
+              end do
+              end do
+              end do
+
+!$acc host_data use_device(cur_zekr4,cur_wf,cur_out)
+              cur_stat = cublasZgemmStridedBatched(cur_handle, CUBLAS_OP_C, CUBLAS_OP_N, &
+                  cur_np4, cur_nb, ppg%nps, &
+                  (1d0,0d0), cur_zekr4, ppg%nps, int(ppg%nps,8)*int(cur_np4,8), &
+                  cur_wf, ppg%nps, int(ppg%nps,8)*int(cur_io_block,8), &
+                  (0d0,0d0), cur_out, cur_np4, int(cur_np4,8)*int(cur_io_block,8), &
+                  cur_natom)
+!$acc end host_data
+              if (cur_stat /= CUBLAS_STATUS_SUCCESS) stop 'calc_current: cublasZgemmStridedBatched failed'
+
+!$acc parallel loop collapse(2) present(cur_out,cur_rinv,cur_nproj_atom,system) &
+!$acc&              private(cur_uv,cur_w,cur_p) reduction(+:jx,jy,jz)
+              do cur_ia=1,cur_natom
+              do cur_b=1,cur_nb
+                cur_w = system%rocc(cur_blk_s+cur_b-1,ik,ispin) * system%wtk(ik)
+!$acc loop seq
+                do cur_p=1,cur_nproj_atom(cur_ia)
+                  cur_uv = cur_out(cur_p,cur_b,cur_ia) * cur_rinv(cur_p,cur_ia)
+                  jx = jx + 2d0*aimag(conjg(cur_out(cur_p +   cur_max_nproj,cur_b,cur_ia))*cur_uv)*cur_w
+                  jy = jy + 2d0*aimag(conjg(cur_out(cur_p + 2*cur_max_nproj,cur_b,cur_ia))*cur_uv)*cur_w
+                  jz = jz + 2d0*aimag(conjg(cur_out(cur_p + 3*cur_max_nproj,cur_b,cur_ia))*cur_uv)*cur_w
+                end do
+              end do
+              end do
+
+              cur_blk_s = cur_blk_s + cur_nb
+            end do
+          end do
+#else
 !$acc kernels copyin(ispin,im)
 !$acc loop gang private(ik,io,wrk3,wrk4) reduction(+:jx,jy,jz) collapse(2) independent
           do ik=info%ik_s,info%ik_e
@@ -405,6 +519,7 @@ contains
           end do
           end do
 !$acc end kernels
+#endif
 !$acc exit data copyout(jx,jy,jz)
         end if ! yn_spinorbit=='y'
       else ! yn_jm == 'n'

--- a/src/common/density_matrix.f90
+++ b/src/common/density_matrix.f90
@@ -291,8 +291,10 @@ contains
 
     call timer_begin(LOG_CURRENT_CALC_UVPSI_RDIVIDED)
     if (info%if_divide_rspace .and. yn_jm=='n' .and. .not. yn_spinorbit=='y') then
+#if !defined(USE_OPENACC)
       call calc_uVpsi_rdivided(nspin,info,ppg,psi,uVpsibox,uVpsibox2)
       allocate(uVpsi(ppg%Nlma))
+#endif
     end if
     call timer_end(LOG_CURRENT_CALC_UVPSI_RDIVIDED)
 
@@ -467,7 +469,11 @@ contains
     end do
     end do
 
-    if (info%if_divide_rspace .and. yn_jm=='n' .and. .not. yn_spinorbit=='y') deallocate(uVpsibox,uVpsibox2,uVpsi)
+    if (info%if_divide_rspace .and. yn_jm=='n' .and. .not. yn_spinorbit=='y') then
+#if !defined(USE_OPENACC)
+      deallocate(uVpsibox,uVpsibox2,uVpsi)
+#endif
+    end if
 
     call nvtxEndRange
     return

--- a/src/common/density_matrix.f90
+++ b/src/common/density_matrix.f90
@@ -280,7 +280,7 @@ contains
     ! Locals for stencil_current inlined below (OpenACC, non-CUDA branch).
     integer    :: ix,iy,iz
     real(8)    :: rtmp
-    complex(8) :: cpsi,xtmp,ytmp,ztmp
+    complex(8) :: cpsi
 #if defined(USE_OPENACC) && defined(USE_GEMM)
     ! Batched-GEMM nonlocal current: zpseudo's phase-1 contraction, but four
     ! projections per (ilma,io) -- zekr_uV plus x/y/z-weighted copies, stacked
@@ -342,51 +342,44 @@ contains
 !$acc enter data copyin(jx,jy,jz)
 !$acc update device(system%vec_Ac)
 
+! Grid-parallel stencil: collapse (ik,io,grid) so gang count is
+! nk*numo*ngrid, not nk*numo; weighting is linear so it moves inside.
 !$acc kernels copyin(BT,ispin,im)
-!$acc loop gang private(ik,io,kAc,wrk1,wrk2,wrk3,wrk4,rtmp,xtmp,ytmp,ztmp,cpsi,ix,iy,iz) &
-!$acc&         reduction(+:jx,jy,jz) collapse(2) independent
+!$acc loop gang private(ik,io,ix,iy,iz,kAc,wrk1,wrk2,wrk3,wrk4,rtmp,cpsi) &
+!$acc&         reduction(+:jx,jy,jz) collapse(5) independent
       do ik=info%ik_s,info%ik_e
       do io=info%io_s,info%io_e
+      do iz=mg%is(3),mg%ie(3)
+      do iy=mg%is(2),mg%ie(2)
+      do ix=mg%is(1),mg%ie(1)
         kAc(1:3) = system%vec_k(1:3,ik) + system%vec_Ac(1:3)
-        ! Inlined stencil_current: removes a device-routine call boundary that cost register-spill overhead.
-        rtmp = 0d0
-        xtmp = 0d0
-        ytmp = 0d0
-        ztmp = 0d0
-!$acc loop vector collapse(3) private(iz,iy,ix,cpsi) reduction(+:rtmp,xtmp,ytmp,ztmp)
-        do iz=mg%is(3),mg%ie(3)
-        do iy=mg%is(2),mg%ie(2)
-        do ix=mg%is(1),mg%ie(1)
-          rtmp = rtmp + abs(psi%zwf(ix,iy,iz,ispin,io,ik,im))**2
-          cpsi = conjg(psi%zwf(ix,iy,iz,ispin,io,ik,im))
-          xtmp = xtmp + stencil%coef_nab(1,1) * cpsi * psi%zwf(mg%idx(ix+1),iy,iz,ispin,io,ik,im) &
-                      + stencil%coef_nab(2,1) * cpsi * psi%zwf(mg%idx(ix+2),iy,iz,ispin,io,ik,im) &
-                      + stencil%coef_nab(3,1) * cpsi * psi%zwf(mg%idx(ix+3),iy,iz,ispin,io,ik,im) &
-                      + stencil%coef_nab(4,1) * cpsi * psi%zwf(mg%idx(ix+4),iy,iz,ispin,io,ik,im)
-          ytmp = ytmp + stencil%coef_nab(1,2) * cpsi * psi%zwf(ix,mg%idy(iy+1),iz,ispin,io,ik,im) &
-                      + stencil%coef_nab(2,2) * cpsi * psi%zwf(ix,mg%idy(iy+2),iz,ispin,io,ik,im) &
-                      + stencil%coef_nab(3,2) * cpsi * psi%zwf(ix,mg%idy(iy+3),iz,ispin,io,ik,im) &
-                      + stencil%coef_nab(4,2) * cpsi * psi%zwf(ix,mg%idy(iy+4),iz,ispin,io,ik,im)
-          ztmp = ztmp + stencil%coef_nab(1,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+1),ispin,io,ik,im) &
-                      + stencil%coef_nab(2,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+2),ispin,io,ik,im) &
-                      + stencil%coef_nab(3,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+3),ispin,io,ik,im) &
-                      + stencil%coef_nab(4,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+4),ispin,io,ik,im)
-        end do
-        end do
-        end do
+        cpsi = conjg(psi%zwf(ix,iy,iz,ispin,io,ik,im))
+        rtmp = abs(psi%zwf(ix,iy,iz,ispin,io,ik,im))**2
         wrk1(1) = kAc(1)*rtmp
         wrk1(2) = kAc(2)*rtmp
         wrk1(3) = kAc(3)*rtmp
-        wrk2(1) = aimag(xtmp*2d0)
-        wrk2(2) = aimag(ytmp*2d0)
-        wrk2(3) = aimag(ztmp*2d0)
-        wrk3(1) = BT(1,1) * wrk2(1) + BT(1,2) * wrk2(2) + BT(1,3) * wrk2(3)
-        wrk3(2) = BT(2,1) * wrk2(1) + BT(2,2) * wrk2(2) + BT(2,3) * wrk2(3)
-        wrk3(3) = BT(3,1) * wrk2(1) + BT(3,2) * wrk2(2) + BT(3,3) * wrk2(3)
+        wrk2(1) = aimag(2d0 * ( stencil%coef_nab(1,1) * cpsi * psi%zwf(mg%idx(ix+1),iy,iz,ispin,io,ik,im) &
+                              + stencil%coef_nab(2,1) * cpsi * psi%zwf(mg%idx(ix+2),iy,iz,ispin,io,ik,im) &
+                              + stencil%coef_nab(3,1) * cpsi * psi%zwf(mg%idx(ix+3),iy,iz,ispin,io,ik,im) &
+                              + stencil%coef_nab(4,1) * cpsi * psi%zwf(mg%idx(ix+4),iy,iz,ispin,io,ik,im) ))
+        wrk2(2) = aimag(2d0 * ( stencil%coef_nab(1,2) * cpsi * psi%zwf(ix,mg%idy(iy+1),iz,ispin,io,ik,im) &
+                              + stencil%coef_nab(2,2) * cpsi * psi%zwf(ix,mg%idy(iy+2),iz,ispin,io,ik,im) &
+                              + stencil%coef_nab(3,2) * cpsi * psi%zwf(ix,mg%idy(iy+3),iz,ispin,io,ik,im) &
+                              + stencil%coef_nab(4,2) * cpsi * psi%zwf(ix,mg%idy(iy+4),iz,ispin,io,ik,im) ))
+        wrk2(3) = aimag(2d0 * ( stencil%coef_nab(1,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+1),ispin,io,ik,im) &
+                              + stencil%coef_nab(2,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+2),ispin,io,ik,im) &
+                              + stencil%coef_nab(3,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+3),ispin,io,ik,im) &
+                              + stencil%coef_nab(4,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+4),ispin,io,ik,im) ))
+        wrk3(1) = BT(1,1)*wrk2(1) + BT(1,2)*wrk2(2) + BT(1,3)*wrk2(3)
+        wrk3(2) = BT(2,1)*wrk2(1) + BT(2,2)*wrk2(2) + BT(2,3)*wrk2(3)
+        wrk3(3) = BT(3,1)*wrk2(1) + BT(3,2)*wrk2(2) + BT(3,3)*wrk2(3)
         wrk4 = (wrk1 + wrk3) * system%rocc(io,ik,ispin) * system%wtk(ik)
         jx = jx + wrk4(1)
         jy = jy + wrk4(2)
         jz = jz + wrk4(3)
+      end do
+      end do
+      end do
       end do
       end do
 !$acc end kernels

--- a/src/common/density_matrix.f90
+++ b/src/common/density_matrix.f90
@@ -273,6 +273,10 @@ contains
     complex(8),allocatable :: uVpsibox2(:,:,:,:,:)
     complex(8),allocatable :: uVpsi(:)
     real(8) :: jx,jy,jz
+    ! Locals for stencil_current inlined below (OpenACC, non-CUDA branch).
+    integer    :: ix,iy,iz
+    real(8)    :: rtmp
+    complex(8) :: cpsi,xtmp,ytmp,ztmp
     call nvtxStartRange('calc_current', __LINE__)
     call timer_begin(LOG_CURRENT_CALC)
 #ifdef FORTRAN_COMPILER_HAS_2MB_ALIGNED_ALLOCATION
@@ -318,12 +322,43 @@ contains
 !$acc update device(system%vec_Ac)
 
 !$acc kernels copyin(BT,ispin,im)
-!$acc loop gang private(ik,io,kAc,wrk1,wrk2,wrk3,wrk4) reduction(+:jx,jy,jz) collapse(2) independent
+!$acc loop gang private(ik,io,kAc,wrk1,wrk2,wrk3,wrk4,rtmp,xtmp,ytmp,ztmp,cpsi,ix,iy,iz) &
+!$acc&         reduction(+:jx,jy,jz) collapse(2) independent
       do ik=info%ik_s,info%ik_e
       do io=info%io_s,info%io_e
         kAc(1:3) = system%vec_k(1:3,ik) + system%vec_Ac(1:3)
-        call stencil_current(mg%is_array,mg%ie_array,mg%is,mg%ie,mg%idx,mg%idy,mg%idz,stencil%coef_nab &
-                            ,kAc,psi%zwf(:,:,:,ispin,io,ik,im),wrk1,wrk2)
+        ! Inlined stencil_current: removes a device-routine call boundary that cost register-spill overhead.
+        rtmp = 0d0
+        xtmp = 0d0
+        ytmp = 0d0
+        ztmp = 0d0
+!$acc loop vector collapse(3) private(iz,iy,ix,cpsi) reduction(+:rtmp,xtmp,ytmp,ztmp)
+        do iz=mg%is(3),mg%ie(3)
+        do iy=mg%is(2),mg%ie(2)
+        do ix=mg%is(1),mg%ie(1)
+          rtmp = rtmp + abs(psi%zwf(ix,iy,iz,ispin,io,ik,im))**2
+          cpsi = conjg(psi%zwf(ix,iy,iz,ispin,io,ik,im))
+          xtmp = xtmp + stencil%coef_nab(1,1) * cpsi * psi%zwf(mg%idx(ix+1),iy,iz,ispin,io,ik,im) &
+                      + stencil%coef_nab(2,1) * cpsi * psi%zwf(mg%idx(ix+2),iy,iz,ispin,io,ik,im) &
+                      + stencil%coef_nab(3,1) * cpsi * psi%zwf(mg%idx(ix+3),iy,iz,ispin,io,ik,im) &
+                      + stencil%coef_nab(4,1) * cpsi * psi%zwf(mg%idx(ix+4),iy,iz,ispin,io,ik,im)
+          ytmp = ytmp + stencil%coef_nab(1,2) * cpsi * psi%zwf(ix,mg%idy(iy+1),iz,ispin,io,ik,im) &
+                      + stencil%coef_nab(2,2) * cpsi * psi%zwf(ix,mg%idy(iy+2),iz,ispin,io,ik,im) &
+                      + stencil%coef_nab(3,2) * cpsi * psi%zwf(ix,mg%idy(iy+3),iz,ispin,io,ik,im) &
+                      + stencil%coef_nab(4,2) * cpsi * psi%zwf(ix,mg%idy(iy+4),iz,ispin,io,ik,im)
+          ztmp = ztmp + stencil%coef_nab(1,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+1),ispin,io,ik,im) &
+                      + stencil%coef_nab(2,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+2),ispin,io,ik,im) &
+                      + stencil%coef_nab(3,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+3),ispin,io,ik,im) &
+                      + stencil%coef_nab(4,3) * cpsi * psi%zwf(ix,iy,mg%idz(iz+4),ispin,io,ik,im)
+        end do
+        end do
+        end do
+        wrk1(1) = kAc(1)*rtmp
+        wrk1(2) = kAc(2)*rtmp
+        wrk1(3) = kAc(3)*rtmp
+        wrk2(1) = aimag(xtmp*2d0)
+        wrk2(2) = aimag(ytmp*2d0)
+        wrk2(3) = aimag(ztmp*2d0)
         wrk3(1) = BT(1,1) * wrk2(1) + BT(1,2) * wrk2(2) + BT(1,3) * wrk2(3)
         wrk3(2) = BT(2,1) * wrk2(1) + BT(2,2) * wrk2(2) + BT(2,3) * wrk2(3)
         wrk3(3) = BT(3,1) * wrk2(1) + BT(3,2) * wrk2(2) + BT(3,3) * wrk2(3)

--- a/src/common/hamiltonian.f90
+++ b/src/common/hamiltonian.f90
@@ -905,16 +905,19 @@ subroutine add_xc_tau_operator(htpsi,tpsi,info,mg,system,stencil,srg)
   ! grid loop below, where kvec_u = k - u(r).
   complex(8), allocatable :: gpsi(:,:,:,:)         ! (3, grid), one orbital at a time
   complex(8), allocatable :: uloc(:,:,:,:)         ! (grid, 3)                    no r-space division
-  complex(8), allocatable :: uorb(:,:,:,:,:,:,:,:) ! (grid, nspin,io,ik,im, 3)    r-space division
   ! real (Gamma-only) path
   real(8),    allocatable :: rgpsi(:,:,:,:)
   real(8),    allocatable :: rgw(:,:,:,:)
   real(8),    allocatable :: rwvec(:,:,:,:)         ! (grid, 3)                    no r-space division
+#ifndef USE_OPENACC
+  ! 8-dim arrays exceed nvfortran's dimension limit; unused on the abort path below.
+  complex(8), allocatable :: uorb(:,:,:,:,:,:,:,:)  ! (grid, nspin,io,ik,im, 3)    r-space division
   real(8),    allocatable :: ruorb(:,:,:,:,:,:,:,:) ! (grid, nspin,io,ik,im, 3)    r-space division
+#endif
 
 #ifdef USE_OPENACC
   call fail_tau_operator("support is unavailable for OpenACC builds")
-#endif
+#else
   if (.not. system%xc_payload%use_tau_operator) return
   if (.not. allocated(system%xc_payload%vtau%f)) then
     call fail_tau_operator("payload is enabled without a vtau field")
@@ -1183,6 +1186,7 @@ subroutine add_xc_tau_operator(htpsi,tpsi,info,mg,system,stencil,srg)
   end do
   end do
   deallocate(gpsi,uorb)
+#endif
 
 end subroutine add_xc_tau_operator
 

--- a/src/common/nonlocal_potential.f90
+++ b/src/common/nonlocal_potential.f90
@@ -181,7 +181,6 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   use cublas
   use openacc
   use cudafor
-  use communication, only: comm_summation
   use mpi, only: MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_IN_PLACE
 #endif
   implicit none
@@ -274,9 +273,8 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   Nlma = ppg%Nlma
 
 #if defined(USE_OPENACC) && defined(USE_GEMM)
-  ! --- GEMM path: handles both domain and non-domain decomposition ---
-  ! Under domain decomposition, ppg%jxyz/mps are already local (built from mg%is/ie),
-  ! so the GEMM computes partial sums per atom; comm_summation combines them across rgrid ranks.
+  ! GEMM path, both domain and non-domain decomposition: ppg%jxyz/mps are already local,
+  ! so under domain decomposition the GEMM yields per-rank partial sums, reduced in phase 1.5.
 
   gemm_natom = size(ppg%mps)
 
@@ -292,13 +290,14 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
 
     allocate(gemm_l2g(gemm_max_nproj, gemm_natom))
     gemm_l2g = 0
-    gemm_nproj_atom = 0
+    gemm_nproj_atom = 0   ! reused as a per-atom fill cursor below
     do ilma=1,Nlma
       ia = ppg%ia_tbl(ilma)
       gemm_nproj_atom(ia) = gemm_nproj_atom(ia) + 1
       gemm_l2g(gemm_nproj_atom(ia), ia) = ilma
     end do
 
+    ! Kept 3D (no ik dimension): a slice through host_data/cublas triggers an nvfortran ICE.
     allocate(gemm_zekr_packed(ppg%nps, gemm_max_nproj, gemm_natom))
     allocate(gemm_rinv_packed(gemm_max_nproj, gemm_natom))
     gemm_zekr_packed = (0.d0,0.d0)
@@ -319,11 +318,14 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
     gemm_stat = cublasCreate(gemm_handle)
   end if
 
+  ! cublas must share OpenACC's stream, or the scatter kernel may read the GEMM output early.
   gemm_stat = cublasSetStream(gemm_handle, acc_get_cuda_stream(acc_async_sync))
 
   ! Phase 1: batched GEMM projection, blocked over bands to bound gemm_wf_packed's memory.
   do im=im_s,im_e
   do ik=ik_s,ik_e
+    ! Refresh per (call, k-point): zekr_uV carries the time-dependent A(t), so packing it
+    ! only at setup would freeze the t=0 phases and silently drift the physics.
 !$acc parallel loop collapse(3) present(ppg, gemm_zekr_packed, gemm_l2g, gemm_nproj_atom)
     do gemm_ia = 1, gemm_natom
     do gemm_p = 1, gemm_max_nproj
@@ -381,9 +383,8 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   end do
   end do
 
-  ! Phase 1.5: reduce partial sums across rgrid ranks (domain decomposition only).
-  ! Each rank computed partial uVpsi for atoms overlapping its local grid slab;
-  ! comm_summation combines them into the complete projection.
+  ! Phase 1.5: reduce each rank's partial uVpsi across rgrid ranks. Staged through a CUDA
+  ! Fortran device buffer so CUDA-aware MPI sees a real device pointer, not managed memory.
   if(info%if_divide_rspace) then
     call timer_end(LOG_UHPSI_PSEUDO)
     call timer_begin(LOG_UHPSI_PSEUDO_COMM)

--- a/src/common/nonlocal_potential.f90
+++ b/src/common/nonlocal_potential.f90
@@ -177,6 +177,10 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   use structures
   use timer
   use iso_c_binding
+#if defined(USE_OPENACC) && defined(USE_GEMM)
+  use cublas
+  use openacc
+#endif
   implicit none
   intrinsic :: aimag
   integer,intent(in) :: nspin
@@ -231,6 +235,18 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
       complex(c_double_complex), intent(in) :: tpsi_zwf(mg_is_array_1:mg_ie_array_1, mg_is_array_2:mg_ie_array_2,mg_is_array_2:mg_ie_array_3, Nspin, io_e:io_s, ik_s:ik_e, im_s:im_e)
     end subroutine zpseudo_cuda
   end interface
+#endif
+#if defined(USE_OPENACC) && defined(USE_GEMM)
+  ! Batched-GEMM reformulation of phase 1 (projection); phase 2 (back-projection) is unchanged below.
+  integer, parameter :: gemm_io_block = 64
+  integer,save :: gemm_max_nproj = -1
+  integer,allocatable,save :: gemm_nproj_atom(:), gemm_l2g(:,:)
+  complex(8),allocatable,save :: gemm_zekr_packed(:,:,:)
+  real(8),allocatable,save :: gemm_rinv_packed(:,:)
+  complex(8),allocatable,save :: gemm_wf_packed(:,:,:), gemm_out_packed(:,:,:)
+  type(cublasHandle),save :: gemm_handle
+  integer :: gemm_ia, gemm_p, gemm_ilma, gemm_j, gemm_natom
+  integer :: gemm_io_blk_s, gemm_this_block, gemm_io_local, gemm_stat
 #endif
 
 #ifdef FORTRAN_COMPILER_HAS_2MB_ALIGNED_ALLOCATION
@@ -402,6 +418,148 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
         ppg%zekr_uV,&
         ppg%rinv_uvu,&
         tpsi%zwf)
+#elif defined(USE_GEMM)
+    gemm_natom = size(ppg%mps)
+
+    ! One-time setup: build zero-padded dense companion arrays, since ppg%zekr_uV/jxyz are only filled up to mps(ia) and reading beyond that is uninitialized.
+    if (gemm_max_nproj < 0) then
+      allocate(gemm_nproj_atom(gemm_natom))
+      gemm_nproj_atom = 0
+      do ilma=1,Nlma
+        ia = ppg%ia_tbl(ilma)
+        gemm_nproj_atom(ia) = gemm_nproj_atom(ia) + 1
+      end do
+      gemm_max_nproj = maxval(gemm_nproj_atom)
+
+      allocate(gemm_l2g(gemm_max_nproj, gemm_natom))
+      gemm_l2g = 0
+      gemm_nproj_atom = 0   ! reused as a per-atom fill cursor below
+      do ilma=1,Nlma
+        ia = ppg%ia_tbl(ilma)
+        gemm_nproj_atom(ia) = gemm_nproj_atom(ia) + 1
+        gemm_l2g(gemm_nproj_atom(ia), ia) = ilma
+      end do
+
+      ! gemm_zekr_packed has no ik dimension -- refreshed per k-point in the per-call loop below (see there for why).
+      allocate(gemm_zekr_packed(ppg%nps, gemm_max_nproj, gemm_natom))
+      allocate(gemm_rinv_packed(gemm_max_nproj, gemm_natom))
+      gemm_zekr_packed = (0.d0,0.d0)
+      gemm_rinv_packed = 0.d0
+      do gemm_ia=1,gemm_natom
+      do gemm_p=1,gemm_nproj_atom(gemm_ia)
+        gemm_ilma = gemm_l2g(gemm_p, gemm_ia)
+        gemm_rinv_packed(gemm_p, gemm_ia) = ppg%rinv_uvu(gemm_ilma)
+      end do
+      end do
+!$acc enter data copyin(gemm_zekr_packed, gemm_rinv_packed, gemm_l2g, gemm_nproj_atom)
+
+      ! Padding rows (j>mps(ia)) stay zero for the run's lifetime: only the valid sub-region is ever written, here or in the per-call gather below.
+      allocate(gemm_wf_packed(ppg%nps, gemm_io_block, gemm_natom))
+      allocate(gemm_out_packed(gemm_max_nproj, gemm_io_block, gemm_natom))
+      gemm_wf_packed = (0.d0, 0.d0)
+!$acc enter data copyin(gemm_wf_packed) create(gemm_out_packed)
+
+      gemm_stat = cublasCreate(gemm_handle)
+    end if
+
+    ! cublas must share OpenACC's synchronous stream, or nothing guarantees the GEMM finishes before the scatter kernel reads its output.
+    gemm_stat = cublasSetStream(gemm_handle, acc_get_cuda_stream(acc_async_sync))
+
+    ! Per-call: batched GEMM projection, blocked over bands to bound gemm_wf_packed's memory.
+    do im=im_s,im_e
+    do ik=ik_s,ik_e
+      ! zekr_uV = exp(-i(k+A/c)r)*uv depends on k and on the time-dependent A(t), which time_evolution_step.f90 advances every RT step.
+      ! So refresh the packed copy once per (call, k-point) -- packing it only at setup freezes the t=0 phases and silently drifts the physics.
+      ! Kept 3D (no ik dimension) so it is never passed as a slice through host_data/cublas, which triggers an nvfortran ICE.
+!$acc parallel loop collapse(3) present(ppg, gemm_zekr_packed, gemm_l2g, gemm_nproj_atom)
+      do gemm_ia = 1, gemm_natom
+      do gemm_p = 1, gemm_max_nproj
+      do gemm_j = 1, ppg%nps
+        if (gemm_p <= gemm_nproj_atom(gemm_ia) .and. gemm_j <= ppg%mps(gemm_ia)) then
+          gemm_zekr_packed(gemm_j, gemm_p, gemm_ia) = &
+              ppg%zekr_uV(gemm_j, gemm_l2g(gemm_p, gemm_ia), ik)
+        end if
+      end do
+      end do
+      end do
+
+    do ispin=1,Nspin
+      gemm_io_blk_s = io_s
+      do while (gemm_io_blk_s <= io_e)
+        gemm_this_block = min(gemm_io_block, io_e - gemm_io_blk_s + 1)
+
+        ! Gather; loop over the invariant ppg%nps (not the ragged ppg%mps(ia)) since collapse() needs a rectangular iteration space, guard with an if instead.
+!$acc parallel loop collapse(3) present(tpsi,ppg,gemm_wf_packed)
+        do gemm_ia = 1, gemm_natom
+        do gemm_io_local = 1, gemm_this_block
+        do gemm_j = 1, ppg%nps
+          if (gemm_j <= ppg%mps(gemm_ia)) then
+            gemm_wf_packed(gemm_j, gemm_io_local, gemm_ia) = tpsi%zwf( &
+                ppg%jxyz(1,gemm_j,gemm_ia), ppg%jxyz(2,gemm_j,gemm_ia), ppg%jxyz(3,gemm_j,gemm_ia), &
+                ispin, gemm_io_blk_s+gemm_io_local-1, ik, im)
+          end if
+        end do
+        end do
+        end do
+
+        ! Batched GEMM: (max_nproj x nps) @ (nps x this_block) per atom, natom batches. CUBLAS_OP_C applies conjg().
+!$acc host_data use_device(gemm_zekr_packed, gemm_wf_packed, gemm_out_packed)
+        gemm_stat = cublasZgemmStridedBatched(gemm_handle, CUBLAS_OP_C, CUBLAS_OP_N, &
+            gemm_max_nproj, gemm_this_block, ppg%nps, &
+            (1.d0,0.d0), gemm_zekr_packed, ppg%nps, int(ppg%nps,8)*int(gemm_max_nproj,8), &
+            gemm_wf_packed, ppg%nps, int(ppg%nps,8)*int(gemm_io_block,8), &
+            (0.d0,0.d0), gemm_out_packed, gemm_max_nproj, int(gemm_max_nproj,8)*int(gemm_io_block,8), &
+            gemm_natom)
+!$acc end host_data
+
+        ! Scale by rinv_uvu, scatter back into ppg%uVpsibox's ilma indexing via gemm_l2g; padding rows (p>nproj_atom(ia)) are skipped.
+!$acc parallel loop collapse(3) present(ppg,gemm_out_packed,gemm_rinv_packed,gemm_l2g,gemm_nproj_atom)
+        do gemm_ia = 1, gemm_natom
+        do gemm_io_local = 1, gemm_this_block
+        do gemm_p = 1, gemm_max_nproj
+          if (gemm_p <= gemm_nproj_atom(gemm_ia)) then
+            ppg%uVpsibox(gemm_l2g(gemm_p,gemm_ia), ispin, gemm_io_blk_s+gemm_io_local-1, ik, im) = &
+                gemm_out_packed(gemm_p, gemm_io_local, gemm_ia) * gemm_rinv_packed(gemm_p, gemm_ia)
+          end if
+        end do
+        end do
+        end do
+
+        gemm_io_blk_s = gemm_io_blk_s + gemm_this_block
+      end do
+    end do
+    end do
+    end do
+
+    ! Phase 2 (back-projection): unchanged from the plain-acc path below, own acc kernels region since phase 1 no longer shares one with it.
+!$acc kernels present(ppg,tpsi,htpsi)
+!$acc loop collapse(5) independent private(ilocal,ilma,ia,uVpsi,vi,my_nlma,k,j,ix,iy,iz,wrk)
+    do im=im_s,im_e
+    do ik=ik_s,ik_e
+    do io=io_s,io_e
+    do ispin=1,Nspin
+      do vi=0,ppg%max_vi-1
+        my_nlma = ppg%v2nlma(vi)
+        if (my_nlma < 1) cycle
+
+        wrk = 0d0
+!$acc loop seq
+        do k=1,my_nlma
+          ilma = ppg%k2ilma(vi,k)
+          j    = ppg%k2j(vi,k)
+          wrk  = wrk + ppg%uVpsibox(ilma,ispin,io,ik,im) * ppg%zekr_uV(j,ilma,ik)
+        end do
+
+        ix = ppg%v2j(1,vi)
+        iy = ppg%v2j(2,vi)
+        iz = ppg%v2j(3,vi)
+        htpsi%zwf(ix,iy,iz,ispin,io,ik,im) = htpsi%zwf(ix,iy,iz,ispin,io,ik,im) + wrk
+      end do
+    end do
+    end do
+    end do
+    end do
+!$acc end kernels
 #else
 !$acc kernels present(ppg,tpsi,htpsi)
 !$acc loop collapse(5) independent gang private(ilocal,ilma,ia,uVpsi,vi,my_nlma,k,j,ix,iy,iz,wrk)

--- a/src/common/nonlocal_potential.f90
+++ b/src/common/nonlocal_potential.f90
@@ -182,6 +182,10 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   use openacc
   use cudafor
   use mpi, only: MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_IN_PLACE
+#ifdef USE_NCCL
+  use nccl
+  use mpi, only: MPI_CHARACTER
+#endif
 #endif
   implicit none
   intrinsic :: aimag
@@ -197,8 +201,19 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   complex(8),allocatable :: uVpsibox (:,:,:,:,:)
   complex(8),allocatable :: uVpsibox2(:,:,:,:,:)
 #if defined(USE_OPENACC) && defined(USE_GEMM)
-  complex(8), device, allocatable, save :: d_reduce(:,:,:,:,:)
+  complex(8), device, allocatable, save, target :: d_reduce(:,:,:,:,:)
   integer, save :: d_reduce_allocated = 0
+#ifdef USE_NCCL
+  ! NCCL reduces on the GPU; MPI_Allreduce does the arithmetic on the host,
+  ! which costs ~30x on this buffer even though both take a device pointer.
+  type(ncclComm), save :: nccl_comm
+  integer(cuda_stream_kind), save :: nccl_stream
+  logical, save :: nccl_ready = .false.
+  type(ncclUniqueId) :: nccl_uid
+  type(ncclResult) :: nccl_stat
+  real(8), device, pointer :: d_reduce_re(:)
+  integer :: nccl_rank, nccl_size, cuda_stat
+#endif
 #endif
 #ifdef USE_OPENACC
   real(8),allocatable,save :: htpsi_zwf_r(:,:,:,:,:,:,:), htpsi_zwf_i(:,:,:,:,:,:,:)
@@ -411,7 +426,24 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
     end do
     !$acc wait
 
+#ifdef USE_NCCL
+    if (.not. nccl_ready) then
+      call MPI_Comm_rank(info%icomm_r, nccl_rank, mpi_ierr)
+      call MPI_Comm_size(info%icomm_r, nccl_size, mpi_ierr)
+      if (nccl_rank == 0) nccl_stat = ncclGetUniqueId(nccl_uid)
+      call MPI_Bcast(nccl_uid%internal, 128, MPI_CHARACTER, 0, info%icomm_r, mpi_ierr)
+      nccl_stat = ncclCommInitRank(nccl_comm, nccl_size, nccl_uid, nccl_rank)
+      if (nccl_stat /= ncclSuccess) stop 'zpseudo: ncclCommInitRank failed'
+      cuda_stat = cudaStreamCreate(nccl_stream)
+      nccl_ready = .true.
+    end if
+    ! complex sum == double sum over twice as many elements
+    call c_f_pointer(c_devloc(d_reduce), d_reduce_re, [2*Nlma*norb])
+    nccl_stat = ncclAllReduce(d_reduce_re, d_reduce_re, 2*Nlma*norb, ncclDouble, ncclSum, nccl_comm, nccl_stream)
+    cuda_stat = cudaStreamSynchronize(nccl_stream)
+#else
     call MPI_Allreduce(MPI_IN_PLACE, d_reduce, int(Nlma*norb), MPI_DOUBLE_COMPLEX, MPI_SUM, info%icomm_r, mpi_ierr)
+#endif
 
     !$acc parallel loop collapse(5) deviceptr(d_reduce) present(ppg)
     do im=im_s,im_e

--- a/src/common/nonlocal_potential.f90
+++ b/src/common/nonlocal_potential.f90
@@ -204,8 +204,8 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   complex(8), device, allocatable, save, target :: d_reduce(:,:,:,:,:)
   integer, save :: d_reduce_allocated = 0
 #ifdef USE_NCCL
-  ! NCCL reduces on the GPU; MPI_Allreduce does the arithmetic on the host,
-  ! which costs ~30x on this buffer even though both take a device pointer.
+  ! NCCL reduces on the GPU; MPI_Allreduce does the arithmetic on the host
+  ! even when handed a device pointer, so it leaves NVLink entirely.
   type(ncclComm), save :: nccl_comm
   integer(cuda_stream_kind), save :: nccl_stream
   logical, save :: nccl_ready = .false.
@@ -441,6 +441,7 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
     call c_f_pointer(c_devloc(d_reduce), d_reduce_re, [2*Nlma*norb])
     nccl_stat = ncclAllReduce(d_reduce_re, d_reduce_re, 2*Nlma*norb, ncclDouble, ncclSum, nccl_comm, nccl_stream)
     cuda_stat = cudaStreamSynchronize(nccl_stream)
+    if (nccl_stat /= ncclSuccess .or. cuda_stat /= 0) stop 'zpseudo: ncclAllReduce failed'
 #else
     call MPI_Allreduce(MPI_IN_PLACE, d_reduce, int(Nlma*norb), MPI_DOUBLE_COMPLEX, MPI_SUM, info%icomm_r, mpi_ierr)
 #endif

--- a/src/common/nonlocal_potential.f90
+++ b/src/common/nonlocal_potential.f90
@@ -180,6 +180,9 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
 #if defined(USE_OPENACC) && defined(USE_GEMM)
   use cublas
   use openacc
+  use cudafor
+  use communication, only: comm_summation
+  use mpi, only: MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_IN_PLACE
 #endif
   implicit none
   intrinsic :: aimag
@@ -189,11 +192,15 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   type(s_orbital),intent(in) :: tpsi
   type(s_orbital) :: htpsi
   !
-  integer :: ispin,io,ik,im,im_s,im_e,ik_s,ik_e,io_s,io_e
+  integer :: ispin,io,ik,im,im_s,im_e,ik_s,ik_e,io_s,io_e,norb
   integer :: ilma,ia,j,ix,iy,iz,Nlma,ilocal,vi,my_nlma,k
   complex(8) :: uVpsi,wrk
   complex(8),allocatable :: uVpsibox (:,:,:,:,:)
   complex(8),allocatable :: uVpsibox2(:,:,:,:,:)
+#if defined(USE_OPENACC) && defined(USE_GEMM)
+  complex(8), device, allocatable, save :: d_reduce(:,:,:,:,:)
+  integer, save :: d_reduce_allocated = 0
+#endif
 #ifdef USE_OPENACC
   real(8),allocatable,save :: htpsi_zwf_r(:,:,:,:,:,:,:), htpsi_zwf_i(:,:,:,:,:,:,:)
   integer :: i1, i2, i3, i4, i5, i6, i7
@@ -247,6 +254,7 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
   type(cublasHandle),save :: gemm_handle
   integer :: gemm_ia, gemm_p, gemm_ilma, gemm_j, gemm_natom
   integer :: gemm_io_blk_s, gemm_this_block, gemm_io_local, gemm_stat
+  integer :: mpi_ierr
 #endif
 
 #ifdef FORTRAN_COMPILER_HAS_2MB_ALIGNED_ALLOCATION
@@ -265,6 +273,194 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
 
   Nlma = ppg%Nlma
 
+#if defined(USE_OPENACC) && defined(USE_GEMM)
+  ! --- GEMM path: handles both domain and non-domain decomposition ---
+  ! Under domain decomposition, ppg%jxyz/mps are already local (built from mg%is/ie),
+  ! so the GEMM computes partial sums per atom; comm_summation combines them across rgrid ranks.
+
+  gemm_natom = size(ppg%mps)
+
+  ! One-time setup: build zero-padded dense companion arrays, since ppg%zekr_uV/jxyz are only filled up to mps(ia) and reading beyond that is uninitialized.
+  if (gemm_max_nproj < 0) then
+    allocate(gemm_nproj_atom(gemm_natom))
+    gemm_nproj_atom = 0
+    do ilma=1,Nlma
+      ia = ppg%ia_tbl(ilma)
+      gemm_nproj_atom(ia) = gemm_nproj_atom(ia) + 1
+    end do
+    gemm_max_nproj = maxval(gemm_nproj_atom)
+
+    allocate(gemm_l2g(gemm_max_nproj, gemm_natom))
+    gemm_l2g = 0
+    gemm_nproj_atom = 0
+    do ilma=1,Nlma
+      ia = ppg%ia_tbl(ilma)
+      gemm_nproj_atom(ia) = gemm_nproj_atom(ia) + 1
+      gemm_l2g(gemm_nproj_atom(ia), ia) = ilma
+    end do
+
+    allocate(gemm_zekr_packed(ppg%nps, gemm_max_nproj, gemm_natom))
+    allocate(gemm_rinv_packed(gemm_max_nproj, gemm_natom))
+    gemm_zekr_packed = (0.d0,0.d0)
+    gemm_rinv_packed = 0.d0
+    do gemm_ia=1,gemm_natom
+    do gemm_p=1,gemm_nproj_atom(gemm_ia)
+      gemm_ilma = gemm_l2g(gemm_p, gemm_ia)
+      gemm_rinv_packed(gemm_p, gemm_ia) = ppg%rinv_uvu(gemm_ilma)
+    end do
+    end do
+!$acc enter data copyin(gemm_zekr_packed, gemm_rinv_packed, gemm_l2g, gemm_nproj_atom)
+
+    allocate(gemm_wf_packed(ppg%nps, gemm_io_block, gemm_natom))
+    allocate(gemm_out_packed(gemm_max_nproj, gemm_io_block, gemm_natom))
+    gemm_wf_packed = (0.d0, 0.d0)
+!$acc enter data copyin(gemm_wf_packed) create(gemm_out_packed)
+
+    gemm_stat = cublasCreate(gemm_handle)
+  end if
+
+  gemm_stat = cublasSetStream(gemm_handle, acc_get_cuda_stream(acc_async_sync))
+
+  ! Phase 1: batched GEMM projection, blocked over bands to bound gemm_wf_packed's memory.
+  do im=im_s,im_e
+  do ik=ik_s,ik_e
+!$acc parallel loop collapse(3) present(ppg, gemm_zekr_packed, gemm_l2g, gemm_nproj_atom)
+    do gemm_ia = 1, gemm_natom
+    do gemm_p = 1, gemm_max_nproj
+    do gemm_j = 1, ppg%nps
+      if (gemm_p <= gemm_nproj_atom(gemm_ia) .and. gemm_j <= ppg%mps(gemm_ia)) then
+        gemm_zekr_packed(gemm_j, gemm_p, gemm_ia) = &
+            ppg%zekr_uV(gemm_j, gemm_l2g(gemm_p, gemm_ia), ik)
+      end if
+    end do
+    end do
+    end do
+
+  do ispin=1,Nspin
+    gemm_io_blk_s = io_s
+    do while (gemm_io_blk_s <= io_e)
+      gemm_this_block = min(gemm_io_block, io_e - gemm_io_blk_s + 1)
+
+!$acc parallel loop collapse(3) present(tpsi,ppg,gemm_wf_packed)
+      do gemm_ia = 1, gemm_natom
+      do gemm_io_local = 1, gemm_this_block
+      do gemm_j = 1, ppg%nps
+        if (gemm_j <= ppg%mps(gemm_ia)) then
+          gemm_wf_packed(gemm_j, gemm_io_local, gemm_ia) = tpsi%zwf( &
+              ppg%jxyz(1,gemm_j,gemm_ia), ppg%jxyz(2,gemm_j,gemm_ia), ppg%jxyz(3,gemm_j,gemm_ia), &
+              ispin, gemm_io_blk_s+gemm_io_local-1, ik, im)
+        end if
+      end do
+      end do
+      end do
+
+!$acc host_data use_device(gemm_zekr_packed, gemm_wf_packed, gemm_out_packed)
+      gemm_stat = cublasZgemmStridedBatched(gemm_handle, CUBLAS_OP_C, CUBLAS_OP_N, &
+          gemm_max_nproj, gemm_this_block, ppg%nps, &
+          (1.d0,0.d0), gemm_zekr_packed, ppg%nps, int(ppg%nps,8)*int(gemm_max_nproj,8), &
+          gemm_wf_packed, ppg%nps, int(ppg%nps,8)*int(gemm_io_block,8), &
+          (0.d0,0.d0), gemm_out_packed, gemm_max_nproj, int(gemm_max_nproj,8)*int(gemm_io_block,8), &
+          gemm_natom)
+!$acc end host_data
+
+!$acc parallel loop collapse(3) present(ppg,gemm_out_packed,gemm_rinv_packed,gemm_l2g,gemm_nproj_atom)
+      do gemm_ia = 1, gemm_natom
+      do gemm_io_local = 1, gemm_this_block
+      do gemm_p = 1, gemm_max_nproj
+        if (gemm_p <= gemm_nproj_atom(gemm_ia)) then
+          ppg%uVpsibox(gemm_l2g(gemm_p,gemm_ia), ispin, gemm_io_blk_s+gemm_io_local-1, ik, im) = &
+              gemm_out_packed(gemm_p, gemm_io_local, gemm_ia) * gemm_rinv_packed(gemm_p, gemm_ia)
+        end if
+      end do
+      end do
+      end do
+
+      gemm_io_blk_s = gemm_io_blk_s + gemm_this_block
+    end do
+  end do
+  end do
+  end do
+
+  ! Phase 1.5: reduce partial sums across rgrid ranks (domain decomposition only).
+  ! Each rank computed partial uVpsi for atoms overlapping its local grid slab;
+  ! comm_summation combines them into the complete projection.
+  if(info%if_divide_rspace) then
+    call timer_end(LOG_UHPSI_PSEUDO)
+    call timer_begin(LOG_UHPSI_PSEUDO_COMM)
+
+    norb = Nspin * info%numo * info%numk * info%numm
+
+    if (d_reduce_allocated /= Nlma*norb) then
+      if (d_reduce_allocated > 0) deallocate(d_reduce)
+      allocate(d_reduce(Nlma, Nspin, io_e-io_s+1, ik_e-ik_s+1, im_e-im_s+1))
+      d_reduce_allocated = Nlma*norb
+    end if
+
+    !$acc parallel loop collapse(5) deviceptr(d_reduce) present(ppg)
+    do im=im_s,im_e
+    do ik=ik_s,ik_e
+    do io=io_s,io_e
+    do ispin=1,Nspin
+    do ilma=1,Nlma
+      d_reduce(ilma,ispin,io-io_s+1,ik-ik_s+1,im-im_s+1) = ppg%uVpsibox(ilma,ispin,io,ik,im)
+    end do
+    end do
+    end do
+    end do
+    end do
+    !$acc wait
+
+    call MPI_Allreduce(MPI_IN_PLACE, d_reduce, int(Nlma*norb), MPI_DOUBLE_COMPLEX, MPI_SUM, info%icomm_r, mpi_ierr)
+
+    !$acc parallel loop collapse(5) deviceptr(d_reduce) present(ppg)
+    do im=im_s,im_e
+    do ik=ik_s,ik_e
+    do io=io_s,io_e
+    do ispin=1,Nspin
+    do ilma=1,Nlma
+      ppg%uVpsibox(ilma,ispin,io,ik,im) = d_reduce(ilma,ispin,io-io_s+1,ik-ik_s+1,im-im_s+1)
+    end do
+    end do
+    end do
+    end do
+    end do
+    !$acc wait
+
+    call timer_end(LOG_UHPSI_PSEUDO_COMM)
+    call timer_begin(LOG_UHPSI_PSEUDO)
+  end if
+
+  ! Phase 2 (back-projection): v2j-based scatter, no atomics.
+!$acc kernels present(ppg,tpsi,htpsi)
+!$acc loop collapse(5) independent private(ilocal,ilma,ia,uVpsi,vi,my_nlma,k,j,ix,iy,iz,wrk)
+  do im=im_s,im_e
+  do ik=ik_s,ik_e
+  do io=io_s,io_e
+  do ispin=1,Nspin
+    do vi=0,ppg%max_vi-1
+      my_nlma = ppg%v2nlma(vi)
+      if (my_nlma < 1) cycle
+
+      wrk = 0d0
+!$acc loop seq
+      do k=1,my_nlma
+        ilma = ppg%k2ilma(vi,k)
+        j    = ppg%k2j(vi,k)
+        wrk  = wrk + ppg%uVpsibox(ilma,ispin,io,ik,im) * ppg%zekr_uV(j,ilma,ik)
+      end do
+
+      ix = ppg%v2j(1,vi)
+      iy = ppg%v2j(2,vi)
+      iz = ppg%v2j(3,vi)
+      htpsi%zwf(ix,iy,iz,ispin,io,ik,im) = htpsi%zwf(ix,iy,iz,ispin,io,ik,im) + wrk
+    end do
+  end do
+  end do
+  end do
+  end do
+!$acc end kernels
+
+#else
   if(info%if_divide_rspace) then
 
     call timer_end(LOG_UHPSI_PSEUDO)
@@ -418,148 +614,6 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
         ppg%zekr_uV,&
         ppg%rinv_uvu,&
         tpsi%zwf)
-#elif defined(USE_GEMM)
-    gemm_natom = size(ppg%mps)
-
-    ! One-time setup: build zero-padded dense companion arrays, since ppg%zekr_uV/jxyz are only filled up to mps(ia) and reading beyond that is uninitialized.
-    if (gemm_max_nproj < 0) then
-      allocate(gemm_nproj_atom(gemm_natom))
-      gemm_nproj_atom = 0
-      do ilma=1,Nlma
-        ia = ppg%ia_tbl(ilma)
-        gemm_nproj_atom(ia) = gemm_nproj_atom(ia) + 1
-      end do
-      gemm_max_nproj = maxval(gemm_nproj_atom)
-
-      allocate(gemm_l2g(gemm_max_nproj, gemm_natom))
-      gemm_l2g = 0
-      gemm_nproj_atom = 0   ! reused as a per-atom fill cursor below
-      do ilma=1,Nlma
-        ia = ppg%ia_tbl(ilma)
-        gemm_nproj_atom(ia) = gemm_nproj_atom(ia) + 1
-        gemm_l2g(gemm_nproj_atom(ia), ia) = ilma
-      end do
-
-      ! gemm_zekr_packed has no ik dimension -- refreshed per k-point in the per-call loop below (see there for why).
-      allocate(gemm_zekr_packed(ppg%nps, gemm_max_nproj, gemm_natom))
-      allocate(gemm_rinv_packed(gemm_max_nproj, gemm_natom))
-      gemm_zekr_packed = (0.d0,0.d0)
-      gemm_rinv_packed = 0.d0
-      do gemm_ia=1,gemm_natom
-      do gemm_p=1,gemm_nproj_atom(gemm_ia)
-        gemm_ilma = gemm_l2g(gemm_p, gemm_ia)
-        gemm_rinv_packed(gemm_p, gemm_ia) = ppg%rinv_uvu(gemm_ilma)
-      end do
-      end do
-!$acc enter data copyin(gemm_zekr_packed, gemm_rinv_packed, gemm_l2g, gemm_nproj_atom)
-
-      ! Padding rows (j>mps(ia)) stay zero for the run's lifetime: only the valid sub-region is ever written, here or in the per-call gather below.
-      allocate(gemm_wf_packed(ppg%nps, gemm_io_block, gemm_natom))
-      allocate(gemm_out_packed(gemm_max_nproj, gemm_io_block, gemm_natom))
-      gemm_wf_packed = (0.d0, 0.d0)
-!$acc enter data copyin(gemm_wf_packed) create(gemm_out_packed)
-
-      gemm_stat = cublasCreate(gemm_handle)
-    end if
-
-    ! cublas must share OpenACC's synchronous stream, or nothing guarantees the GEMM finishes before the scatter kernel reads its output.
-    gemm_stat = cublasSetStream(gemm_handle, acc_get_cuda_stream(acc_async_sync))
-
-    ! Per-call: batched GEMM projection, blocked over bands to bound gemm_wf_packed's memory.
-    do im=im_s,im_e
-    do ik=ik_s,ik_e
-      ! zekr_uV = exp(-i(k+A/c)r)*uv depends on k and on the time-dependent A(t), which time_evolution_step.f90 advances every RT step.
-      ! So refresh the packed copy once per (call, k-point) -- packing it only at setup freezes the t=0 phases and silently drifts the physics.
-      ! Kept 3D (no ik dimension) so it is never passed as a slice through host_data/cublas, which triggers an nvfortran ICE.
-!$acc parallel loop collapse(3) present(ppg, gemm_zekr_packed, gemm_l2g, gemm_nproj_atom)
-      do gemm_ia = 1, gemm_natom
-      do gemm_p = 1, gemm_max_nproj
-      do gemm_j = 1, ppg%nps
-        if (gemm_p <= gemm_nproj_atom(gemm_ia) .and. gemm_j <= ppg%mps(gemm_ia)) then
-          gemm_zekr_packed(gemm_j, gemm_p, gemm_ia) = &
-              ppg%zekr_uV(gemm_j, gemm_l2g(gemm_p, gemm_ia), ik)
-        end if
-      end do
-      end do
-      end do
-
-    do ispin=1,Nspin
-      gemm_io_blk_s = io_s
-      do while (gemm_io_blk_s <= io_e)
-        gemm_this_block = min(gemm_io_block, io_e - gemm_io_blk_s + 1)
-
-        ! Gather; loop over the invariant ppg%nps (not the ragged ppg%mps(ia)) since collapse() needs a rectangular iteration space, guard with an if instead.
-!$acc parallel loop collapse(3) present(tpsi,ppg,gemm_wf_packed)
-        do gemm_ia = 1, gemm_natom
-        do gemm_io_local = 1, gemm_this_block
-        do gemm_j = 1, ppg%nps
-          if (gemm_j <= ppg%mps(gemm_ia)) then
-            gemm_wf_packed(gemm_j, gemm_io_local, gemm_ia) = tpsi%zwf( &
-                ppg%jxyz(1,gemm_j,gemm_ia), ppg%jxyz(2,gemm_j,gemm_ia), ppg%jxyz(3,gemm_j,gemm_ia), &
-                ispin, gemm_io_blk_s+gemm_io_local-1, ik, im)
-          end if
-        end do
-        end do
-        end do
-
-        ! Batched GEMM: (max_nproj x nps) @ (nps x this_block) per atom, natom batches. CUBLAS_OP_C applies conjg().
-!$acc host_data use_device(gemm_zekr_packed, gemm_wf_packed, gemm_out_packed)
-        gemm_stat = cublasZgemmStridedBatched(gemm_handle, CUBLAS_OP_C, CUBLAS_OP_N, &
-            gemm_max_nproj, gemm_this_block, ppg%nps, &
-            (1.d0,0.d0), gemm_zekr_packed, ppg%nps, int(ppg%nps,8)*int(gemm_max_nproj,8), &
-            gemm_wf_packed, ppg%nps, int(ppg%nps,8)*int(gemm_io_block,8), &
-            (0.d0,0.d0), gemm_out_packed, gemm_max_nproj, int(gemm_max_nproj,8)*int(gemm_io_block,8), &
-            gemm_natom)
-!$acc end host_data
-
-        ! Scale by rinv_uvu, scatter back into ppg%uVpsibox's ilma indexing via gemm_l2g; padding rows (p>nproj_atom(ia)) are skipped.
-!$acc parallel loop collapse(3) present(ppg,gemm_out_packed,gemm_rinv_packed,gemm_l2g,gemm_nproj_atom)
-        do gemm_ia = 1, gemm_natom
-        do gemm_io_local = 1, gemm_this_block
-        do gemm_p = 1, gemm_max_nproj
-          if (gemm_p <= gemm_nproj_atom(gemm_ia)) then
-            ppg%uVpsibox(gemm_l2g(gemm_p,gemm_ia), ispin, gemm_io_blk_s+gemm_io_local-1, ik, im) = &
-                gemm_out_packed(gemm_p, gemm_io_local, gemm_ia) * gemm_rinv_packed(gemm_p, gemm_ia)
-          end if
-        end do
-        end do
-        end do
-
-        gemm_io_blk_s = gemm_io_blk_s + gemm_this_block
-      end do
-    end do
-    end do
-    end do
-
-    ! Phase 2 (back-projection): unchanged from the plain-acc path below, own acc kernels region since phase 1 no longer shares one with it.
-!$acc kernels present(ppg,tpsi,htpsi)
-!$acc loop collapse(5) independent private(ilocal,ilma,ia,uVpsi,vi,my_nlma,k,j,ix,iy,iz,wrk)
-    do im=im_s,im_e
-    do ik=ik_s,ik_e
-    do io=io_s,io_e
-    do ispin=1,Nspin
-      do vi=0,ppg%max_vi-1
-        my_nlma = ppg%v2nlma(vi)
-        if (my_nlma < 1) cycle
-
-        wrk = 0d0
-!$acc loop seq
-        do k=1,my_nlma
-          ilma = ppg%k2ilma(vi,k)
-          j    = ppg%k2j(vi,k)
-          wrk  = wrk + ppg%uVpsibox(ilma,ispin,io,ik,im) * ppg%zekr_uV(j,ilma,ik)
-        end do
-
-        ix = ppg%v2j(1,vi)
-        iy = ppg%v2j(2,vi)
-        iz = ppg%v2j(3,vi)
-        htpsi%zwf(ix,iy,iz,ispin,io,ik,im) = htpsi%zwf(ix,iy,iz,ispin,io,ik,im) + wrk
-      end do
-    end do
-    end do
-    end do
-    end do
-!$acc end kernels
 #else
 !$acc kernels present(ppg,tpsi,htpsi)
 !$acc loop collapse(5) independent gang private(ilocal,ilma,ia,uVpsi,vi,my_nlma,k,j,ix,iy,iz,wrk)
@@ -649,6 +703,7 @@ subroutine zpseudo(tpsi,htpsi,info,nspin,ppg)
 #endif
 
   end if
+#endif
 
   call nvtxEndRange()
   call timer_end(LOG_UHPSI_PSEUDO)

--- a/src/common/sendrecv_grid.f90
+++ b/src/common/sendrecv_grid.f90
@@ -22,6 +22,15 @@ module sendrecv_grid
 #define comm_send_init comm_send_init_device
 #define comm_recv_init comm_recv_init_device
 #endif
+! A call whose continuation crosses #ifdef/#else/#endif defeats CMake's
+! Fortran dependency scanner (silently drops later `use` lines). Pick the callee by macro instead.
+#ifdef USE_OPENACC
+#define PACK_COPY_DATA copy_data_m2d
+#define UNPACK_COPY_DATA copy_data_d2m
+#else
+#define PACK_COPY_DATA copy_data
+#define UNPACK_COPY_DATA copy_data
+#endif
 
   implicit none
 
@@ -296,11 +305,7 @@ module sendrecv_grid
       integer :: is_s(1:3), ie_s(1:3) ! src region
       is_s(1:3) = srg%is_block(1:3, itype_send, jside, jdir)
       ie_s(1:3) = srg%ie_block(1:3, itype_send, jside, jdir)
-#ifdef USE_OPENACC
-      call copy_data_m2d( &
-#else
-      call copy_data( &
-#endif
+      call PACK_COPY_DATA( &
         data(is_s(1):ie_s(1), is_s(2):ie_s(2), is_s(3):ie_s(3), 1:srg%nb), &
         srg%cache(itype_send, jside, jdir)%dbuf)
     end subroutine pack_cache
@@ -316,11 +321,7 @@ module sendrecv_grid
       integer :: is_d(1:3), ie_d(1:3) ! dst region
       is_d(1:3) = srg%is_block(1:3, itype_recv, jside, jdir)
       ie_d(1:3) = srg%ie_block(1:3, itype_recv, jside, jdir)
-#ifdef USE_OPENACC
-      call copy_data_d2m( &
-#else
-      call copy_data( &
-#endif
+      call UNPACK_COPY_DATA( &
         srg%cache(itype_recv, jside, jdir)%dbuf, &
         data(is_d(1):ie_d(1), is_d(2):ie_d(2), is_d(3):ie_d(3), 1:srg%nb))
     end subroutine unpack_cache
@@ -463,11 +464,7 @@ module sendrecv_grid
       integer :: is_s(1:3), ie_s(1:3) ! src region
       is_s(1:3) = srg%is_block(1:3, itype_send, jside, jdir)
       ie_s(1:3) = srg%ie_block(1:3, itype_send, jside, jdir)
-#ifdef USE_OPENACC
-      call copy_data_m2d( &
-#else
-      call copy_data( &
-#endif
+      call PACK_COPY_DATA( &
         data(is_s(1):ie_s(1), is_s(2):ie_s(2), is_s(3):ie_s(3), 1:srg%nb), &
         srg%cache(itype_send, jside, jdir)%zbuf)
     end subroutine pack_cache
@@ -483,11 +480,7 @@ module sendrecv_grid
       integer :: is_d(1:3), ie_d(1:3) ! dst region
       is_d(1:3) = srg%is_block(1:3, itype_recv, jside, jdir)
       ie_d(1:3) = srg%ie_block(1:3, itype_recv, jside, jdir)
-#ifdef USE_OPENACC
-      call copy_data_d2m( &
-#else
-      call copy_data( &
-#endif
+      call UNPACK_COPY_DATA( &
         srg%cache(itype_recv, jside, jdir)%zbuf, &
         data(is_d(1):ie_d(1), is_d(2):ie_d(2), is_d(3):ie_d(3), 1:srg%nb))
     end subroutine unpack_cache

--- a/src/common/total_energy.f90
+++ b/src/common/total_energy.f90
@@ -22,7 +22,9 @@ MODULE Total_Energy
 ! Raise or drop the version test below once NVIDIA fixes this.
 ! Separately, init_ewald's fill loop declared copyin(ewald) while writing
 ! ewald%bk / ewald%npair_bk, discarding those device writes; clause removed.
-#if defined(USE_OPENACC)
+! -DSALMON_NO_EWALD_WORKAROUND puts the reductions back on the GPU, for
+! re-testing whether a given compiler still has the bug.
+#if defined(USE_OPENACC) && !defined(SALMON_NO_EWALD_WORKAROUND)
 #  if defined(__NVCOMPILER_MAJOR__) && (__NVCOMPILER_MAJOR__ > 26 || (__NVCOMPILER_MAJOR__ == 26 && __NVCOMPILER_MINOR__ >= 5))
 #    define SALMON_ACC_REDUCTION_BROKEN 1
 #  endif

--- a/src/common/total_energy.f90
+++ b/src/common/total_energy.f90
@@ -16,28 +16,12 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
 MODULE Total_Energy
 
-! ---------------------------------------------------------------------------
-! nvfortran 26.5 OpenACC reduction workaround.
-!
-! Under nvhpc 26.5 the OpenACC reductions in init_ewald (reduction(max:)) and
-! calc_Total_Energy_periodic (reduction(+:)) silently return the reduction
-! IDENTITY (0) instead of the computed value. Verified by building the very
-! same loops as hand-written CUDA kernels on the same GPU with the same data:
-! CUDA gives 74 / 0.4478233939199485 (correct), OpenACC gives 0 / 0.
-! nvhpc 26.3 is unaffected. Both loops are one-time / per-ion-move setup, so
-! running them on the host costs essentially nothing.
-!
-! The book-keeping fill loop in init_ewald is affected the same way (its
-! per-atom counter comes back as 1 instead of ~74), so it is gated too.
-!
-! Unrelated to the compiler, that same fill loop also declared copyin(ewald)
-! -- host->device ONLY -- while writing ewald%bk / ewald%npair_bk inside the
-! region, so those device writes were semantically discarded. The wrong clause
-! is removed here so the GPU path is correct once the gate is relaxed. (That
-! fix on its own does not cure 26.5; the codegen bug above is the blocker.)
-!
-! When NVIDIA fixes this, drop the version test below (or raise the bound).
-! ---------------------------------------------------------------------------
+! nvfortran >= 26.5 silently returns the identity from the OpenACC reductions
+! in init_ewald and calc_Total_Energy_periodic, so those loops run on the host
+! there; they are one-time setup, so the cost is negligible. 26.3 is fine.
+! Raise or drop the version test below once NVIDIA fixes this.
+! Separately, init_ewald's fill loop declared copyin(ewald) while writing
+! ewald%bk / ewald%npair_bk, discarding those device writes; clause removed.
 #if defined(USE_OPENACC)
 #  if defined(__NVCOMPILER_MAJOR__) && (__NVCOMPILER_MAJOR__ > 26 || (__NVCOMPILER_MAJOR__ == 26 && __NVCOMPILER_MINOR__ >= 5))
 #    define SALMON_ACC_REDUCTION_BROKEN 1

--- a/src/common/total_energy.f90
+++ b/src/common/total_energy.f90
@@ -15,6 +15,39 @@
 !
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
 MODULE Total_Energy
+
+! ---------------------------------------------------------------------------
+! nvfortran 26.5 OpenACC reduction workaround.
+!
+! Under nvhpc 26.5 the OpenACC reductions in init_ewald (reduction(max:)) and
+! calc_Total_Energy_periodic (reduction(+:)) silently return the reduction
+! IDENTITY (0) instead of the computed value. Verified by building the very
+! same loops as hand-written CUDA kernels on the same GPU with the same data:
+! CUDA gives 74 / 0.4478233939199485 (correct), OpenACC gives 0 / 0.
+! nvhpc 26.3 is unaffected. Both loops are one-time / per-ion-move setup, so
+! running them on the host costs essentially nothing.
+!
+! The book-keeping fill loop in init_ewald is affected the same way (its
+! per-atom counter comes back as 1 instead of ~74), so it is gated too.
+!
+! Unrelated to the compiler, that same fill loop also declared copyin(ewald)
+! -- host->device ONLY -- while writing ewald%bk / ewald%npair_bk inside the
+! region, so those device writes were semantically discarded. The wrong clause
+! is removed here so the GPU path is correct once the gate is relaxed. (That
+! fix on its own does not cure 26.5; the codegen bug above is the blocker.)
+!
+! When NVIDIA fixes this, drop the version test below (or raise the bound).
+! ---------------------------------------------------------------------------
+#if defined(USE_OPENACC)
+#  if defined(__NVCOMPILER_MAJOR__) && (__NVCOMPILER_MAJOR__ > 26 || (__NVCOMPILER_MAJOR__ == 26 && __NVCOMPILER_MINOR__ >= 5))
+#    define SALMON_ACC_REDUCTION_BROKEN 1
+#  endif
+#endif
+
+#if defined(USE_OPENACC) && !defined(SALMON_ACC_REDUCTION_BROKEN)
+#  define SALMON_EWALD_ACC 1
+#endif
+
 implicit none
 
 CONTAINS
@@ -325,7 +358,7 @@ CONTAINS
 
       if(ewald%yn_bookkeep=='y') then
 
-#ifdef USE_OPENACC
+#ifdef SALMON_EWALD_ACC
 !$acc kernels copyin(ewald)
 !$acc loop private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr) reduction(+:E_tmp)
 #else
@@ -358,7 +391,7 @@ CONTAINS
 
             end do  !ipair
          end do     !ia
-#ifdef USE_OPENACC
+#ifdef SALMON_EWALD_ACC
 !$acc end kernels
 #else
 !$omp end parallel do
@@ -850,7 +883,7 @@ CONTAINS
 
     !(check maximum number of pairs and allocate)
     npair_bk_max = 0
-#ifdef USE_OPENACC
+#ifdef SALMON_EWALD_ACC
 !$acc kernels loop private(iia,ia,ix,iy,iz,ib,r,rab,rr,npair_bk_loc) reduction(max:npair_bk_max)
 #else
 !$omp parallel do private(iia,ia,ix,iy,iz,ib,r,rab,rr,npair_bk_loc) &
@@ -887,7 +920,7 @@ CONTAINS
         end do
         npair_bk_max = max(npair_bk_max,npair_bk_loc)
       end do
-#ifdef USE_OPENACC
+#ifdef SALMON_EWALD_ACC
 !$acc end kernels
 #else
 !$omp end parallel do
@@ -904,8 +937,8 @@ CONTAINS
 820      format(a,i6)
       endif
 
-#ifdef USE_OPENACC
-!$acc kernels loop private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr) copyin(ewald)
+#ifdef SALMON_EWALD_ACC
+!$acc kernels loop private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr)
 #else
 !$omp parallel do private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr)
 #endif
@@ -944,7 +977,7 @@ CONTAINS
         end do
         ewald%npair_bk(iia) = ipair
       end do
-#ifdef USE_OPENACC
+#ifdef SALMON_EWALD_ACC
 !$acc end kernels
 #else
 !$omp end parallel do

--- a/src/common/total_energy.f90
+++ b/src/common/total_energy.f90
@@ -16,24 +16,6 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
 MODULE Total_Energy
 
-! nvfortran >= 26.5 silently returns the identity from the OpenACC reductions
-! in init_ewald and calc_Total_Energy_periodic, so those loops run on the host
-! there; they are one-time setup, so the cost is negligible. 26.3 is fine.
-! Raise or drop the version test below once NVIDIA fixes this.
-! Separately, init_ewald's fill loop declared copyin(ewald) while writing
-! ewald%bk / ewald%npair_bk, discarding those device writes; clause removed.
-! -DSALMON_NO_EWALD_WORKAROUND puts the reductions back on the GPU, for
-! re-testing whether a given compiler still has the bug.
-#if defined(USE_OPENACC) && !defined(SALMON_NO_EWALD_WORKAROUND)
-#  if defined(__NVCOMPILER_MAJOR__) && (__NVCOMPILER_MAJOR__ > 26 || (__NVCOMPILER_MAJOR__ == 26 && __NVCOMPILER_MINOR__ >= 5))
-#    define SALMON_ACC_REDUCTION_BROKEN 1
-#  endif
-#endif
-
-#if defined(USE_OPENACC) && !defined(SALMON_ACC_REDUCTION_BROKEN)
-#  define SALMON_EWALD_ACC 1
-#endif
-
 implicit none
 
 CONTAINS
@@ -318,6 +300,7 @@ CONTAINS
     real(8) :: rr,rab(3),r(3),E_tmp,E_tmp_l,g(3),Gd,sysvol,E_wrk(5),E_sum(5)
     real(8) :: E_wrk_local_1,E_wrk_local_2
     real(8) :: etmp
+    integer :: nion_mg_l
     complex(8) :: rho_e,rho_i
     call nvtxStartRange('calc_Total_Energy_periodic', __LINE__)
     call timer_begin(LOG_TE_PERIODIC_CALC)
@@ -344,13 +327,16 @@ CONTAINS
 
       if(ewald%yn_bookkeep=='y') then
 
-#ifdef SALMON_EWALD_ACC
+         ! nvfortran >= 26.5 evaluates the loop tripcount on the device,
+         ! where info%nion_mg is not resident; use a local scalar.
+         nion_mg_l = info%nion_mg
+#ifdef USE_OPENACC
 !$acc kernels copyin(ewald)
 !$acc loop private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr) reduction(+:E_tmp)
 #else
 !$omp parallel do private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr) reduction(+:E_tmp)
 #endif
-         do iia=1,info%nion_mg
+         do iia=1,nion_mg_l
         !do ia=1,system%nion
             ia = info%ia_mg(iia)
             do ipair = 1,ewald%npair_bk(iia)
@@ -377,7 +363,7 @@ CONTAINS
 
             end do  !ipair
          end do     !ia
-#ifdef SALMON_EWALD_ACC
+#ifdef USE_OPENACC
 !$acc end kernels
 #else
 !$omp end parallel do
@@ -836,6 +822,7 @@ CONTAINS
     !
     integer :: ix,iy,iz,iia,ia,ib,ir,ipair   !,ig
     integer :: npair_bk_max, npair_bk_loc
+    integer :: nion_mg_l
    !integer :: k,irank, nproc, ig_tmp,ig_sum
     real(8) :: rr,rab(3),r(3) !,g(3),G2
     real(8) :: r1, cutoff_erfc_r, tmp
@@ -869,13 +856,14 @@ CONTAINS
 
     !(check maximum number of pairs and allocate)
     npair_bk_max = 0
-#ifdef SALMON_EWALD_ACC
+    nion_mg_l = info%nion_mg
+#ifdef USE_OPENACC
 !$acc kernels loop private(iia,ia,ix,iy,iz,ib,r,rab,rr,npair_bk_loc) reduction(max:npair_bk_max)
 #else
 !$omp parallel do private(iia,ia,ix,iy,iz,ib,r,rab,rr,npair_bk_loc) &
 !$omp             reduction(max:npair_bk_max)
 #endif
-    do iia=1,info%nion_mg
+    do iia=1,nion_mg_l
    !do ia=1,system%nion
        ia = info%ia_mg(iia)
        npair_bk_loc = 0
@@ -906,7 +894,7 @@ CONTAINS
         end do
         npair_bk_max = max(npair_bk_max,npair_bk_loc)
       end do
-#ifdef SALMON_EWALD_ACC
+#ifdef USE_OPENACC
 !$acc end kernels
 #else
 !$omp end parallel do
@@ -923,12 +911,13 @@ CONTAINS
 820      format(a,i6)
       endif
 
-#ifdef SALMON_EWALD_ACC
+    nion_mg_l = info%nion_mg
+#ifdef USE_OPENACC
 !$acc kernels loop private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr)
 #else
 !$omp parallel do private(iia,ia,ipair,ix,iy,iz,ib,r,rab,rr)
 #endif
-    do iia=1,info%nion_mg
+    do iia=1,nion_mg_l
    !do ia=1,system%nion
        ia = info%ia_mg(iia)
        ipair = 0
@@ -963,7 +952,7 @@ CONTAINS
         end do
         ewald%npair_bk(iia) = ipair
       end do
-#ifdef SALMON_EWALD_ACC
+#ifdef USE_OPENACC
 !$acc end kernels
 #else
 !$omp end parallel do

--- a/src/common/zstencil_core/gpu/seq.f90
+++ b/src/common/zstencil_core/gpu/seq.f90
@@ -71,10 +71,8 @@ subroutine zstencil_typical_gpu(io_s,io_e,Nspin,is_array,ie_array,is,ie,idx,idy,
 #define DY(dt) ix,idy(iy+(dt)),iz
 #define DZ(dt) ix,iy,idz(iz+(dt))
 #ifdef USE_OPENACC
-  ! Pulling io out of the collapse is ~1.4x faster on Blackwell but ~1.6x slower on
-  ! Hopper, so choose per device. The binary is built for several architectures at
-  ! once (-gpu=cc80,cc90,...), so this cannot be decided at compile time. Only
-  ! Blackwell and newer are opted in; anything else keeps the original loop.
+  ! Pulling io out of the collapse is ~1.4x faster on Blackwell, ~1.6x slower on
+  ! Hopper; the binary is multi-architecture, so dispatch at runtime.
   if (.not. probed) then
     cuda_stat = cudaGetDevice(cuda_dev)
     cuda_stat = cudaGetDeviceProperties(prop, cuda_dev)

--- a/src/common/zstencil_core/gpu/seq.f90
+++ b/src/common/zstencil_core/gpu/seq.f90
@@ -18,6 +18,9 @@ subroutine zstencil_typical_gpu(io_s,io_e,Nspin,is_array,ie_array,is,ie,idx,idy,
                                ,tpsi,htpsi,V_local,lap0,lapt,nabt &
                                )
   use structures
+#ifdef USE_OPENACC
+  use cudafor, only: cudaGetDevice, cudaGetDeviceProperties, cudaDeviceProp
+#endif
   implicit none
 
 
@@ -43,6 +46,13 @@ subroutine zstencil_typical_gpu(io_s,io_e,Nspin,is_array,ie_array,is,ie,idx,idy,
   complex(8) :: t_0,t_1
   integer    :: i
 
+#ifdef USE_OPENACC
+  logical,save :: probed = .false.
+  logical,save :: io_restructure = .false.
+  type(cudaDeviceProp) :: prop
+  integer :: cuda_stat, cuda_dev
+#endif
+
 #ifdef __INTEL_COMPILER
 #if defined(__KNC__) || defined(__AVX512F__)
 #   define MEM_ALIGN   64
@@ -60,15 +70,77 @@ subroutine zstencil_typical_gpu(io_s,io_e,Nspin,is_array,ie_array,is,ie,idx,idy,
 #define DX(dt) idx(ix+(dt)),iy,iz
 #define DY(dt) ix,idy(iy+(dt)),iz
 #define DZ(dt) ix,iy,idz(iz+(dt))
+#ifdef USE_OPENACC
+  ! Pulling io out of the collapse is ~1.4x faster on Blackwell but ~1.6x slower on
+  ! Hopper, so choose per device. The binary is built for several architectures at
+  ! once (-gpu=cc80,cc90,...), so this cannot be decided at compile time. Only
+  ! Blackwell and newer are opted in; anything else keeps the original loop.
+  if (.not. probed) then
+    cuda_stat = cudaGetDevice(cuda_dev)
+    cuda_stat = cudaGetDeviceProperties(prop, cuda_dev)
+    io_restructure = (cuda_stat == 0 .and. prop%major >= 10)
+    probed = .true.
+  end if
+
+  if (io_restructure) then
+
+!$acc kernels copyin(V_local, tpsi) copy(htpsi)
+!$acc loop collapse(4)
+  do ispin=1,Nspin
+  do iz=igs(3),ige(3)
+  do iy=igs(2),ige(2)
+  do ix=igs(1),ige(1)
+  !$acc loop seq
+  do io=io_s,io_e
+    v = z0
+    w = z0
+    !$acc loop seq
+    do i = 1,4
+      t_0 = tpsi(DX( i), ispin, io)
+      t_1 = tpsi(DX(-i), ispin, io)
+      v=lapt(i)*(t_0+t_1) + v
+      w=nabt(i)*(t_0-t_1) + w
+    end do
+    htpsi(ix,iy,iz,ispin,io) = V_local(ispin)%f(ix,iy,iz)*tpsi(ix,iy,iz,ispin,io) &
+                    + lap0*tpsi(ix,iy,iz,ispin,io) &
+                    - 0.5d0 * v - zI * w
+  end do
+
+  !$acc loop seq
+  do io=io_s,io_e
+    v = z0
+    w = z0
+    !$acc loop seq
+    do i = 1,4
+      t_0 = tpsi(DY( i), ispin, io)
+      t_1 = tpsi(DY(-i), ispin, io)
+      v=lapt(i+4)*(t_0+t_1) + v
+      w=nabt(i+4)*(t_0-t_1) + w
+    end do
+    !$acc loop seq
+    do i = 1,4
+      t_0 = tpsi(DZ( i), ispin, io)
+      t_1 = tpsi(DZ(-i), ispin, io)
+      v=lapt(i+8)*(t_0+t_1) + v
+      w=nabt(i+8)*(t_0-t_1) + w
+    end do
+    htpsi(ix,iy,iz,ispin,io) = htpsi(ix,iy,iz,ispin,io) &
+                    - 0.5d0 * v - zI * w
+  end do
+  end do
+  end do
+  end do
+  end do
+!$acc end kernels
+
+  else
+
 !$acc kernels copyin(V_local, tpsi) copy(htpsi)
 !$acc loop collapse(5)
   do io=io_s,io_e
   do ispin=1,Nspin
   do iz=igs(3),ige(3)
   do iy=igs(2),ige(2)
-! !dir$ assume_aligned V_local(is(1),iy,iz):MEM_ALIGN
-! !dir$ assume_aligned tpsi(is_array(1),iy,iz)   :MEM_ALIGN
-! !dir$ assume_aligned htpsi(is_array(1),iy,iz)  :MEM_ALIGN
   do ix=igs(1),ige(1)
     v = z0
     w = z0
@@ -79,7 +151,6 @@ subroutine zstencil_typical_gpu(io_s,io_e,Nspin,is_array,ie_array,is,ie,idx,idy,
       v=lapt(i)*(t_0+t_1) + v
       w=nabt(i)*(t_0-t_1) + w
     end do
-#ifdef USE_OPENACC
     htpsi(ix,iy,iz,ispin,io) = V_local(ispin)%f(ix,iy,iz)*tpsi(ix,iy,iz,ispin,io) &
                     + lap0*tpsi(ix,iy,iz,ispin,io) &
                     - 0.5d0 * v - zI * w
@@ -97,7 +168,6 @@ subroutine zstencil_typical_gpu(io_s,io_e,Nspin,is_array,ie_array,is,ie,idx,idy,
   do ix=igs(1),ige(1)
     v = z0
     w = z0
-#endif
     !$acc loop seq
     do i = 1,4
       t_0 = tpsi(DY( i), ispin, io)
@@ -112,18 +182,52 @@ subroutine zstencil_typical_gpu(io_s,io_e,Nspin,is_array,ie_array,is,ie,idx,idy,
       v=lapt(i+8)*(t_0+t_1) + v
       w=nabt(i+8)*(t_0-t_1) + w
     end do
-#ifdef USE_OPENACC
     htpsi(ix,iy,iz,ispin,io) = htpsi(ix,iy,iz,ispin,io) &
                     - 0.5d0 * v - zI * w
-#else
-    htpsi(ix,iy,iz,ispin,io) = V_local(ispin)%f(ix,iy,iz)*tpsi(ix,iy,iz,ispin,io) &
-                    + lap0*tpsi(ix,iy,iz,ispin,io) &
-                    - 0.5d0 * v - zI * w
-#endif
   end do
   end do
   end do
   end do
   end do
 !$acc end kernels
+
+  end if
+#else
+  do io=io_s,io_e
+  do ispin=1,Nspin
+  do iz=igs(3),ige(3)
+  do iy=igs(2),ige(2)
+! !dir$ assume_aligned V_local(is(1),iy,iz):MEM_ALIGN
+! !dir$ assume_aligned tpsi(is_array(1),iy,iz)   :MEM_ALIGN
+! !dir$ assume_aligned htpsi(is_array(1),iy,iz)  :MEM_ALIGN
+  do ix=igs(1),ige(1)
+    v = z0
+    w = z0
+    do i = 1,4
+      t_0 = tpsi(DX( i), ispin, io)
+      t_1 = tpsi(DX(-i), ispin, io)
+      v=lapt(i)*(t_0+t_1) + v
+      w=nabt(i)*(t_0-t_1) + w
+    end do
+    do i = 1,4
+      t_0 = tpsi(DY( i), ispin, io)
+      t_1 = tpsi(DY(-i), ispin, io)
+      v=lapt(i+4)*(t_0+t_1) + v
+      w=nabt(i+4)*(t_0-t_1) + w
+    end do
+    do i = 1,4
+      t_0 = tpsi(DZ( i), ispin, io)
+      t_1 = tpsi(DZ(-i), ispin, io)
+      v=lapt(i+8)*(t_0+t_1) + v
+      w=nabt(i+8)*(t_0-t_1) + w
+    end do
+    htpsi(ix,iy,iz,ispin,io) = V_local(ispin)%f(ix,iy,iz)*tpsi(ix,iy,iz,ispin,io) &
+                    + lap0*tpsi(ix,iy,iz,ispin,io) &
+                    - 0.5d0 * v - zI * w
+  end do
+  end do
+  end do
+  end do
+  end do
+#endif
 end subroutine

--- a/src/parallel/communication.f90
+++ b/src/parallel/communication.f90
@@ -306,17 +306,9 @@ contains
     integer :: ierr
     integer :: iprovided
 #ifdef USE_OPENACC
-    ! Force CUDA context creation *before* MPI_Init_thread. Without this,
-    ! UCC's MPI_COMM_WORLD team bootstrap (inside MPI_Init) does CUDA-aware
-    ! UCX rendezvous-protocol probing (cuCtxGetDevice) with no CUDA context
-    ! yet established -- CUDA_ERROR_INVALID_CONTEXT, silently swallowed by
-    ! UCX, which appears to cache a broken protocol config for that team.
-    ! That cached config later fails for real ("cannot find remote protocol
-    ! for: UCC_UCP_CONTEXT inter-node cfg#N") on the first real collective
-    ! that needs it, hanging 2+ node runs. acc_init respects
-    ! CUDA_VISIBLE_DEVICES (already set per-rank by wrapper.sh before this
-    ! point), so this binds the correct GPU. See subwg2-benchmarks'
-    ! salmon-gpu-optimization-ideas skill for the full investigation.
+    ! Establish the CUDA context before MPI_Init_thread: UCC's team bootstrap
+    ! probes CUDA-aware UCX and caches a broken config if none exists yet,
+    ! which later hangs multi-node collectives.
     call acc_init(acc_device_nvidia)
 #endif
     MPI_ERROR_CHECK(call MPI_Init_thread(MPI_THREAD_FUNNELED, iprovided, ierr))

--- a/src/parallel/communication.f90
+++ b/src/parallel/communication.f90
@@ -299,9 +299,26 @@ module communication
 contains
   subroutine comm_init
     use mpi, only: MPI_THREAD_FUNNELED
+#ifdef USE_OPENACC
+    use openacc
+#endif
     implicit none
     integer :: ierr
     integer :: iprovided
+#ifdef USE_OPENACC
+    ! Force CUDA context creation *before* MPI_Init_thread. Without this,
+    ! UCC's MPI_COMM_WORLD team bootstrap (inside MPI_Init) does CUDA-aware
+    ! UCX rendezvous-protocol probing (cuCtxGetDevice) with no CUDA context
+    ! yet established -- CUDA_ERROR_INVALID_CONTEXT, silently swallowed by
+    ! UCX, which appears to cache a broken protocol config for that team.
+    ! That cached config later fails for real ("cannot find remote protocol
+    ! for: UCC_UCP_CONTEXT inter-node cfg#N") on the first real collective
+    ! that needs it, hanging 2+ node runs. acc_init respects
+    ! CUDA_VISIBLE_DEVICES (already set per-rank by wrapper.sh before this
+    ! point), so this binds the correct GPU. See subwg2-benchmarks'
+    ! salmon-gpu-optimization-ideas skill for the full investigation.
+    call acc_init(acc_device_nvidia)
+#endif
     MPI_ERROR_CHECK(call MPI_Init_thread(MPI_THREAD_FUNNELED, iprovided, ierr))
   end subroutine
 


### PR DESCRIPTION
## Summary

Eight independent, individually-reviewable changes for the OpenACC (GPU) build, each landed as its own commit:

1. **Optimize stencil / current-density / pseudo-pt OpenACC kernels** — batched cuBLAS GEMM for the nonlocal-potential (pseudo-pt) application (`USE_GEMM`), current-density inlined into `calc_current`'s OpenACC region (removes a device-routine call boundary), and a restructured hpsi stencil kernel. Measured on B200 (Rikyu): `rt iterations` improves 1.55x on 1-GPU, 1.59x on 4-GPU; 1.39x on GH200. Correctness bit-exact everywhere. (Originally the entire content of this PR before the additions below.)
2. **Add `nvhpc-openacc-gemm.cmake`** — new `configure.py` platform preset wiring up (1): OpenACC on, `USE_CUDA` deliberately off (SALMON's older hand-written CUDA kernels in `zpseudo.cu`/`stencil_current.cu` are a separate, older optimization path -- a net performance loss at the problem sizes tested so far, and `stencil_current.cu`'s host wrapper has a real out-of-bounds device-buffer bug under real-space decomposition), `-DUSE_GEMM`, `cusolver` linked alongside `cublas`.
3. **Fix OpenACC loop tripcounts for device-side evaluation** — `nvfortran` 26.5 evaluates a loop's tripcount on the device rather than on the host, which is the spec-correct behaviour. Three loops in `total_energy.f90` took their bound from `info%nion_mg`, a scalar member of a dummy-argument derived type that is not device-resident under `-gpu=managed`, so the device read a zero tripcount: the loops ran zero times and the reductions in them returned the identity, giving a wrong but plausible total energy with no crash and no warning. Fix: hoist the bound into a local scalar at each loop, so they stay on the GPU and 26.5 reproduces 26.3 bit-for-bit (verified on B200 at 1, 2 and 4 ranks, where `info%nion_mg` differs per rank). Diagnosis of the tripcount default change is due to Seth Camp ([@scamp-nvidia](https://github.com/scamp-nvidia), NVIDIA); an earlier revision of this PR misattributed the symptom to a compiler codegen defect and worked around it with a version gate and a host fallback, both now removed. Also drops a `copyin` clause on one of those loops, which writes to the structure it declared host-to-device only, so those device writes were being discarded.
4. **Force CUDA context creation before `MPI_Init_thread`** — fixes a real, 100%-reproducible hang at 2+ nodes on native `nvhpc/26.5` (HPC-X 2.50/UCC 1.8.0/UCX 1.21.0). UCC's `MPI_COMM_WORLD` team bootstrap happens inside `MPI_Init`, and does CUDA-aware UCX rendezvous-protocol probing (`cuCtxGetDevice`) as part of that -- but SALMON calls `MPI_Init` before ever touching CUDA, so the probe runs with no context and fails with `CUDA_ERROR_INVALID_CONTEXT`. UCX appears to swallow that silently and cache a broken protocol config for the team, which only surfaces later as an infinite spin on the first real collective that needs it (`cannot find remote protocol for: UCC_UCP_CONTEXT inter-node cfg#N | tag_send from cuda-managed/GPU0`). Root-caused via a live `gdb` backtrace on the hung process and `compute-sanitizer` on the real binary (caught the actual `CUDA_ERROR_INVALID_CONTEXT` inside `MPI_Init`'s UCC team-creation path). Fix: `acc_init(acc_device_nvidia)` before `MPI_Init_thread`, gated on `USE_OPENACC` (no-op otherwise).
5. **Device-buffer reduce for pseudo-pt under domain decomposition** — the reduction buffer was managed memory, so CUDA-aware MPI never used NVLink (`!$acc update host`/`device` are no-ops under `-gpu=managed`). Packing into a CUDA Fortran `device` buffer cut pseudo-pt communication 3.9-4.3x. `-DUSE_NCCL` optionally routes the same reduce through `ncclAllReduce`.
6. **Grid-parallel current-density stencil** — collapse `(ik, io, grid)` into one gang reduction in `calc_current`'s inlined stencil, which was occupancy-starved at high orbital parallelism (~60 gangs against ~148 SMs at `Po=32`). Bit-exact; `rt iter` improves 4.5% at 4 GPUs rising to 23% at 32.
7. **Fix a CMake dependency-scanner bug in `sendrecv_grid.f90`** — a call spanning `#ifdef`/`#else`/`#endif` made CMake silently drop a later `use` statement in the file, breaking parallel builds with no error. Select the callee with a `#define` instead, matching the pattern already used for `comm_send_init`/`comm_recv_init` in this same file.
8. **Guard `add_xc_tau_operator`'s 8-dimension arrays under `USE_OPENACC`** — two local arrays declare 8 dimensions, over nvfortran's 7-dimension limit. The function already aborts immediately under `USE_OPENACC`, but only the abort call was guarded; the declarations and the rest of the body were still compiled and never reached. Guard the whole thing the same way.

Earlier revisions of this PR carried a version-gated host fallback for (3), on the assumption that the reductions were miscompiled. They were not, and it has been removed.

## Scaling matrix

Same binary throughout (`USE_GEMM` + `USE_NCCL`), `nvhpc-hpcx-cuda13/26.5`, `--mca fcoll individual`, `--exclusive`. Every run bit-exact at `-164703.595116277 eV`. 3x3x3 SiO2: 486 atoms, 2592 electrons, 1944 states, grid 87x147x93, Gamma-only, `nt=300` from a pre-staged folded restart.

Times are seconds for the whole `rt iterations` block (300 steps). `Po` = `nproc_ob`, `Pg` = product of `nproc_rgrid`; mixed layouts keep `Pg` inside a node via `process_allocation='grid_sequential'`.

| layout | GPUs | nodes | rt iter | speedup | stencil | pseudo-pt | pp comm | curr | halo comm |
|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|
| none | 1 | 1 | 208.35 | 1.00x | 61.79 | 89.53 | — | 22.49 | — |
| orbital `Po4` | 4 | 1 | **57.77** | 3.61x | 15.65 | 23.09 | 0 | 7.94 | 0 |
| domain `Pg4` | 4 | 1 | 79.63 | 2.62x | 17.77 | 24.46 | 1.71 | 13.16 | 10.67 |
| orbital `Po8` | 8 | 2 | **30.92** | 6.74x | 7.96 | 11.72 | 0 | 4.34 | 0 |
| mixed `Po2xPg4` | 8 | 2 | 42.95 | 4.85x | 8.95 | 12.20 | 0.98 | 7.19 | 5.64 |
| orbital `Po16` | 16 | 4 | **18.72** | 11.13x | 4.12 | 6.19 | 0 | 3.63 | 0 |
| mixed `Po4xPg4` | 16 | 4 | 24.23 | 8.60x | 4.59 | 6.30 | 0.59 | 4.15 | 3.13 |
| orbital `Po32` | 32 | 8 | **12.53** | 16.63x | 2.45 | 3.30 | 0 | 3.22 | 0 |
| mixed `Po8xPg4` | 32 | 8 | 16.56 | 12.58x | 2.45 | 3.30 | 0.57 | 2.77 | 1.89 |

Pure orbital decomposition is fastest at every count, by 1.29-1.39x over the best mixed layout. Real-space decomposition's only advantage is on current density, and that kernel is now small enough (2.8-4.3 s at 8+ GPUs) that it does not pay for the halo exchange splitting the grid costs. Domain decomposition stays useful as the fallback when orbital parallelism runs out, since `Po` has to divide sensibly into `nstate`.

Two environment notes for reproducing this:

- Built and run with `nvhpc-hpcx-cuda13/26.5`. On a single node `26.3 + --mca coll_ucc_enable 1` gives a faster allreduce, but UCC is not usable across nodes on this stack, so it is not used anywhere above.
- **`--mca fcoll individual` is required.** `MPI_File_read_all` reads the restart directly into `spsi%zwf`, which is managed memory, and OMPIO's two-phase collective I/O then redistributes it through `cuMemcpyAsync`. On 26.3 that is merely slow (restart read 66.9s -> 41.7s with the flag); on 26.5 it **deadlocks** whenever the `nproc_rgrid` product exceeds 2.

## Miyabi-G: three-way build comparison at 4 GPUs

3x3x3 SiO2, 486 atoms, `nt=300`, orbital `nproc_ob=4`. Miyabi-G is 1 GPU/node (H100, IB NDR), so 4 GPUs = 4 nodes. Built with nvhpc/26.3 (cc90). Rikyu row from the matrix above (B200, 1 node, NVLink, nvhpc/26.5).

| build | machine | rt iter | stencil | pseudo-pt | curr |
|---|---|---:|---:|---:|---:|
| `USE_OPENACC` | Miyabi-G (H100, 4 nodes, IB) | 127.83 | 25.02 | 41.52 | 49.54 |
| `USE_CUDA` | Miyabi-G (H100, 4 nodes, IB) | 172.34 | 24.98 | 104.96 | 30.25 |
| This PR | Miyabi-G (H100, 4 nodes, IB) | 68.66 | 25.08 | 26.07 | 5.70 |
| This PR | Rikyu (B200, 1 node, NVLink) | 57.77 | 15.65 | 23.09 | 7.94 |



