### PR TITLE
Fix MPI collective call mismatch in write_tm_data (tm.bin)

### DIFF
--- a/src/io/write.f90
+++ b/src/io/write.f90
@@ -126,8 +126,9 @@ contains
     integer :: i,j,ik,ib,ib1,ib2,ilma,nlma,ia,ix,iy,iz,NB,NK,im,ispin
     integer :: ik_s,ik_e,io_s,io_e,is(3),ie(3)
     integer :: icomm, iopen_flag, minfo, mfile, ierr, n_count, source_type, file_type
-    integer :: gsize(4), lsize(4), lstart(4)
-    integer(kind=MPI_OFFSET_KIND) :: disp, block_size, base_vnl
+    integer :: gsize(5), lsize(5), lstart(5)
+    integer(8) :: n_count8
+    integer(kind=MPI_OFFSET_KIND) :: block_size, base_vnl
     real(8) :: x,y,z
     complex(8),allocatable :: upu(:,:,:,:,:),upu_l(:,:,:,:,:)
     complex(8),allocatable :: upu_all(:,:,:,:,:),upu_all_l(:,:,:,:,:)
@@ -408,37 +409,30 @@ contains
       iofile = file_tm_data
       icomm = info%icomm_ko
 
-      gsize  = [3, system%nspin, NB             , NB]
-      lsize  = [3, system%nspin, io_e - io_s + 1, NB]
-      lstart = [1, 1,            io_s,            1 ] - 1
+      gsize  = [3, system%nspin, NB             , NB, NK             ]
+      lsize  = [3, system%nspin, io_e - io_s + 1, NB, ik_e - ik_s + 1]
+      lstart = [1, 1,            io_s,            1,  ik_s           ] - 1
 
-      n_count = lsize(1)*lsize(2)*lsize(3)*lsize(4)
+      n_count8 = int(lsize(1),8)*int(lsize(2),8)*int(lsize(3),8)*int(lsize(4),8)*int(lsize(5),8)
+      if ( n_count8 > int(huge(n_count),8) ) then
+        write(*,*) 'error: n_count exceeds 32-bit integer range in write_tm_data (tm.bin)'
+        call end_parallel
+        stop
+      end if
+      n_count = int(n_count8, kind(n_count))
 
-      call MPI_Type_create_subarray(4, gsize, lsize, lstart, MPI_ORDER_FORTRAN, source_type, file_type, ierr)
+      call MPI_Type_create_subarray(5, gsize, lsize, lstart, MPI_ORDER_FORTRAN, source_type, file_type, ierr)
       call MPI_Type_commit(file_type, ierr)
       call MPI_File_open(icomm, iofile, iopen_flag, minfo, mfile, ierr)
 
       block_size = int(3,8)*system%nspin*NB*NB*int(16,8)
-
-      do ik = ik_s, ik_e
-
-      disp = int(ik-1, MPI_OFFSET_KIND) * block_size
-
-      call MPI_File_set_view(mfile, disp, source_type, file_type, 'native', minfo, ierr)
-      call MPI_File_write_all(mfile, upu(1,1,io_s,1,ik), n_count, source_type, MPI_STATUS_IGNORE, ierr)
-
-      end do
-
       base_vnl = int(NK,8) * block_size
 
-      do ik = ik_s, ik_e
+      call MPI_File_set_view(mfile, 0_MPI_OFFSET_KIND, source_type, file_type, 'native', minfo, ierr)
+      call MPI_File_write_all(mfile, upu(1,1,io_s,1,ik_s), n_count, source_type, MPI_STATUS_IGNORE, ierr)
 
-      disp = base_vnl + int(ik-1, MPI_OFFSET_KIND) * block_size
-
-      call MPI_File_set_view(mfile, disp, source_type, file_type, 'native', minfo, ierr)
-      call MPI_File_write_all(mfile, u_rVnl_Vnlr_u(1,1,io_s,1,ik), n_count, source_type, MPI_STATUS_IGNORE, ierr)
-
-      end do 
+      call MPI_File_set_view(mfile, base_vnl, source_type, file_type, 'native', minfo, ierr)
+      call MPI_File_write_all(mfile, u_rVnl_Vnlr_u(1,1,io_s,1,ik_s), n_count, source_type, MPI_STATUS_IGNORE, ierr)
 
       call MPI_File_close(mfile, ierr) 
       call MPI_Type_free(file_type, ierr)

--- a/src/io/write.f90
+++ b/src/io/write.f90
@@ -106,7 +106,7 @@ contains
     use salmon_global, only: yn_out_tm,yn_out_tm_bin,yn_out_gs_sgm_eps, &
                        out_gs_sgm_eps_mu_nu, out_gs_sgm_eps_width, &
                        base_directory,sysname, de,nenergy,nelec,xc
-    use parallelization, only: nproc_id_global
+    use parallelization, only: nproc_id_global, end_parallel
     use communication, only: comm_is_root,comm_summation,comm_sync_all
     use filesystem, only: open_filehandle
     use inputoutput, only: t_unit_energy


### PR DESCRIPTION
## Problem

When writing `tm.bin` (`yn_out_tm_bin='y'`) with MPI, `write_tm_data` in `src/io/write.f90` called the collective `MPI_File_write_all` once per local k-point, looping over `ik = ik_s, ik_e`. Because `info%ik_s`/
`info%ik_e` are computed by integer division, ranks in `icomm_ko` can have different numbers of local k-points whenever `NK` is not divisible by `nproc_k`. Since a collective MPI call must be issued the same number of times by every rank in the communicator, this loop-per-`ik` pattern caused a hang/crash (observed on Fugaku with `NK=27`, `nproc_k=4`).

## Fix

Fold the k-point dimension into a single `MPI_Type_create_subarray` (5D:`[x/y/z, spin, io, ib, ik]`) and issue one `MPI_File_write_all` call per rank, matching the pattern already used on the read side in
`src/analysis/dm_unfold.f90`'s `init_dm_unfold`. This makes the number of collective calls per rank independent of the local k-point count.

Also added an explicit overflow check: folding `ik` into the subarray multiplies the local element count by the local k-range, so `n_count` (32-bit `INTEGER`, required by the classic MPI Fortran interface) could
in principle overflow for large `nb`/`nk`. The local element count is now computed in `integer(8)` first and checked against `huge(n_count)` before narrowing.

## Testing

- Reproduced the original crash on Fugaku (unfolding GS run, `NK=27`,  `nproc_k=4`).
- Confirmed the fix resolves it, and re-ran four draft unfolding /gamma-centered testsuites on Fugaku (to be proposed separately as new  testsuites), including one that exercises the fixed `tm.bin` write path.
- Re-tested after merging in the latest `develop-2.0.0` (including the  "Guard MPI-only unfolding I/O in serial builds" change); all still pass.