### PR TITLE
fix: constant dielectric media in 1D maxwell solver

### DIFF
--- a/src/maxwell/fdtd_weyl_gauge.f90
+++ b/src/maxwell/fdtd_weyl_gauge.f90
@@ -140,7 +140,7 @@ contains
             & ) * r_inv_h(1) ** 2
             Ac_tmp(:, i1, i2, i3) = (2 * fw%vec_Ac%v(:,i1, i2, i3) - fw%vec_Ac_old%v(:,i1, i2, i3) &
                 & + fw%vec_j_em%v(:,i1, i2, i3) * 4.0 * pi * (fw%dt**2)  / fw%epsilon%f(i1, i2, i3) &
-                & - rot2_Ac(:) * (cspeed_au * fw%dt)**2)  / fw%epsilon%f(i1, i2, i3)
+                & - rot2_Ac(:) * (cspeed_au * fw%dt)**2 / fw%epsilon%f(i1, i2, i3))  
         end do
         !$omp end parallel do
 


### PR DESCRIPTION
This pull request fixes issues that occur when partially incorporating a classical medium with a fixed dielectric constant into TDDFT multiscale calculations using a 1D Maxwell solver.