### PR TITLE
Fix network_address module dependency detection

### DIFF
--- a/src/common/sendrecv_grid.f90
+++ b/src/common/sendrecv_grid.f90
@@ -17,6 +17,7 @@
 
 module sendrecv_grid
   use structures, only: s_rgrid, s_pcomm_cache, s_sendrecv_grid
+  use network_address, only: get_neighbour_rank
 #ifdef USE_OPENACC
   use cudafor
 #define comm_send_init comm_send_init_device
@@ -509,7 +510,6 @@ module sendrecv_grid
   end subroutine update_overlap_complex8
 
   subroutine create_sendrecv_neig(neig, info)
-    use network_address, only: get_neighbour_rank
     use structures, only: s_parallel_info
     use communication, only: comm_proc_null
     use salmon_global, only: yn_periodic
@@ -538,5 +538,4 @@ module sendrecv_grid
   end subroutine create_sendrecv_neig
 
 end module sendrecv_grid
-
 


### PR DESCRIPTION
Move the `network_address` import from the internal `create_sendrecv_neig` subroutine to the declaration section of the `sendrecv_grid` module. This makes the Fortran module dependency explicit and allows CMake to compile `network_address.f90` before `sendrecv_grid.f90`.

With highly parallel builds, compilation may occasionally succeed due to favorable timing, but it frequently fails because `network_address.mod` is not yet available when `sendrecv_grid.f90` is compiled. This change removes that timing-dependent behavior and makes parallel builds reliable.