### PR TITLE
Guard MPI-only unfolding I/O in serial builds

### DIFF
--- a/src/analysis/dm_unfold.f90
+++ b/src/analysis/dm_unfold.f90
@@ -14,6 +14,9 @@
 !  limitations under the License.
 !
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
+
+#include "config.h"
+
 module dm_unfold_sub
   implicit none
 
@@ -29,13 +32,16 @@ contains
   use filesystem, only: open_filehandle
   use inputoutput, only: t_unit_time, t_unit_ac, t_unit_current
   use math_constants, only: zI,pi
+#ifdef USE_MPI
   use mpi
+#endif
   implicit none
   type(s_rgrid),           intent(in)    :: lg
   type(s_dft_system),      intent(inout) :: system
   type(s_parallel_info),   intent(in)    :: info
   type(s_ofile),           intent(out)   :: ofl
   type(s_unfold),          intent(inout) :: unfold
+#ifdef USE_MPI
   character(256) :: iofile
   integer :: icomm
   integer :: gsize(7), lsize(7), lstart(7)
@@ -488,6 +494,9 @@ contains
     end if
 
   end if ! yn_out_mom_distr_gs
+#else
+  stop 'dm_unfold_option requires a build with MPI support.'
+#endif
 
   end subroutine init_dm_unfold
 

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -2813,6 +2813,15 @@ contains
     call yn_argument_check(yn_dc_lcfo)
     call yn_argument_check(yn_dc_lcfo_diag)
 
+#ifndef USE_MPI
+    if(trim(dm_unfold_option)/='no') then
+      stop 'dm_unfold_option requires a build with MPI support.'
+    end if
+    if(yn_out_tm_bin=='y') then
+      stop "yn_out_tm_bin='y' requires a build with MPI support."
+    end if
+#endif
+
     select case(trim(lcfo_eigensolver))
     case('lapack')
       continue

--- a/src/io/write.f90
+++ b/src/io/write.f90
@@ -14,6 +14,9 @@
 !  limitations under the License.
 !
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
+
+#include "config.h"
+
 module write_sub
   use math_constants,only : zi,pi
   implicit none
@@ -110,7 +113,9 @@ contains
     use communication, only: comm_is_root,comm_summation,comm_sync_all
     use filesystem, only: open_filehandle
     use inputoutput, only: t_unit_energy
+#ifdef USE_MPI
     use mpi
+#endif
     implicit none
     type(s_dft_system) ,intent(in) :: system
     type(s_parallel_info),intent(in) :: info
@@ -125,9 +130,11 @@ contains
     integer :: fh_tm, narray
     integer :: i,j,ik,ib,ib1,ib2,ilma,nlma,ia,ix,iy,iz,NB,NK,im,ispin
     integer :: ik_s,ik_e,io_s,io_e,is(3),ie(3)
+#ifdef USE_MPI
     integer :: icomm, iopen_flag, minfo, mfile, ierr, n_count, source_type, file_type
     integer :: gsize(4), lsize(4), lstart(4)
     integer(kind=MPI_OFFSET_KIND) :: disp, block_size, base_vnl
+#endif
     real(8) :: x,y,z
     complex(8),allocatable :: upu(:,:,:,:,:),upu_l(:,:,:,:,:)
     complex(8),allocatable :: upu_all(:,:,:,:,:),upu_all_l(:,:,:,:,:)
@@ -395,6 +402,7 @@ contains
 
     end if  !flag_print_tm
 
+#ifdef USE_MPI
     if(flag_print_tm_bin) then
 
       file_tm_data = trim(base_directory)//'data_for_restart/tm.bin'
@@ -444,6 +452,7 @@ contains
       call MPI_Type_free(file_type, ierr)
 
     end if  !flag_print_tm_bin
+#endif
 
     if (flag_print_eps) then
        ! taken from tm2sigma.f90 in utility directory


### PR DESCRIPTION
@yabana Yabana-sensei, I fixed a serial build error caused by the unfolding implementation. Please review.