### PR TITLE
Fix time centering in velocity-gauge SBE propagation

### DIFF
--- a/src/ssbe/multiscale_ssbe.f90
+++ b/src/ssbe/multiscale_ssbe.f90
@@ -25,7 +25,7 @@ subroutine main_multiscale_ssbe(icomm)
     real(8), allocatable :: Ac_ext_t(:, :)
     integer :: it, i
     integer :: nproc, irank, icomm_macro, nproc_macro, irank_macro
-    real(8), allocatable :: Ac_macro(:, :), E_macro(:, :)
+    real(8), allocatable :: Ac_macro(:, :), Ac_macro_old(:, :), E_macro(:, :)
     real(8), allocatable :: Jmat_macro_tmp(:, :), Jmat_macro(:, :)
     integer, allocatable :: itbl_macro_coord(:, :)
     integer, allocatable :: itbl_macro_itype_sbe(:)
@@ -110,6 +110,7 @@ subroutine main_multiscale_ssbe(icomm)
         icomm_macro = comm_create_group(icomm, imacro_min, 0)
         call comm_get_groupinfo(icomm_macro, irank_macro, nproc_macro)
         allocate(Ac_macro(1:3, nmacro))
+        allocate(Ac_macro_old(1:3, nmacro))
         allocate(E_macro(1:3, nmacro))
         allocate(Jmat_macro_tmp(1:3, nmacro))
         allocate(Jmat_macro(1:3, nmacro))
@@ -186,17 +187,22 @@ subroutine main_multiscale_ssbe(icomm)
                     iy = itbl_macro_coord(2, imacro)
                     iz = itbl_macro_coord(3, imacro)
                     Ac_macro(1:3, imacro) = fw%vec_Ac_new%v(1:3, ix, iy, iz)
+                    Ac_macro_old(1:3, imacro) = fw%vec_Ac%v(1:3, ix, iy, iz)
                     E_macro(1:3, imacro) = fw%vec_E%v(1:3, ix, iy, iz)
                 end do
             end if
             call comm_bcast(Ac_macro, icomm, 0)
+            call comm_bcast(Ac_macro_old, icomm, 0)
             call comm_bcast(E_macro, icomm, 0)
 
             Jmat_macro_tmp = 0.0d0
             do imacro = imacro_min, imacro_max
                 if (trim(gauge_sbe) == "velocity_gauge") then
+                    ! At loop entry, vec_Ac and vec_Ac_new hold the two
+                    ! endpoints of the current material-propagation interval.
                     call dt_evolve_bloch(sbe(imacro), gs(itbl_macro_itype_sbe(imacro)), &
-                                         Ac_macro(1:3, imacro), dt)
+                                         0.5d0 * (Ac_macro_old(1:3, imacro) &
+                                                + Ac_macro(1:3, imacro)), dt)
                     call calc_current_bloch(sbe(imacro), gs(itbl_macro_itype_sbe(imacro)), &
                                             Ac_macro(1:3, imacro), jmat, icomm_macro)
                 else ! trim(gauge_sbe) == "length_gauge"

--- a/src/ssbe/realtime_ssbe.f90
+++ b/src/ssbe/realtime_ssbe.f90
@@ -78,7 +78,10 @@ subroutine main_realtime_ssbe(icomm)
         t = dt * it
         E(:) = -(Ac_ext_t(:, it + 1) - Ac_ext_t(:, it - 1)) / (2 * dt)
         if (trim(gauge_sbe) == "velocity_gauge") then
-            call dt_evolve_bloch(sbe, gs, Ac_ext_t(:, it), dt)
+            ! Propagate over [t_(it-1), t_it] using the vector potential at
+            ! the midpoint of the interval.
+            call dt_evolve_bloch(sbe, gs, &
+                0.5d0 * (Ac_ext_t(:, it-1) + Ac_ext_t(:, it)), dt)
             call calc_current_bloch(sbe, gs, Ac_ext_t(:, it), Jmat, icomm)
         else ! trim(gauge_sbe) == "length_gauge")
             call dt_evolve_bloch_lg(sbe, gs, E(:), bj_am, dt, icomm)


### PR DESCRIPTION
## Summary

This PR fixes the time centering of the vector potential used in the
velocity-gauge SBE propagation.

Previously, the density matrix was propagated over the interval
`[t_(n-1), t_n]` using the vector potential at the endpoint `A(t_n)`.
The propagation now uses the midpoint value

```
A_mid = [A(t_(n-1)) + A(t_n)] / 2.
```

The same treatment is applied to Maxwell--SBE, where `vec_Ac` and
`vec_Ac_new` provide the two endpoints of the current material-propagation
interval.

## Root cause and impact

The Maxwell field uses a centered leapfrog-type update, while the
velocity-gauge Bloch propagation sampled the driving vector potential at
one endpoint of the full interval. This first-order material--field time
staggering can produce a secular material-work error and artificial gain in
Maxwell--SBE calculations.

The current is still evaluated with the vector potential at the current
time endpoint. The length-gauge path, input keywords, and output formats are
unchanged.

## Scope

Only two files are modified:

- `src/ssbe/realtime_ssbe.f90`
- `src/ssbe/multiscale_ssbe.f90`

## Validation

- Complete Fugaku/A64FX MPI + OpenMP release build: passed.
- In a single-cell energy-balance diagnostic, the Hamiltonian-energy
  residual decreased from `3.39e-7` a.u. to `6.97e-14` a.u.
- For a weak-field 0.2-micrometre Si film, the artificial Maxwell gain was
  removed:
  - `norder=0`: `1-R-T` changed from `-0.18045` to `+0.000349`.
  - `norder=1`: `1-R-T` changed from `-0.09072` to `+0.000112`.

The numerical validation used the same midpoint expressions applied here;
this PR isolates them from the additional diagnostic code.
